### PR TITLE
change namespace

### DIFF
--- a/Indicators/BollingerBands/BollingerBands.Models.cs
+++ b/Indicators/BollingerBands/BollingerBands.Models.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace StockIndicators
+namespace Skender.Stock.Indicators
 {
 
     public class BollingerBandsResult

--- a/Indicators/BollingerBands/BollingerBands.cs
+++ b/Indicators/BollingerBands/BollingerBands.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
-namespace StockIndicators
+namespace Skender.Stock.Indicators
 {
-    public static partial class Indicators
+    public static partial class Indicator
     {
         // BOLLINGER BANDS
         public static IEnumerable<BollingerBandsResult> GetBollingerBands(IEnumerable<Quote> history, int lookbackPeriod = 20, decimal standardDeviations = 2)

--- a/Indicators/Ema/Ema.Models.cs
+++ b/Indicators/Ema/Ema.Models.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace StockIndicators
+namespace Skender.Stock.Indicators
 {
 
     public class EmaResult

--- a/Indicators/Ema/Ema.cs
+++ b/Indicators/Ema/Ema.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
-namespace StockIndicators
+namespace Skender.Stock.Indicators
 {
-    public static partial class Indicators
+    public static partial class Indicator
     {
         // EXPONENTIAL MOVING AVERAGE
         public static IEnumerable<EmaResult> GetEma(IEnumerable<Quote> history, int lookbackPeriod)

--- a/Indicators/HeikinAshi/HeikinAshi.Models.cs
+++ b/Indicators/HeikinAshi/HeikinAshi.Models.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace StockIndicators
+namespace Skender.Stock.Indicators
 {
 
     public class HeikinAshiResult

--- a/Indicators/HeikinAshi/HeikinAshi.cs
+++ b/Indicators/HeikinAshi/HeikinAshi.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
-namespace StockIndicators
+namespace Skender.Stock.Indicators
 {
-    public static partial class Indicators
+    public static partial class Indicator
     {
         // HEIKIN-ASHI
         public static IEnumerable<HeikinAshiResult> GetHeikinAshi(IEnumerable<Quote> history)

--- a/Indicators/Indicators.csproj
+++ b/Indicators/Indicators.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.2;netcoreapp3.1;netstandard2.0;netstandard2.1;net462;net472;net48</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.0.3</Version>
+    <Version>0.0.3-preview</Version>
     <Authors>Dave Skender</Authors>
     <Company></Company>
     <Product>Stock Indicators</Product>
@@ -13,7 +13,7 @@
     <RepositoryUrl>https://github.com/DaveSkender/Stock.Indicators</RepositoryUrl>
     <RepositoryType>GitHub (Git)</RepositoryType>
     <PackageId>Skender.Stock.Indicators</PackageId>
-    <PackageReleaseNotes></PackageReleaseNotes>
+    <PackageReleaseNotes>This software is currently in active pre-release development.</PackageReleaseNotes>
     <AssemblyName>Stock.Indicators</AssemblyName>
     <AssemblyVersion>0.0.3.0</AssemblyVersion>
     <FileVersion>0.0.3.0</FileVersion>

--- a/Indicators/Indicators.csproj
+++ b/Indicators/Indicators.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.2;netcoreapp3.1;netstandard2.0;netstandard2.1;net462;net472;net48</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.0.2</Version>
+    <Version>0.0.3</Version>
     <Authors>Dave Skender</Authors>
     <Company></Company>
     <Product>Stock Indicators</Product>
@@ -15,10 +15,10 @@
     <PackageId>Skender.Stock.Indicators</PackageId>
     <PackageReleaseNotes></PackageReleaseNotes>
     <AssemblyName>Stock.Indicators</AssemblyName>
-    <AssemblyVersion>0.0.2.0</AssemblyVersion>
-    <FileVersion>0.0.2.0</FileVersion>
+    <AssemblyVersion>0.0.3.0</AssemblyVersion>
+    <FileVersion>0.0.3.0</FileVersion>
     <Copyright>@2020 Dave Skender</Copyright>
-    <RootNamespace>StockIndicators</RootNamespace>
+    <RootNamespace>Skender.Stock.Indicators</RootNamespace>
     <LangVersion>8.0</LangVersion>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageLicenseExpression></PackageLicenseExpression>

--- a/Indicators/Macd/Macd.Models.cs
+++ b/Indicators/Macd/Macd.Models.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace StockIndicators
+namespace Skender.Stock.Indicators
 {
 
     public class MacdResult

--- a/Indicators/Macd/Macd.cs
+++ b/Indicators/Macd/Macd.cs
@@ -2,9 +2,9 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace StockIndicators
+namespace Skender.Stock.Indicators
 {
-    public static partial class Indicators
+    public static partial class Indicator
     {
         // MOVING AVERAGE CONVERGENCE/DIVERGENCE (MACD) OSCILLATOR
         public static IEnumerable<MacdResult> GetMacd(IEnumerable<Quote> history, int fastPeriod = 12, int slowPeriod = 26, int signalPeriod = 9)

--- a/Indicators/ParabolicSar/ParabolicSar.Models.cs
+++ b/Indicators/ParabolicSar/ParabolicSar.Models.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace StockIndicators
+namespace Skender.Stock.Indicators
 {
 
     public class ParabolicSarResult

--- a/Indicators/ParabolicSar/ParabolicSar.cs
+++ b/Indicators/ParabolicSar/ParabolicSar.cs
@@ -2,9 +2,9 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace StockIndicators
+namespace Skender.Stock.Indicators
 {
-    public static partial class Indicators
+    public static partial class Indicator
     {
         // PARABOLIC SAR
         public static IEnumerable<ParabolicSarResult> GetParabolicSar(

--- a/Indicators/Rsi/Rsi.Models.cs
+++ b/Indicators/Rsi/Rsi.Models.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace StockIndicators
+namespace Skender.Stock.Indicators
 {
 
     public class RsiResult

--- a/Indicators/Rsi/Rsi.cs
+++ b/Indicators/Rsi/Rsi.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
-namespace StockIndicators
+namespace Skender.Stock.Indicators
 {
-    public static partial class Indicators
+    public static partial class Indicator
     {
         // RELATIVE STRENGTH INDEX
         public static IEnumerable<RsiResult> GetRsi(IEnumerable<Quote> history, int lookbackPeriod = 14)

--- a/Indicators/Sma/Sma.Models.cs
+++ b/Indicators/Sma/Sma.Models.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace StockIndicators
+namespace Skender.Stock.Indicators
 {
 
     public class SmaResult

--- a/Indicators/Sma/Sma.cs
+++ b/Indicators/Sma/Sma.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
-namespace StockIndicators
+namespace Skender.Stock.Indicators
 {
-    public static partial class Indicators
+    public static partial class Indicator
     {
         // SIMPLE MOVING AVERAGE
         public static IEnumerable<SmaResult> GetSma(IEnumerable<Quote> history, int lookbackPeriod)

--- a/Indicators/Stoch/Stoch.Models.cs
+++ b/Indicators/Stoch/Stoch.Models.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace StockIndicators
+namespace Skender.Stock.Indicators
 {
 
     public class StochResult

--- a/Indicators/Stoch/Stoch.cs
+++ b/Indicators/Stoch/Stoch.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
-namespace StockIndicators
+namespace Skender.Stock.Indicators
 {
-    public static partial class Indicators
+    public static partial class Indicator
     {
         // STOCHASTIC OSCILLATOR
         public static IEnumerable<StochResult> GetStoch(IEnumerable<Quote> history, int lookbackPeriod = 14, int signalPeriod = 3, int smoothPeriod = 3)

--- a/Indicators/Ulcer/Ulcer.Models.cs
+++ b/Indicators/Ulcer/Ulcer.Models.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace StockIndicators
+namespace Skender.Stock.Indicators
 {
 
     public class UlcerIndexResult

--- a/Indicators/Ulcer/Ulcer.cs
+++ b/Indicators/Ulcer/Ulcer.cs
@@ -2,9 +2,9 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace StockIndicators
+namespace Skender.Stock.Indicators
 {
-    public static partial class Indicators
+    public static partial class Indicator
     {
         // ULCER INDEX (UI)
         public static IEnumerable<UlcerIndexResult> GetUlcerIndex(IEnumerable<Quote> history, int lookbackPeriod = 14)

--- a/Indicators/_Common/Cleaners.cs
+++ b/Indicators/_Common/Cleaners.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
-namespace StockIndicators
+namespace Skender.Stock.Indicators
 {
     public static class Cleaners
     {

--- a/Indicators/_Common/Functions.cs
+++ b/Indicators/_Common/Functions.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace StockIndicators
+namespace Skender.Stock.Indicators
 {
     internal static class Functions
     {

--- a/Indicators/_Common/Models.cs
+++ b/Indicators/_Common/Models.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace StockIndicators
+namespace Skender.Stock.Indicators
 {
 
     public class Quote

--- a/IndicatorsTests/Test Data/History.cs
+++ b/IndicatorsTests/Test Data/History.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Skender.Stock.Indicators;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/IndicatorsTests/Test.BollingerBands.cs
+++ b/IndicatorsTests/Test.BollingerBands.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Skender.Stock.Indicators;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,7 +16,7 @@ namespace StockIndicators.Tests
             int lookbackPeriod = 20;
             int standardDeviations = 2;
 
-            IEnumerable<BollingerBandsResult> results = Indicators.GetBollingerBands(history, lookbackPeriod, standardDeviations);
+            IEnumerable<BollingerBandsResult> results = Indicator.GetBollingerBands(history, lookbackPeriod, standardDeviations);
 
             // assertions
 

--- a/IndicatorsTests/Test.Ema.cs
+++ b/IndicatorsTests/Test.Ema.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Skender.Stock.Indicators;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,7 +14,7 @@ namespace StockIndicators.Tests
         public void GetEmaTest()
         {
             int lookbackPeriod = 20;
-            IEnumerable<EmaResult> results = Indicators.GetEma(history, lookbackPeriod);
+            IEnumerable<EmaResult> results = Indicator.GetEma(history, lookbackPeriod);
 
             // assertions
 

--- a/IndicatorsTests/Test.HeikinAshi.cs
+++ b/IndicatorsTests/Test.HeikinAshi.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Skender.Stock.Indicators;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,7 +14,7 @@ namespace StockIndicators.Tests
         public void GetHeikinAshiTest()
         {
 
-            IEnumerable<HeikinAshiResult> results = Indicators.GetHeikinAshi(history);
+            IEnumerable<HeikinAshiResult> results = Indicator.GetHeikinAshi(history);
 
             // assertions
 

--- a/IndicatorsTests/Test.Macd.cs
+++ b/IndicatorsTests/Test.Macd.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Skender.Stock.Indicators;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,7 +17,7 @@ namespace StockIndicators.Tests
             int slowPeriod = 26;
             int signalPeriod = 9;
 
-            IEnumerable<MacdResult> results = Indicators.GetMacd(history, fastPeriod, slowPeriod, signalPeriod);
+            IEnumerable<MacdResult> results = Indicator.GetMacd(history, fastPeriod, slowPeriod, signalPeriod);
 
             // assertions
 

--- a/IndicatorsTests/Test.ParabolicSar.cs
+++ b/IndicatorsTests/Test.ParabolicSar.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Skender.Stock.Indicators;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,7 +16,7 @@ namespace StockIndicators.Tests
             decimal acclerationStep = (decimal)0.02;
             decimal maxAccelerationFactor = (decimal)0.2;
 
-            IEnumerable<ParabolicSarResult> results = Indicators.GetParabolicSar(history, acclerationStep, maxAccelerationFactor);
+            IEnumerable<ParabolicSarResult> results = Indicator.GetParabolicSar(history, acclerationStep, maxAccelerationFactor);
 
             // assertions
 

--- a/IndicatorsTests/Test.Rsi.cs
+++ b/IndicatorsTests/Test.Rsi.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Skender.Stock.Indicators;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,7 +15,7 @@ namespace StockIndicators.Tests
         {
             int lookbackPeriod = 14;
 
-            IEnumerable<RsiResult> results = Indicators.GetRsi(history, lookbackPeriod);
+            IEnumerable<RsiResult> results = Indicator.GetRsi(history, lookbackPeriod);
 
             // assertions
 

--- a/IndicatorsTests/Test.Sma.cs
+++ b/IndicatorsTests/Test.Sma.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Skender.Stock.Indicators;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,7 +14,7 @@ namespace StockIndicators.Tests
         public void GetSmaTest()
         {
             int lookbackPeriod = 20;
-            IEnumerable<SmaResult> results = Indicators.GetSma(history, lookbackPeriod);
+            IEnumerable<SmaResult> results = Indicator.GetSma(history, lookbackPeriod);
 
             // assertions
 

--- a/IndicatorsTests/Test.Stoch.cs
+++ b/IndicatorsTests/Test.Stoch.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Skender.Stock.Indicators;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,7 +17,7 @@ namespace StockIndicators.Tests
             int signalPeriod = 3;
             int smoothPeriod = 3;
 
-            IEnumerable<StochResult> results = Indicators.GetStoch(history, lookbackPeriod, signalPeriod, smoothPeriod);
+            IEnumerable<StochResult> results = Indicator.GetStoch(history, lookbackPeriod, signalPeriod, smoothPeriod);
 
             // assertions
 

--- a/IndicatorsTests/Test.UlcerIndex.cs
+++ b/IndicatorsTests/Test.UlcerIndex.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Skender.Stock.Indicators;
 
 namespace StockIndicators.Tests
 {
@@ -14,7 +15,7 @@ namespace StockIndicators.Tests
         {
             int lookbackPeriod = 14;
 
-            IEnumerable<UlcerIndexResult> results = Indicators.GetUlcerIndex(history, lookbackPeriod);
+            IEnumerable<UlcerIndexResult> results = Indicator.GetUlcerIndex(history, lookbackPeriod);
 
             // assertions
 

--- a/IndicatorsTests/_Initialize.cs
+++ b/IndicatorsTests/_Initialize.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Skender.Stock.Indicators;
 using System.Collections.Generic;
 
 namespace StockIndicators.Tests


### PR DESCRIPTION
To avoid confusing `using` statements, I'm changing the namespace to match the NuGet package name `Skender.Stock.Indicators`.