### PR TITLE
bug fix: perist IsIncreasing trend

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing to Stock.Indicators
 
+[![Board Status](https://dev.azure.com/skender/5123ca47-74f2-4d67-a5d4-c4d90b8d670a/69f29c08-2257-4429-9cea-1629abcd3064/_apis/work/boardbadge/a1dfc6ae-7836-4b56-a849-9a48698252c2)](https://dev.azure.com/skender/5123ca47-74f2-4d67-a5d4-c4d90b8d670a/_boards/board/t/69f29c08-2257-4429-9cea-1629abcd3064/Microsoft.RequirementCategory/)
+
 Thanks for taking the time to contribute!
 
 This project is simpler than most, so it's a good place to start contributing to the open source community, even if you're a newbie.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ We use the `GitVersion` tool for versioning.  It is mostly auto generated in the
 
 ## Contact info
 
-Contact us through the NuGet [Contact Owners](https://www.nuget.org/packages/Skender.Stock.Indicators) method (preferred) or [submit an Issue](https://github.com/DaveSkender/Stock.Indicators/issues) with your question if it is publicly relevant.
+Contact us through the NuGet [Contact Owners](https://www.nuget.org/packages/Skender.Stock.Indicators) method or [submit an Issue](https://github.com/DaveSkender/Stock.Indicators/issues) with your question if it is publicly relevant.
 
 Thanks,
 Dave Skender

--- a/Indicators/HeikinAshi/HeikinAshi.Models.cs
+++ b/Indicators/HeikinAshi/HeikinAshi.Models.cs
@@ -11,7 +11,7 @@ namespace Skender.Stock.Indicators
         public decimal High { get; set; }
         public decimal Low { get; set; }
         public decimal Close { get; set; }
-        public bool IsBullish { get; set; }
+        public bool? IsBullish { get; set; }
         public decimal Weakness { get; set; }
     }
 

--- a/Indicators/HeikinAshi/HeikinAshi.cs
+++ b/Indicators/HeikinAshi/HeikinAshi.cs
@@ -26,6 +26,7 @@ namespace Skender.Stock.Indicators
 
             decimal? prevOpen = null;
             decimal? prevClose = null;
+            bool? prevTrend = null;
 
             foreach (Quote h in history)
             {
@@ -46,7 +47,7 @@ namespace Skender.Stock.Indicators
 
                 // trend (bullish (buy / green), bearish (sell / red)
                 // strength (size of directional shadow / no shadow is strong)
-                bool trend;
+                bool? trend;
                 decimal strength;
 
                 if (close > open)
@@ -54,10 +55,15 @@ namespace Skender.Stock.Indicators
                     trend = true;
                     strength = open - low;
                 }
-                else
+                else if (close < open)
                 {
                     trend = false;
                     strength = high - open;
+                }
+                else
+                {
+                    trend = prevTrend;
+                    strength = high - low;
                 }
 
                 HeikinAshiResult result = new HeikinAshiResult
@@ -76,6 +82,7 @@ namespace Skender.Stock.Indicators
                 // save for next iteration
                 prevOpen = open;
                 prevClose = close;
+                prevTrend = trend;
             }
 
             return results;

--- a/Indicators/HeikinAshi/README.md
+++ b/Indicators/HeikinAshi/README.md
@@ -31,7 +31,7 @@ The first period will have `null` values since there's not enough data to calcul
 | `High` | decimal | Modified high price
 | `Low` | decimal | Modified low price
 | `Close` | decimal | Modified close price
-| `IsBullish` | bool | Indication of bar direction
+| `IsBullish` | bool | Indication of bar direction.  Persists for no change.
 | `Weakness` | decimal | Size of directional shadow, weakness of signal (no shadow is strong)
 
 ## Example

--- a/Indicators/Rsi/README.md
+++ b/Indicators/Rsi/README.md
@@ -31,7 +31,7 @@ The first `N-1` periods will have `null` values since there's not enough data to
 | `Index` | int | Sequence of dates
 | `Date` | DateTime | Date
 | `Rsi` | float | RSI over prior `N` lookback periods
-| `IsIncreasing` | bool | Direction since last period (e.g. up or down)
+| `IsIncreasing` | bool | Direction since last period (e.g. up or down).  Is `null` for no change.
 
 ## Example
 

--- a/Indicators/Rsi/README.md
+++ b/Indicators/Rsi/README.md
@@ -31,7 +31,7 @@ The first `N-1` periods will have `null` values since there's not enough data to
 | `Index` | int | Sequence of dates
 | `Date` | DateTime | Date
 | `Rsi` | float | RSI over prior `N` lookback periods
-| `IsIncreasing` | bool | Direction since last period (e.g. up or down).  Is `null` for no change.
+| `IsIncreasing` | bool | Direction since last period (e.g. up or down).  Persists for no change.
 
 ## Example
 

--- a/Indicators/Rsi/Rsi.cs
+++ b/Indicators/Rsi/Rsi.cs
@@ -68,7 +68,15 @@ namespace Skender.Stock.Indicators
                     r.Rsi = 100;
                 }
 
-                r.IsIncreasing = (r.Rsi > lastRSI);
+                if (r.Rsi > lastRSI)
+                {
+                    r.IsIncreasing = true;
+                }
+                else if (r.Rsi < lastRSI)
+                {
+                    r.IsIncreasing = false;
+                }
+
                 lastRSI = (float)r.Rsi;
             }
 

--- a/Indicators/Rsi/Rsi.cs
+++ b/Indicators/Rsi/Rsi.cs
@@ -50,7 +50,7 @@ namespace Skender.Stock.Indicators
 
             // initial RSI for trend analysis
             float lastRSI = (avgLoss > 0) ? 100 - (100 / (1 + (avgGain / avgLoss))) : 100;
-
+            bool? lastIsIncreasing = null;
 
             // calculate RSI
             foreach (RsiResult r in results.Where(x => x.Index >= lookbackPeriod).OrderBy(d => d.Index))
@@ -76,8 +76,14 @@ namespace Skender.Stock.Indicators
                 {
                     r.IsIncreasing = false;
                 }
+                else
+                {
+                    // no change, keep trend
+                    r.IsIncreasing = lastIsIncreasing;
+                }
 
                 lastRSI = (float)r.Rsi;
+                lastIsIncreasing = r.IsIncreasing;
             }
 
             return results;

--- a/Indicators/Stochastic/README.md
+++ b/Indicators/Stochastic/README.md
@@ -33,7 +33,7 @@ The first `N-1` periods will have `null` values since there's not enough data to
 | `Date` | DateTime | Date
 | `Oscillator` | float | Oscillator over prior `N` lookback periods
 | `Signal` | float | Simple moving average of Oscillator
-| `IsIncreasing` | bool | Direction since last period (e.g. up or down)
+| `IsIncreasing` | bool | Direction since last period (e.g. up or down).  Is `null` for no change.
 
 ## Example
 

--- a/Indicators/Stochastic/README.md
+++ b/Indicators/Stochastic/README.md
@@ -33,7 +33,7 @@ The first `N-1` periods will have `null` values since there's not enough data to
 | `Date` | DateTime | Date
 | `Oscillator` | float | Oscillator over prior `N` lookback periods
 | `Signal` | float | Simple moving average of Oscillator
-| `IsIncreasing` | bool | Direction since last period (e.g. up or down).  Is `null` for no change.
+| `IsIncreasing` | bool | Direction since last period (e.g. up or down).  Persists for no change.
 
 ## Example
 

--- a/Indicators/Stochastic/Stoch.cs
+++ b/Indicators/Stochastic/Stoch.cs
@@ -93,7 +93,18 @@ namespace Skender.Stock.Indicators
                                  .Select(v => v.Oscillator)
                                  .Average();
 
-                r.IsIncreasing = (r.Oscillator > lastOsc);
+                if (r.Index >= (lookbackPeriod + signalPeriod + smoothPeriod) + 1)
+                {
+                    if (r.Oscillator > lastOsc)
+                    {
+                        r.IsIncreasing = true;
+                    }
+                    else if (r.Oscillator < lastOsc)
+                    {
+                        r.IsIncreasing = false;
+                    }
+                }
+
                 lastOsc = (float)r.Oscillator;
             }
 

--- a/Indicators/Stochastic/Stoch.cs
+++ b/Indicators/Stochastic/Stoch.cs
@@ -86,6 +86,7 @@ namespace Skender.Stock.Indicators
 
             // new signal and trend info
             float lastOsc = 0;
+            bool? lastIsIncreasing = null;
             foreach (StochResult r in results
                 .Where(x => x.Index >= (lookbackPeriod + signalPeriod + smoothPeriod) && x.Oscillator != null))
             {
@@ -103,9 +104,15 @@ namespace Skender.Stock.Indicators
                     {
                         r.IsIncreasing = false;
                     }
+                    else
+                    {
+                        // no change, keep trend
+                        r.IsIncreasing = lastIsIncreasing;
+                    }
                 }
 
                 lastOsc = (float)r.Oscillator;
+                lastIsIncreasing = r.IsIncreasing;
             }
 
             return results;

--- a/Indicators/StochasticRsi/README.md
+++ b/Indicators/StochasticRsi/README.md
@@ -30,7 +30,7 @@ The first `2×N-1` periods will have `null` values since there's not enough data
 | `Index` | int | Sequence of dates
 | `Date` | DateTime | Date
 | `StochRsi` | float | StochRSI over prior `N` lookback periods
-| `IsIncreasing` | bool | Direction since last period (e.g. up or down)
+| `IsIncreasing` | bool | Direction since last period (e.g. up or down).  Is `null` for no change.
 
 ## Example
 

--- a/Indicators/StochasticRsi/README.md
+++ b/Indicators/StochasticRsi/README.md
@@ -30,7 +30,7 @@ The first `2×N-1` periods will have `null` values since there's not enough data
 | `Index` | int | Sequence of dates
 | `Date` | DateTime | Date
 | `StochRsi` | float | StochRSI over prior `N` lookback periods
-| `IsIncreasing` | bool | Direction since last period (e.g. up or down).  Is `null` for no change.
+| `IsIncreasing` | bool | Direction since last period (e.g. up or down).  Persists for no change.
 
 ## Example
 

--- a/Indicators/StochasticRsi/StochRsi.cs
+++ b/Indicators/StochasticRsi/StochRsi.cs
@@ -54,9 +54,16 @@ namespace Skender.Stock.Indicators
             float? lastRSI = 0;
             foreach (StochRsiResult r in results.Where(x => x.Index >= 2 * lookbackPeriod).OrderBy(d => d.Index))
             {
-                if (r.Index >= lookbackPeriod)
+                if (r.Index >= 2 * lookbackPeriod + 1)
                 {
-                    r.IsIncreasing = (r.StochRsi > lastRSI);
+                    if (r.StochRsi > lastRSI)
+                    {
+                        r.IsIncreasing = true;
+                    }
+                    else if (r.StochRsi < lastRSI)
+                    {
+                        r.IsIncreasing = false;
+                    }
                 }
 
                 lastRSI = r.StochRsi;

--- a/Indicators/StochasticRsi/StochRsi.cs
+++ b/Indicators/StochasticRsi/StochRsi.cs
@@ -52,6 +52,7 @@ namespace Skender.Stock.Indicators
 
             // add direction
             float? lastRSI = 0;
+            bool? lastIsIncreasing = null;
             foreach (StochRsiResult r in results.Where(x => x.Index >= 2 * lookbackPeriod).OrderBy(d => d.Index))
             {
                 if (r.Index >= 2 * lookbackPeriod + 1)
@@ -64,9 +65,15 @@ namespace Skender.Stock.Indicators
                     {
                         r.IsIncreasing = false;
                     }
+                    else
+                    {
+                        // no change, keep trend
+                        r.IsIncreasing = lastIsIncreasing;
+                    }
                 }
 
                 lastRSI = r.StochRsi;
+                lastIsIncreasing = r.IsIncreasing;
             }
 
             return results;

--- a/IndicatorsTests/Test.Cleaner.cs
+++ b/IndicatorsTests/Test.Cleaner.cs
@@ -2,6 +2,7 @@
 using Skender.Stock.Indicators;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace StockIndicators.Tests
 {
@@ -18,6 +19,9 @@ namespace StockIndicators.Tests
 
             // should always be the same number of results as there is history
             Assert.AreEqual(502, h.Count);
+
+            // should always have index
+            Assert.IsFalse(h.Where(x => x.Index == null || x.Index <= 0).Any());
         }
 
 

--- a/IndicatorsTests/Test.StochRsi.cs
+++ b/IndicatorsTests/Test.StochRsi.cs
@@ -23,7 +23,9 @@ namespace StockIndicators.Tests
             // should always be the same number of results as there is history
             Assert.AreEqual(502, results.Count());
             Assert.AreEqual(502 - 2 * lookbackPeriod + 1, results.Where(x => x.StochRsi != null).Count());
-            Assert.AreEqual(502 - 2 * lookbackPeriod + 1, results.Where(x => x.IsIncreasing != null).Count());
+
+            // this series starts with 4 periods of topped Stochastic RSI, so no direction can be determined
+            Assert.AreEqual(502 - 2 * lookbackPeriod + 1 - 4, results.Where(x => x.IsIncreasing != null).Count());
 
             // sample value
             StochRsiResult result = results.Where(x => x.Date == DateTime.Parse("12/31/2018")).FirstOrDefault();

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -6,7 +6,7 @@ The public compiled NuGet package `Skender.Stock.Indicators` is free to use in a
 
 However, at this time we ask that modifications to source code occur by contributing to this repository: https://github.com/DaveSkender/Stock.Indicators.  Extending functionality beyond its primary use can be done in your own wrapper software.
 
-With that said, we welcome contributions to make it better.  Please see our Contributing Guidelines for instructions on how you can help: https://github.com/DaveSkender/Stock.Indicators/blob/master/CONTRIBUTING.md
+With that said, we welcome contributions to make it better.  Please see our Contributing Guidelines for instructions on how you can help: https://daveskender.github.io/Stock.Indicators/CONTRIBUTING.html
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Stock Indicators
 
-[![Build status](https://dev.azure.com/skender/Stock.Indicators/_apis/build/status/Stock.Indicators)](https://dev.azure.com/skender/Stock.Indicators/_build/latest?definitionId=18)
-[![Board Status](https://dev.azure.com/skender/5123ca47-74f2-4d67-a5d4-c4d90b8d670a/69f29c08-2257-4429-9cea-1629abcd3064/_apis/work/boardbadge/a1dfc6ae-7836-4b56-a849-9a48698252c2)](https://dev.azure.com/skender/5123ca47-74f2-4d67-a5d4-c4d90b8d670a/_boards/board/t/69f29c08-2257-4429-9cea-1629abcd3064/Microsoft.RequirementCategory/)
+[![NuGet package](https://img.shields.io/nuget/v/skender.stock.indicators?color=green&label=NuGet%20Package)](https://www.nuget.org/packages/Skender.Stock.Indicators)
+[![build status](https://img.shields.io/azure-devops/build/skender/5123ca47-74f2-4d67-a5d4-c4d90b8d670a/18/master?label=Build%20Status)](https://dev.azure.com/skender/Stock.Indicators/_build/latest?definitionId=18)
+[![code coverage](https://img.shields.io/azure-devops/coverage/skender/stock.indicators/18?label=Code%20Coverage)](https://dev.azure.com/skender/Stock.Indicators/_build/latest?definitionId=18&view=codecoverage-tab)
+[![board status](https://dev.azure.com/skender/5123ca47-74f2-4d67-a5d4-c4d90b8d670a/69f29c08-2257-4429-9cea-1629abcd3064/_apis/work/boardbadge/a1dfc6ae-7836-4b56-a849-9a48698252c2)](https://dev.azure.com/skender/5123ca47-74f2-4d67-a5d4-c4d90b8d670a/_boards/board/t/69f29c08-2257-4429-9cea-1629abcd3064/Microsoft.RequirementCategory/)
 
 [Skender.Stock.Indicators](https://www.nuget.org/packages/Skender.Stock.Indicators) is a multi-targeting framework .NET library that produces stock indicators.  Send in historical stock price quotes and get back desired technical indicators (such as moving average, relative strength, parabolic SAR, etc).  Nothing more.
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ There are many places to get stock market data.  Check with your brokerage or ot
 
 Yes.  The documentation site is a GitHub Pages site here: [https://daveskender.github.io/Stock.Indicators](https://daveskender.github.io/Stock.Indicators).  It is automatically generated from the README.md files in this repository, so you can navigate from the above Indicators links too.
 
-**More questions?**  Contact us through the NuGet [Contact Owners](https://www.nuget.org/packages/Skender.Stock.Indicators) method (preferred) or [submit an Issue](https://github.com/DaveSkender/Stock.Indicators/issues) with your question if it is publicly relevant.
+**More questions?**  Contact us through the NuGet [Contact Owners](https://www.nuget.org/packages/Skender.Stock.Indicators) method or [submit an Issue](https://github.com/DaveSkender/Stock.Indicators/issues) with your question if it is publicly relevant.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Stock Indicators
 
 [![Build status](https://dev.azure.com/skender/Stock.Indicators/_apis/build/status/Stock.Indicators)](https://dev.azure.com/skender/Stock.Indicators/_build/latest?definitionId=18)
+[![Board Status](https://dev.azure.com/skender/5123ca47-74f2-4d67-a5d4-c4d90b8d670a/69f29c08-2257-4429-9cea-1629abcd3064/_apis/work/boardbadge/a1dfc6ae-7836-4b56-a849-9a48698252c2)](https://dev.azure.com/skender/5123ca47-74f2-4d67-a5d4-c4d90b8d670a/_boards/board/t/69f29c08-2257-4429-9cea-1629abcd3064/Microsoft.RequirementCategory/)
 
 [Skender.Stock.Indicators](https://www.nuget.org/packages/Skender.Stock.Indicators) is a multi-targeting framework .NET library that produces stock indicators.  Send in historical stock price quotes and get back desired technical indicators (such as moving average, relative strength, parabolic SAR, etc).  Nothing more.
 


### PR DESCRIPTION
- fix: use of `IsIncreasing` flag updated for RSI, StochasticRSI, Stochastic, and Heikin-Ashi indicators and oscillators so flat result does not change trend of this item.  basically, this handles the not increasing nor decreasing edge case.  augments #32
- update of documentation and added a bunch of badges