### PR TITLE
refactor: EMA and StdDev

### DIFF
--- a/Indicators/ChaikinOscillator/ChaikinOsc.cs
+++ b/Indicators/ChaikinOscillator/ChaikinOsc.cs
@@ -20,25 +20,16 @@ namespace Skender.Stock.Indicators
             ValidateChaikinOsc(history, fastPeriod, slowPeriod);
 
             // initialize
-            List<Quote> adlQuote = new List<Quote>();
             List<ChaikinOscResult> results = new List<ChaikinOscResult>();
             IEnumerable<AdlResult> adlResults = GetAdl(history);
 
-            // temp data for interim EMA of ADL
-            foreach (AdlResult r in adlResults)
-            {
-                Quote q = new Quote
-                {
-                    Index = r.Index,
-                    Date = r.Date,
-                    Close = r.Adl
-                };
 
-                adlQuote.Add(q);
-            }
+            // EMA of ADL
+            IEnumerable<BasicData> adlBasicData = adlResults
+                .Select(x => new BasicData { Index = x.Index, Date = x.Date, Value = x.Adl });
 
-            IEnumerable<EmaResult> adlEmaSlow = GetEma(adlQuote, slowPeriod);
-            IEnumerable<EmaResult> adlEmaFast = GetEma(adlQuote, fastPeriod);
+            IEnumerable<EmaResult> adlEmaSlow = CalcEma(adlBasicData, slowPeriod);
+            IEnumerable<EmaResult> adlEmaFast = CalcEma(adlBasicData, fastPeriod);
 
 
             // roll through history

--- a/Indicators/Ema/Ema.cs
+++ b/Indicators/Ema/Ema.cs
@@ -10,11 +10,8 @@ namespace Skender.Stock.Indicators
         public static IEnumerable<EmaResult> GetEma(IEnumerable<Quote> history, int lookbackPeriod)
         {
 
-            // clean quotes
-            history = Cleaners.PrepareHistory(history);
-
             // convert history to basic format
-            List<BasicData> bd = Cleaners.ConvertHistoryToBasic(history, "C");
+            IEnumerable<BasicData> bd = Cleaners.ConvertHistoryToBasic(history, "C");
 
             // calculate
             return CalcEma(bd, lookbackPeriod);

--- a/Indicators/Ema/Ema.cs
+++ b/Indicators/Ema/Ema.cs
@@ -13,21 +13,35 @@ namespace Skender.Stock.Indicators
             // clean quotes
             history = Cleaners.PrepareHistory(history);
 
+            // convert history to basic format
+            List<BasicData> bd = Cleaners.ConvertHistoryToBasic(history, "C");
+
+            // calculate
+            return CalcEma(bd, lookbackPeriod);
+        }
+
+
+        private static IEnumerable<EmaResult> CalcEma(IEnumerable<BasicData> basicData, int lookbackPeriod)
+        {
+
+            // clean quotes
+            basicData = Cleaners.PrepareBasicData(basicData);
+
             // validate parameters
-            ValidateEma(history, lookbackPeriod);
+            ValidateEma(basicData, lookbackPeriod);
 
             // initialize
             List<EmaResult> results = new List<EmaResult>();
 
             // initialize EMA
             decimal k = 2 / (decimal)(lookbackPeriod + 1);
-            decimal lastEma = history
+            decimal lastEma = basicData
                 .Where(x => x.Index < lookbackPeriod)
-                .Select(x => x.Close)
+                .Select(x => x.Value)
                 .Average();
 
             // roll through history
-            foreach (Quote h in history)
+            foreach (BasicData h in basicData)
             {
 
                 EmaResult result = new EmaResult
@@ -38,7 +52,7 @@ namespace Skender.Stock.Indicators
 
                 if (h.Index >= lookbackPeriod)
                 {
-                    result.Ema = lastEma + k * (h.Close - lastEma);
+                    result.Ema = lastEma + k * (h.Value - lastEma);
                     lastEma = (decimal)result.Ema;
                 }
 
@@ -49,7 +63,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateEma(IEnumerable<Quote> history, int lookbackPeriod)
+        private static void ValidateEma(IEnumerable<BasicData> basicData, int lookbackPeriod)
         {
 
             // check parameters
@@ -59,7 +73,7 @@ namespace Skender.Stock.Indicators
             }
 
             // check history
-            int qtyHistory = history.Count();
+            int qtyHistory = basicData.Count();
             int minHistory = Math.Max(2 * lookbackPeriod, lookbackPeriod + 100);
             if (qtyHistory < minHistory)
             {
@@ -72,5 +86,6 @@ namespace Skender.Stock.Indicators
             }
 
         }
+
     }
 }

--- a/Indicators/Macd/Macd.cs
+++ b/Indicators/Macd/Macd.cs
@@ -20,7 +20,7 @@ namespace Skender.Stock.Indicators
             IEnumerable<EmaResult> emaFast = GetEma(history, fastPeriod);
             IEnumerable<EmaResult> emaSlow = GetEma(history, slowPeriod);
 
-            List<Quote> emaDiff = new List<Quote>();
+            List<BasicData> emaDiff = new List<BasicData>();
             List<MacdResult> results = new List<MacdResult>();
 
             foreach (Quote h in history)
@@ -41,11 +41,11 @@ namespace Skender.Stock.Indicators
                     result.Macd = macd;
 
                     // temp data for interim EMA of macd
-                    Quote diff = new Quote
+                    BasicData diff = new BasicData
                     {
                         Date = h.Date,
                         Index = h.Index - slowPeriod,
-                        Close = macd
+                        Value = macd
                     };
 
                     emaDiff.Add(diff);
@@ -54,7 +54,7 @@ namespace Skender.Stock.Indicators
                 results.Add(result);
             }
 
-            IEnumerable<EmaResult> emaSignal = GetEma(emaDiff, signalPeriod);
+            IEnumerable<EmaResult> emaSignal = CalcEma(emaDiff, signalPeriod);
             decimal? prevMacd = null;
             decimal? prevSignal = null;
 

--- a/Indicators/StandardDev/StdDev.cs
+++ b/Indicators/StandardDev/StdDev.cs
@@ -8,11 +8,9 @@ namespace Skender.Stock.Indicators
         // STANDARD DEVIATION
         public static IEnumerable<StdDevResult> GetStdDev(IEnumerable<Quote> history, int lookbackPeriod)
         {
-            // clean quotes
-            history = Cleaners.PrepareHistory(history);
 
             // convert to basic data
-            List<BasicData> bd = Cleaners.ConvertHistoryToBasic(history, "C");
+            IEnumerable<BasicData> bd = Cleaners.ConvertHistoryToBasic(history, "C");
 
             // calculate
             return CalcStdDev(bd, lookbackPeriod);

--- a/Indicators/StandardDev/StdDev.cs
+++ b/Indicators/StandardDev/StdDev.cs
@@ -11,15 +11,28 @@ namespace Skender.Stock.Indicators
             // clean quotes
             history = Cleaners.PrepareHistory(history);
 
+            // convert to basic data
+            List<BasicData> bd = Cleaners.ConvertHistoryToBasic(history, "C");
+
+            // calculate
+            return CalcStdDev(bd, lookbackPeriod);
+        }
+
+
+        private static IEnumerable<StdDevResult> CalcStdDev(IEnumerable<BasicData> basicData, int lookbackPeriod)
+        {
+            // clean data
+            basicData = Cleaners.PrepareBasicData(basicData);
+
             // validate inputs
-            ValidateStdDev(history, lookbackPeriod);
+            ValidateStdDev(basicData, lookbackPeriod);
 
             // initialize results
             List<StdDevResult> results = new List<StdDevResult>();
-            decimal? prevClose = null;
+            decimal? prevValue = null;
 
             // roll through history and compute lookback standard deviation
-            foreach (Quote h in history)
+            foreach (BasicData h in basicData)
             {
                 StdDevResult result = new StdDevResult
                 {
@@ -30,23 +43,23 @@ namespace Skender.Stock.Indicators
                 if (h.Index >= lookbackPeriod)
                 {
                     // price based
-                    IEnumerable<double> period = history
+                    IEnumerable<double> period = basicData
                         .Where(x => x.Index > (h.Index - lookbackPeriod) && x.Index <= h.Index)
-                        .Select(x => (double)x.Close);
+                        .Select(x => (double)x.Value);
 
                     result.StdDev = (decimal)Functions.StdDev(period);
-                    result.ZScore = (h.Close - (decimal)period.Average()) / result.StdDev;
+                    result.ZScore = (h.Value - (decimal)period.Average()) / result.StdDev;
                 }
 
                 results.Add(result);
-                prevClose = h.Close;
+                prevValue = h.Value;
             }
 
             return results;
         }
 
 
-        private static void ValidateStdDev(IEnumerable<Quote> history, int lookbackPeriod)
+        private static void ValidateStdDev(IEnumerable<BasicData> basicData, int lookbackPeriod)
         {
 
             // check parameters
@@ -56,7 +69,7 @@ namespace Skender.Stock.Indicators
             }
 
             // check history
-            int qtyHistory = history.Count();
+            int qtyHistory = basicData.Count();
             int minHistory = lookbackPeriod;
             if (qtyHistory < minHistory)
             {

--- a/Indicators/_Common/Cleaners.cs
+++ b/Indicators/_Common/Cleaners.cs
@@ -41,5 +41,60 @@ namespace Skender.Stock.Indicators
 
             return history.OrderBy(x => x.Index).ToList();
         }
+
+
+        internal static List<BasicData> PrepareBasicData(IEnumerable<BasicData> basicData)
+        {
+            // we cannot rely on date consistency when looking back, so we add an index and sort
+
+            if (basicData == null || !basicData.Any())
+            {
+                throw new BadHistoryException("No basic data provided.");
+            }
+
+            // return if already processed (no missing indexes)
+            if (!basicData.Any(x => x.Index == null))
+            {
+                return basicData.OrderBy(x => x.Index).ToList();
+            }
+
+            // add index and check for errors
+            int i = 1;
+            DateTime lastDate = DateTime.MinValue;
+            foreach (BasicData h in basicData.OrderBy(x => x.Date))
+            {
+                h.Index = i++;
+
+                if (lastDate == h.Date)
+                {
+                    throw new BadHistoryException(string.Format("Duplicate date found on {0}.", h.Date));
+                }
+
+                lastDate = h.Date;
+
+                // TODO: more error evaluation (impossible values, missing values, etc.)
+            }
+
+            return basicData.OrderBy(x => x.Index).ToList();
+        }
+
+
+        internal static List<BasicData> ConvertHistoryToBasic(IEnumerable<Quote> history, string element = "C")
+        {
+            // elements represents the targeted OHLCV parts, so use "O" to return <Open> as base data, etc.
+
+            // convert to basic data format
+            IEnumerable<BasicData> basicData = element switch
+            {
+                "O" => history.Select(x => new BasicData { Index = x.Index, Date = x.Date, Value = x.Open }),
+                "H" => history.Select(x => new BasicData { Index = x.Index, Date = x.Date, Value = x.High }),
+                "L" => history.Select(x => new BasicData { Index = x.Index, Date = x.Date, Value = x.Low }),
+                "C" => history.Select(x => new BasicData { Index = x.Index, Date = x.Date, Value = x.Close }),
+                "V" => history.Select(x => new BasicData { Index = x.Index, Date = x.Date, Value = x.Volume }),
+                _ => new List<BasicData>(),
+            };
+
+            return PrepareBasicData(basicData);
+        }
     }
 }

--- a/Indicators/_Common/Cleaners.cs
+++ b/Indicators/_Common/Cleaners.cs
@@ -7,7 +7,7 @@ namespace Skender.Stock.Indicators
     public static class Cleaners
     {
 
-        public static List<Quote> PrepareHistory(IEnumerable<Quote> history)
+        public static IEnumerable<Quote> PrepareHistory(IEnumerable<Quote> history)
         {
             // we cannot rely on date consistency when looking back, so we add an index and sort
 
@@ -19,7 +19,7 @@ namespace Skender.Stock.Indicators
             // return if already processed (no missing indexes)
             if (!history.Any(x => x.Index == null))
             {
-                return history.OrderBy(x => x.Index).ToList();
+                return history.OrderBy(x => x.Index);
             }
 
             // add index and check for errors
@@ -39,11 +39,11 @@ namespace Skender.Stock.Indicators
                 // TODO: more error evaluation (impossible values, missing values, etc.)
             }
 
-            return history.OrderBy(x => x.Index).ToList();
+            return history.OrderBy(x => x.Index);
         }
 
 
-        internal static List<BasicData> PrepareBasicData(IEnumerable<BasicData> basicData)
+        internal static IEnumerable<BasicData> PrepareBasicData(IEnumerable<BasicData> basicData)
         {
             // we cannot rely on date consistency when looking back, so we add an index and sort
 
@@ -55,7 +55,7 @@ namespace Skender.Stock.Indicators
             // return if already processed (no missing indexes)
             if (!basicData.Any(x => x.Index == null))
             {
-                return basicData.OrderBy(x => x.Index).ToList();
+                return basicData.OrderBy(x => x.Index);
             }
 
             // add index and check for errors
@@ -75,11 +75,11 @@ namespace Skender.Stock.Indicators
                 // TODO: more error evaluation (impossible values, missing values, etc.)
             }
 
-            return basicData.OrderBy(x => x.Index).ToList();
+            return basicData.OrderBy(x => x.Index);
         }
 
 
-        internal static List<BasicData> ConvertHistoryToBasic(IEnumerable<Quote> history, string element = "C")
+        internal static IEnumerable<BasicData> ConvertHistoryToBasic(IEnumerable<Quote> history, string element = "C")
         {
             // elements represents the targeted OHLCV parts, so use "O" to return <Open> as base data, etc.
 

--- a/Indicators/_Common/Models.cs
+++ b/Indicators/_Common/Models.cs
@@ -22,8 +22,8 @@ namespace Skender.Stock.Indicators
 
     internal class BasicData
     {
-        public int? Index { get; set; }
-        public DateTime Date { get; set; }
-        public decimal Value { get; set; }
+        internal int? Index { get; set; }
+        internal DateTime Date { get; set; }
+        internal decimal Value { get; set; }
     }
 }

--- a/Indicators/_Common/Models.cs
+++ b/Indicators/_Common/Models.cs
@@ -20,4 +20,10 @@ namespace Skender.Stock.Indicators
         public DateTime Date { get; set; }
     }
 
+    internal class BasicData
+    {
+        public int? Index { get; set; }
+        public DateTime Date { get; set; }
+        public decimal Value { get; set; }
+    }
 }

--- a/IndicatorsTests/Common/Test.Cleaner.cs
+++ b/IndicatorsTests/Common/Test.Cleaner.cs
@@ -13,12 +13,12 @@ namespace StockIndicators.Tests
         [TestMethod()]
         public void CleanerTest()
         {
-            List<Quote> h = Cleaners.PrepareHistory(history);
+            IEnumerable<Quote> h = Cleaners.PrepareHistory(history);
 
             // assertions
 
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, h.Count);
+            Assert.AreEqual(502, h.Count());
 
             // should always have index
             Assert.IsFalse(h.Where(x => x.Index == null || x.Index <= 0).Any());


### PR DESCRIPTION
- separating EMA and StdDev as independent [internal] methods so it can be better utilized with generic data values.  I'm doing this so, for example, we can later add EMA of indicator results independently - [AB#639](https://dev.azure.com/skender/5123ca47-74f2-4d67-a5d4-c4d90b8d670a/_workitems/edit/639)
- breaking (potentially): Cleaner.PrepareHistory now returns `IEnumerable<Quote>` instead of `List<Quote>` type as this is better practice to avoid extra conversions of data.  This method is typically used internally to the library, but is public, so some users may be using it.