### PR TITLE
make index externally read-only

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -13,11 +13,11 @@ Historical quotes should be of consistent time frequency (e.g. per minute, hour,
 | `Close` | decimal | Close price
 | `Volume` | long | Volume
 
-There is also an `Index` property that is set internally, so do not set that value.  We set this to `public` visibility in case you want to use it in your own wrapper code.  See **Cleaning History** section below if you want to return the `Index` values.
+There is also a public read-only `Index` property in this class that is set internally, so **do not try to set the Index value**.  We set this `Index` property to `public` visibility in case you want to use it in your own wrapper code.  See **Cleaning History** section below if you want to pre-clean the history and get `Index` values in your `IEnumerable<Quote> history` data (optional).
 
 ## Cleaning History
 
-If you intend to use the same composed `IEnumerable<Quote> history` in multiple calls and want to have the same `Index` values mapped into results, we recommend you pre-clean it to initialize those index values.  This will add the `Index` value and sort by `Date` provided; it will also perform basic checks for data quality.
+If you intend to use the same composed `IEnumerable<Quote> history` in multiple calls and want to have the same `Index` values mapped into results, we recommend you pre-clean it to initialize those index values.  This will add the `Index` value and sort by the `Date` provided; it will also perform basic checks for data quality.
 
 You only need to do this if you want to use the `Index` value in your own wrapper software; otherwise, there is no need as `history` is cleaned on every call, internally.  If you pre-clean, the provided `history` will be used as-is without additional cleaning.  The original `Date` and composed `Index` is always returned in resultsets.
 
@@ -25,6 +25,6 @@ You only need to do this if you want to use the `Index` value in your own wrappe
 // fetch historical quotes from your favorite feed, in Quote format
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
-// preclean
+// pre-clean
 history = Cleaners.PrepareHistory(history);
 ```

--- a/Indicators/_Common/Models.cs
+++ b/Indicators/_Common/Models.cs
@@ -5,7 +5,7 @@ namespace Skender.Stock.Indicators
 
     public class Quote
     {
-        public int? Index { get; set; }
+        public int? Index { get; internal set; }
         public DateTime Date { get; set; }
         public decimal Open { get; set; }
         public decimal High { get; set; }
@@ -16,8 +16,8 @@ namespace Skender.Stock.Indicators
 
     public class ResultBase
     {
-        public int Index { get; set; }
-        public DateTime Date { get; set; }
+        public int Index { get; internal set; }
+        public DateTime Date { get; internal set; }
     }
 
     internal class BasicData


### PR DESCRIPTION
I'm making `Index` readonly on `Quote` class and the various results classes.  If a user were to set Index without the proper convention, the indicators won't compute correctly.  I've also set `Date` as readonly on results classes.  [AB#648](https://dev.azure.com/skender/5123ca47-74f2-4d67-a5d4-c4d90b8d670a/_workitems/edit/648)