### PR TITLE
fix: Quote class inheritance

### DIFF
--- a/Indicators/_Common/Models.cs
+++ b/Indicators/_Common/Models.cs
@@ -5,7 +5,7 @@ namespace Skender.Stock.Indicators
 
     public class Quote
     {
-        public int? Index { get; internal set; }
+        public int? Index { get; protected internal set; }
         public DateTime Date { get; set; }
         public decimal Open { get; set; }
         public decimal High { get; set; }
@@ -16,8 +16,8 @@ namespace Skender.Stock.Indicators
 
     public class ResultBase
     {
-        public int Index { get; internal set; }
-        public DateTime Date { get; internal set; }
+        public int Index { get; protected internal set; }
+        public DateTime Date { get; protected internal set; }
     }
 
     internal class BasicData


### PR DESCRIPTION
Turns out `internal` does not allow derived classes, so changing `Quote` and result class `Index` values to `protected internal`, which allows users to inherit the classes and modify data as desired.