### PR TITLE
update Stochastic RSI with more parameters

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -43,7 +43,7 @@ Historical quotes should be of consistent time frequency (e.g. per minute, hour,
 | `Close` | decimal | Close price
 | `Volume` | long | Volume
 
-There is also a public read-only `Index` property in this class that is set internally, so **do not try to set the Index value**.  We set this `Index` property to `public` visibility in case you want to use it in your own wrapper code.  See [Cleaning History](#cleaning-history)) section below if you want to pre-clean the history and get `Index` values in your `IEnumerable<Quote> history` data (optional).  You can also derive and extend classes (optional), see the [Using Derived Classes](#using-derived-classes) section below.
+There is also a public read-only `Index` property in this class that is set internally, so **do not try to set the Index value**.  We set this `Index` property to `public` visibility in case you want to use it in your own wrapper code.  See [Cleaning History](#cleaning-history) section below if you want to pre-clean the history and get `Index` values in your `IEnumerable<Quote> history` data (optional).  You can also derive and extend classes (optional), see the [Using Derived Classes](#using-derived-classes) section below.
 
 ## Cleaning history
 

--- a/Indicators/ConnorsRsi/ConnorsRsi.Models.cs
+++ b/Indicators/ConnorsRsi/ConnorsRsi.Models.cs
@@ -3,14 +3,14 @@
 
     public class ConnorsRsiResult : ResultBase
     {
-        public float? RsiClose { get; set; }
-        public float? RsiStreak { get; set; }
-        public float? PercentRank { get; set; }
-        public float? ConnorsRsi { get; set; }
+        public decimal? RsiClose { get; set; }
+        public decimal? RsiStreak { get; set; }
+        public decimal? PercentRank { get; set; }
+        public decimal? ConnorsRsi { get; set; }
 
         // internal use only
-        internal float? Streak { get; set; }
-        internal float? PeriodGain { get; set; }
+        internal decimal? Streak { get; set; }
+        internal decimal? PeriodGain { get; set; }
     }
 
 }

--- a/Indicators/ConnorsRsi/ConnorsRsi.cs
+++ b/Indicators/ConnorsRsi/ConnorsRsi.cs
@@ -23,7 +23,7 @@ namespace Skender.Stock.Indicators
             int startPeriod = Math.Max(rsiPeriod, Math.Max(streakPeriod, rankPeriod)) + 2;
 
             decimal? lastClose = null;
-            float streak = 0;
+            decimal streak = 0;
 
             // compose interim results
             foreach (BasicData h in bd)
@@ -74,14 +74,14 @@ namespace Skender.Stock.Indicators
                 result.Streak = streak;
 
                 // percentile rank
-                result.PeriodGain = (float)((lastClose <= 0) ? null : (h.Value - lastClose) / lastClose);
+                result.PeriodGain = (decimal)((lastClose <= 0) ? null : (h.Value - lastClose) / lastClose);
 
                 if (h.Index > rankPeriod)
                 {
                     IEnumerable<ConnorsRsiResult> period = results
                         .Where(x => x.Index >= (h.Index - rankPeriod) && x.Index < h.Index);
 
-                    result.PercentRank = (float)100 * period
+                    result.PercentRank = (decimal)100 * period
                         .Where(x => x.PeriodGain < result.PeriodGain).Count() / rankPeriod;
                 }
 

--- a/Indicators/ConnorsRsi/README.md
+++ b/Indicators/ConnorsRsi/README.md
@@ -35,10 +35,10 @@ The first `N-1` periods will have `null` values since there's not enough data to
 | -- |-- |--
 | `Index` | int | Sequence of dates
 | `Date` | DateTime | Date
-| `RsiClose` | float | RSI(`R`) of the Close price.
-| `RsiStreak` | float | RSI(`S`) of the Streak.
-| `PercentRank` | float | Percentile rank of the period gain value.
-| `ConnorsRsi` | float | ConnorsRSI
+| `RsiClose` | decimal | RSI(`R`) of the Close price.
+| `RsiStreak` | decimal | RSI(`S`) of the Streak.
+| `PercentRank` | decimal | Percentile rank of the period gain value.
+| `ConnorsRsi` | decimal | ConnorsRSI
 
 ## Example
 

--- a/Indicators/Indicators.csproj
+++ b/Indicators/Indicators.csproj
@@ -28,10 +28,6 @@ Please contribute to help us get to v1.0.0.  Feedback appreciated.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.3.7">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Indicators/Rsi/README.md
+++ b/Indicators/Rsi/README.md
@@ -30,7 +30,7 @@ The first `N-1` periods will have `null` values since there's not enough data to
 | -- |-- |--
 | `Index` | int | Sequence of dates
 | `Date` | DateTime | Date
-| `Rsi` | float | RSI over prior `N` lookback periods
+| `Rsi` | decimal | RSI over prior `N` lookback periods
 | `IsIncreasing` | bool | Direction since last period (e.g. up or down).  Persists for no change.
 
 ## Example

--- a/Indicators/Rsi/Rsi.Models.cs
+++ b/Indicators/Rsi/Rsi.Models.cs
@@ -3,12 +3,12 @@
 
     public class RsiResult : ResultBase
     {
-        public float? Rsi { get; set; }
+        public decimal? Rsi { get; set; }
         public bool? IsIncreasing { get; set; }
 
         // internal use only
-        internal float Gain { get; set; } = 0;
-        internal float Loss { get; set; } = 0;
+        internal decimal Gain { get; set; } = 0;
+        internal decimal Loss { get; set; } = 0;
     }
 
 }

--- a/Indicators/Rsi/Rsi.cs
+++ b/Indicators/Rsi/Rsi.cs
@@ -38,8 +38,8 @@ namespace Skender.Stock.Indicators
                 {
                     Index = (int)h.Index,
                     Date = h.Date,
-                    Gain = (h.Value > lastValue) ? (float)(h.Value - lastValue) : 0,
-                    Loss = (h.Value < lastValue) ? (float)(lastValue - h.Value) : 0
+                    Gain = (h.Value > lastValue) ? h.Value - lastValue : 0,
+                    Loss = (h.Value < lastValue) ? lastValue - h.Value : 0
                 };
                 results.Add(result);
 
@@ -47,11 +47,11 @@ namespace Skender.Stock.Indicators
             }
 
             // initialize average gain
-            float avgGain = results.Where(x => x.Index <= lookbackPeriod).Select(g => g.Gain).Average();
-            float avgLoss = results.Where(x => x.Index <= lookbackPeriod).Select(g => g.Loss).Average();
+            decimal avgGain = results.Where(x => x.Index <= lookbackPeriod).Select(g => g.Gain).Average();
+            decimal avgLoss = results.Where(x => x.Index <= lookbackPeriod).Select(g => g.Loss).Average();
 
             // initial first record
-            float lastRSI = (avgLoss > 0) ? 100 - (100 / (1 + (avgGain / avgLoss))) : 100;
+            decimal lastRSI = (avgLoss > 0) ? 100 - (100 / (1 + (avgGain / avgLoss))) : 100;
             bool? lastIsIncreasing = null;
 
             RsiResult first = results.Where(x => x.Index == lookbackPeriod + 1).FirstOrDefault();
@@ -65,7 +65,7 @@ namespace Skender.Stock.Indicators
 
                 if (avgLoss > 0)
                 {
-                    float rs = avgGain / avgLoss;
+                    decimal rs = avgGain / avgLoss;
                     r.Rsi = 100 - (100 / (1 + rs));
                 }
                 else
@@ -87,7 +87,7 @@ namespace Skender.Stock.Indicators
                     r.IsIncreasing = lastIsIncreasing;
                 }
 
-                lastRSI = (float)r.Rsi;
+                lastRSI = (decimal)r.Rsi;
                 lastIsIncreasing = r.IsIncreasing;
             }
 

--- a/Indicators/Rsi/Rsi.cs
+++ b/Indicators/Rsi/Rsi.cs
@@ -38,8 +38,8 @@ namespace Skender.Stock.Indicators
                 {
                     Index = (int)h.Index,
                     Date = h.Date,
-                    Gain = (lastValue < h.Value) ? (float)(h.Value - lastValue) : 0,
-                    Loss = (lastValue > h.Value) ? (float)(lastValue - h.Value) : 0
+                    Gain = (h.Value > lastValue) ? (float)(h.Value - lastValue) : 0,
+                    Loss = (h.Value < lastValue) ? (float)(lastValue - h.Value) : 0
                 };
                 results.Add(result);
 
@@ -50,12 +50,15 @@ namespace Skender.Stock.Indicators
             float avgGain = results.Where(x => x.Index <= lookbackPeriod).Select(g => g.Gain).Average();
             float avgLoss = results.Where(x => x.Index <= lookbackPeriod).Select(g => g.Loss).Average();
 
-            // initial RSI for trend analysis
+            // initial first record
             float lastRSI = (avgLoss > 0) ? 100 - (100 / (1 + (avgGain / avgLoss))) : 100;
             bool? lastIsIncreasing = null;
 
+            RsiResult first = results.Where(x => x.Index == lookbackPeriod + 1).FirstOrDefault();
+            first.Rsi = lastRSI;
+
             // calculate RSI
-            foreach (RsiResult r in results.Where(x => x.Index >= lookbackPeriod).OrderBy(d => d.Index))
+            foreach (RsiResult r in results.Where(x => x.Index > (lookbackPeriod + 1)).OrderBy(d => d.Index))
             {
                 avgGain = (avgGain * (lookbackPeriod - 1) + r.Gain) / lookbackPeriod;
                 avgLoss = (avgLoss * (lookbackPeriod - 1) + r.Loss) / lookbackPeriod;

--- a/Indicators/Stochastic/README.md
+++ b/Indicators/Stochastic/README.md
@@ -31,8 +31,8 @@ The first `N+S-1` periods will have `null` Oscillator values since there's not e
 | -- |-- |--
 | `Index` | int | Sequence of dates
 | `Date` | DateTime | Date
-| `Oscillator` | float | %K Oscillator over prior `N` lookback periods
-| `Signal` | float | %D Simple moving average of Oscillator
+| `Oscillator` | decimal | %K Oscillator over prior `N` lookback periods
+| `Signal` | decimal | %D Simple moving average of Oscillator
 | `IsIncreasing` | bool | Direction since last period (e.g. up or down).  Persists for no change.
 
 ## Example

--- a/Indicators/Stochastic/README.md
+++ b/Indicators/Stochastic/README.md
@@ -12,10 +12,10 @@ IEnumerable<StochResult> results = Indicator.GetStoch(history, lookbackPeriod, s
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](/GUIDE.md#Quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N` periods of `history`.
+| `history` | IEnumerable\<[Quote](/GUIDE.md#Quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N+S` periods of `history`.
 | `lookbackPeriod` | int | Lookback period (`N`) for the oscillator (%K).  Must be greater than 0.  Default is 14.
 | `signalPeriod` | int | Lookback period for the signal (%D).  Must be greater than 0.  Default is 3.
-| `smoothingPeriod` | int | Smoothes the Oscillator (%K).  "Slow" stochastic uses 3, "Fast" stochastic uses 1.  You can specify as needed here.  Must be greater than or equal to 1.  Default is 3.
+| `smoothingPeriod` | int | Smoothing period `S` for the Oscillator (%K).  "Slow" stochastic uses 3, "Fast" stochastic uses 1.  You can specify as needed here.  Must be greater than or equal to 1.  Default is 3.
 
 ## Response
 
@@ -23,7 +23,7 @@ IEnumerable<StochResult> results = Indicator.GetStoch(history, lookbackPeriod, s
 IEnumerable<StochResult>
 ```
 
-The first `N-1` periods will have `null` Oscillator values since there's not enough data to calculate.  We always return the same number of elements as there are in the historical quotes.
+The first `N+S-1` periods will have `null` Oscillator values since there's not enough data to calculate.  We always return the same number of elements as there are in the historical quotes.
 
 ### StochResult
 

--- a/Indicators/Stochastic/Stoch.Models.cs
+++ b/Indicators/Stochastic/Stoch.Models.cs
@@ -3,12 +3,12 @@
 
     public class StochResult : ResultBase
     {
-        public float? Oscillator { get; set; }
-        public float? Signal { get; set; }
+        public decimal? Oscillator { get; set; }
+        public decimal? Signal { get; set; }
         public bool? IsIncreasing { get; set; }
 
         // internal use only
-        internal float? Smooth { get; set; }
+        internal decimal? Smooth { get; set; }
     }
 
 }

--- a/Indicators/Stochastic/Stoch.cs
+++ b/Indicators/Stochastic/Stoch.cs
@@ -58,14 +58,15 @@ namespace Skender.Stock.Indicators
             }
 
 
-            // new signal and period direction info
+            // signal and period direction info
             float? lastOsc = null;
             bool? lastIsIncreasing = null;
             foreach (StochResult r in results
-                .Where(x => x.Oscillator != null))
+                .Where(x => x.Index >= (lookbackPeriod + smoothPeriod - 1))
+                .OrderBy(x => x.Index))
             {
                 // add signal
-                if (r.Index >= lookbackPeriod + smoothPeriod + signalPeriod)
+                if (r.Index >= lookbackPeriod + smoothPeriod + signalPeriod - 2)
                 {
                     r.Signal = results.Where(x => x.Index > (r.Index - signalPeriod) && x.Index <= r.Index)
                                      .Select(v => v.Oscillator)
@@ -102,7 +103,7 @@ namespace Skender.Stock.Indicators
         {
 
             // temporarily store interim smoothed oscillator
-            foreach (StochResult r in results.Where(x => x.Index >= (lookbackPeriod + smoothPeriod)))
+            foreach (StochResult r in results.Where(x => x.Index >= (lookbackPeriod + smoothPeriod - 1)))
             {
                 r.Smooth = results.Where(x => x.Index > (r.Index - smoothPeriod) && x.Index <= r.Index)
                                  .Select(v => v.Oscillator)

--- a/Indicators/Stochastic/Stoch.cs
+++ b/Indicators/Stochastic/Stoch.cs
@@ -58,17 +58,22 @@ namespace Skender.Stock.Indicators
             }
 
 
-            // new signal and trend info
-            float lastOsc = 0;
+            // new signal and period direction info
+            float? lastOsc = null;
             bool? lastIsIncreasing = null;
             foreach (StochResult r in results
-                .Where(x => x.Index >= (lookbackPeriod + signalPeriod + smoothPeriod) && x.Oscillator != null))
+                .Where(x => x.Oscillator != null))
             {
-                r.Signal = results.Where(x => x.Index > (r.Index - signalPeriod) && x.Index <= r.Index)
-                                 .Select(v => v.Oscillator)
-                                 .Average();
+                // add signal
+                if (r.Index >= lookbackPeriod + smoothPeriod + signalPeriod)
+                {
+                    r.Signal = results.Where(x => x.Index > (r.Index - signalPeriod) && x.Index <= r.Index)
+                                     .Select(v => v.Oscillator)
+                                     .Average();
+                }
 
-                if (r.Index >= (lookbackPeriod + signalPeriod + smoothPeriod) + 1)
+                // add direction
+                if (lastOsc != null)
                 {
                     if (r.Oscillator > lastOsc)
                     {
@@ -142,7 +147,7 @@ namespace Skender.Stock.Indicators
 
             // check history
             int qtyHistory = history.Count();
-            int minHistory = lookbackPeriod;
+            int minHistory = lookbackPeriod + smoothPeriod;
             if (qtyHistory < minHistory)
             {
                 throw new BadHistoryException("Insufficient history provided for Stochastic.  " +

--- a/Indicators/Stochastic/Stoch.cs
+++ b/Indicators/Stochastic/Stoch.cs
@@ -40,7 +40,7 @@ namespace Skender.Stock.Indicators
 
                     if (lowLow != highHigh)
                     {
-                        result.Oscillator = 100 * (float)((h.Close - lowLow) / (highHigh - lowLow));
+                        result.Oscillator = 100 * ((h.Close - lowLow) / (highHigh - lowLow));
                     }
                     else
                     {
@@ -59,7 +59,7 @@ namespace Skender.Stock.Indicators
 
 
             // signal and period direction info
-            float? lastOsc = null;
+            decimal? lastOsc = null;
             bool? lastIsIncreasing = null;
             foreach (StochResult r in results
                 .Where(x => x.Index >= (lookbackPeriod + smoothPeriod - 1))
@@ -91,7 +91,7 @@ namespace Skender.Stock.Indicators
                     }
                 }
 
-                lastOsc = (float)r.Oscillator;
+                lastOsc = (decimal)r.Oscillator;
                 lastIsIncreasing = r.IsIncreasing;
             }
 
@@ -115,7 +115,7 @@ namespace Skender.Stock.Indicators
             {
                 if (r.Smooth != null)
                 {
-                    r.Oscillator = (float)r.Smooth;
+                    r.Oscillator = (decimal)r.Smooth;
                 }
                 else
                 {

--- a/Indicators/StochasticRsi/README.md
+++ b/Indicators/StochasticRsi/README.md
@@ -6,7 +6,7 @@ It is different from, and often confused with the more traditional [Stochastic O
 
 ```csharp
 // usage
-IEnumerable<StochRsiResult> results = Indicator.GetStochRsi(history, lookbackPeriod);  
+IEnumerable<StochRsiResult> results = Indicator.GetStochRsi(history, rsiPeriod, stochPeriod, signalPeriod, smoothPeriod);
 ```
 
 ## Parameters
@@ -14,7 +14,12 @@ IEnumerable<StochRsiResult> results = Indicator.GetStochRsi(history, lookbackPer
 | name | type | notes
 | -- |-- |--
 | `history` | IEnumerable\<[Quote](/GUIDE.md#Quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least 2×`N` periods of `history`.  Since this uses a smoothing technique in the underlying RSI value, we recommend you use at least 250 data points prior to the intended usage date for maximum precision.
-| `lookbackPeriod` | int | Number of periods (`N`) in the lookback period.  Must be greater than 0.  Default is 14.
+| `rsiPeriod` | int | Number of periods (`R`) in the lookback period.  Must be greater than 0.  Standard is 14.
+| `stochPeriod` | int | Number of periods (`S`) in the lookback period.  Must be greater than 0.  Typically the same value as `rsiPeriod`.
+| `signalPeriod` | int | Number of periods (`G`) in the signal line (SMA of the StochRSI).  Must be greater than 0.  Typically 3-5.
+| `smoothPeriod` | int | Smoothing periods (`M`) for the Stochastic.  Must be greater than 0.  Default is 1 (Fast variant).
+
+The original Stochasic RSI formula uses a the Fast variant of the Stochastic calculation (`smoothPeriod=1`).  For a standard period of 14, the original formula would be `GetStochRSI(history,14,14,3,1)`; though, the "3" here is just for the Signal, which is not present in the original formula, but useful for additional smoothing of the Stochastic RSI.
 
 ## Response
 
@@ -30,7 +35,8 @@ The first `2×N-1` periods will have `null` values since there's not enough data
 | -- |-- |--
 | `Index` | int | Sequence of dates
 | `Date` | DateTime | Date
-| `StochRsi` | float | StochRSI over prior `N` lookback periods
+| `StochRsi` | decimal | %K Oscillator = Stochastic RSI = Stoch(`S`,`G`,`M`) of RSI(`R`)
+| `Signal` | decimal | %D Signal Line = Simple moving average of %K based on `G` periods
 | `IsIncreasing` | bool | Direction since last period (e.g. up or down).  Persists for no change.
 
 ## Example
@@ -40,7 +46,7 @@ The first `2×N-1` periods will have `null` values since there's not enough data
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate StochRSI(14)
-IEnumerable<StochRsiResult> results = Indicator.GetStochRsi(history,14);
+IEnumerable<StochRsiResult> results = Indicator.GetStochRsi(history,14,14,1,1);
 
 // use results as needed
 DateTime evalDate = DateTime.Parse("12/31/2018");

--- a/Indicators/StochasticRsi/README.md
+++ b/Indicators/StochasticRsi/README.md
@@ -13,7 +13,7 @@ IEnumerable<StochRsiResult> results = Indicator.GetStochRsi(history, rsiPeriod, 
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](/GUIDE.md#Quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least 2×`N` periods of `history`.  Since this uses a smoothing technique in the underlying RSI value, we recommend you use at least 250 data points prior to the intended usage date for maximum precision.
+| `history` | IEnumerable\<[Quote](/GUIDE.md#Quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `R+S` periods of `history`.  Since this uses a smoothing technique in the underlying RSI value, we recommend you use at least 250 data points prior to the intended usage date for maximum precision.
 | `rsiPeriod` | int | Number of periods (`R`) in the lookback period.  Must be greater than 0.  Standard is 14.
 | `stochPeriod` | int | Number of periods (`S`) in the lookback period.  Must be greater than 0.  Typically the same value as `rsiPeriod`.
 | `signalPeriod` | int | Number of periods (`G`) in the signal line (SMA of the StochRSI).  Must be greater than 0.  Typically 3-5.
@@ -27,7 +27,7 @@ The original Stochasic RSI formula uses a the Fast variant of the Stochastic cal
 IEnumerable<StochRsiResult>
 ```
 
-The first `2×N-1` periods will have `null` values since there's not enough data to calculate.  We always return the same number of elements as there are in the historical quotes.
+The first `R+S-1` periods will have `null` values for `StochRsi` since there's not enough data to calculate.  We always return the same number of elements as there are in the historical quotes.
 
 ### StochRsiResult
 
@@ -35,7 +35,7 @@ The first `2×N-1` periods will have `null` values since there's not enough data
 | -- |-- |--
 | `Index` | int | Sequence of dates
 | `Date` | DateTime | Date
-| `StochRsi` | decimal | %K Oscillator = Stochastic RSI = Stoch(`S`,`G`,`M`) of RSI(`R`)
+| `StochRsi` | decimal | %K Oscillator = Stochastic RSI = Stoch(`S`,`G`,`M`) of RSI(`R`) of Close price
 | `Signal` | decimal | %D Signal Line = Simple moving average of %K based on `G` periods
 | `IsIncreasing` | bool | Direction since last period (e.g. up or down).  Persists for no change.
 

--- a/Indicators/StochasticRsi/StochRsi.Models.cs
+++ b/Indicators/StochasticRsi/StochRsi.Models.cs
@@ -3,7 +3,8 @@
 
     public class StochRsiResult : ResultBase
     {
-        public float? StochRsi { get; set; }
+        public decimal? StochRsi { get; set; }
+        public decimal? Signal { get; set; }
         public bool? IsIncreasing { get; set; }
     }
 

--- a/Indicators/StochasticRsi/StochRsi.cs
+++ b/Indicators/StochasticRsi/StochRsi.cs
@@ -6,85 +6,94 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // STOCHASTIC RSI
-        public static IEnumerable<StochRsiResult> GetStochRsi(IEnumerable<Quote> history, int lookbackPeriod = 14)
+        public static IEnumerable<StochRsiResult> GetStochRsi(IEnumerable<Quote> history,
+            int rsiPeriod, int stochPeriod, int signalPeriod, int smoothPeriod = 1)
         {
 
             // clean quotes
             history = Cleaners.PrepareHistory(history);
 
             // validate parameters
-            ValidateStochRsi(history, lookbackPeriod);
+            ValidateStochRsi(history, rsiPeriod, stochPeriod, signalPeriod, smoothPeriod);
 
             // initialize
             List<StochRsiResult> results = new List<StochRsiResult>();
-            IEnumerable<RsiResult> rsiResults = GetRsi(history, lookbackPeriod);
 
-            // calculate
-            foreach (Quote h in history)
+            // get RSI
+            IEnumerable<RsiResult> rsiResults = GetRsi(history, rsiPeriod);
+
+            // convert rsi to quote format
+            List<Quote> rsiQuotes = rsiResults
+                .Where(x => x.Rsi != null)
+                .Select(x => new Quote
+                {
+                    Index = null,
+                    Date = x.Date,
+                    High = (decimal)x.Rsi,
+                    Low = (decimal)x.Rsi,
+                    Close = (decimal)x.Rsi
+                })
+                .ToList();
+
+            // get Stochastic of RSI
+            IEnumerable<StochResult> stoResults = GetStoch(rsiQuotes, stochPeriod, signalPeriod, smoothPeriod);
+
+            // compose
+            foreach (RsiResult r in rsiResults)
             {
 
                 StochRsiResult result = new StochRsiResult
                 {
-                    Index = (int)h.Index,
-                    Date = h.Date,
+                    Index = r.Index,
+                    Date = r.Date
                 };
 
-                if (h.Index >= 2 * lookbackPeriod)
+                if (r.Index >= rsiPeriod + stochPeriod)
                 {
-                    IEnumerable<RsiResult> period = rsiResults.Where(x => x.Index <= h.Index && x.Index > (h.Index - lookbackPeriod));
-                    float? rsi = period.Where(x => x.Index == h.Index).FirstOrDefault().Rsi;
-                    float? rsiHigh = period.Select(x => x.Rsi).Max();
-                    float? rsiLow = period.Select(x => x.Rsi).Min();
+                    StochResult sto = stoResults
+                        .Where(x => x.Index == r.Index - stochPeriod)
+                        .FirstOrDefault();
 
-                    result.StochRsi = (rsi - rsiLow) / (rsiHigh - rsiLow);
+                    result.StochRsi = sto.Oscillator;
+                    result.Signal = sto.Signal;
+                    result.IsIncreasing = sto.IsIncreasing;
                 }
 
                 results.Add(result);
-            }
-
-
-            // add direction
-            float? lastRSI = 0;
-            bool? lastIsIncreasing = null;
-            foreach (StochRsiResult r in results.Where(x => x.Index >= 2 * lookbackPeriod).OrderBy(d => d.Index))
-            {
-                if (r.Index >= 2 * lookbackPeriod + 1)
-                {
-                    if (r.StochRsi > lastRSI)
-                    {
-                        r.IsIncreasing = true;
-                    }
-                    else if (r.StochRsi < lastRSI)
-                    {
-                        r.IsIncreasing = false;
-                    }
-                    else
-                    {
-                        // no change, keep trend
-                        r.IsIncreasing = lastIsIncreasing;
-                    }
-                }
-
-                lastRSI = r.StochRsi;
-                lastIsIncreasing = r.IsIncreasing;
             }
 
             return results;
         }
 
 
-        private static void ValidateStochRsi(IEnumerable<Quote> history, int lookbackPeriod)
+        private static void ValidateStochRsi(IEnumerable<Quote> history,
+            int rsiPeriod, int stochPeriod, int signalPeriod, int smoothPeriod)
         {
 
             // check parameters
-            if (lookbackPeriod <= 0)
+            if (rsiPeriod <= 0)
             {
-                throw new BadParameterException("Lookback period must be greater than 0 for Stochastic RSI.");
+                throw new BadParameterException("RSI period must be greater than 0 for Stochastic RSI.");
+            }
+
+            if (stochPeriod <= 0)
+            {
+                throw new BadParameterException("STOCH period must be greater than 0 for Stochastic RSI.");
+            }
+
+            if (signalPeriod <= 0)
+            {
+                throw new BadParameterException("Signal period must be greater than 0 for Stochastic RSI.");
+            }
+
+            if (smoothPeriod <= 0)
+            {
+                throw new BadParameterException("Smooth period must be greater than 0 for Stochastic RSI.");
             }
 
             // check history
             int qtyHistory = history.Count();
-            int minHistory = 2 * lookbackPeriod;
+            int minHistory = rsiPeriod + stochPeriod;
             if (qtyHistory < minHistory)
             {
                 throw new BadHistoryException("Insufficient history provided for Stochastic RSI.  " +

--- a/Indicators/WilliamR/README.md
+++ b/Indicators/WilliamR/README.md
@@ -29,7 +29,7 @@ The first `N-1` periods will have `null` Oscillator values since there's not eno
 | -- |-- |--
 | `Index` | int | Sequence of dates
 | `Date` | DateTime | Date
-| `WilliamR` | float | Oscillator over prior `N` lookback periods
+| `WilliamR` | decimal | Oscillator over prior `N` lookback periods
 | `IsIncreasing` | bool | Direction since last period (e.g. up or down).  Persists for no change.
 
 ## Example

--- a/Indicators/WilliamR/WilliamR.Models.cs
+++ b/Indicators/WilliamR/WilliamR.Models.cs
@@ -3,7 +3,7 @@
 
     public class WilliamResult : ResultBase
     {
-        public float? WilliamR { get; set; }
+        public decimal? WilliamR { get; set; }
         public bool? IsIncreasing { get; set; }
     }
 

--- a/IndicatorsTests/Test.Rsi.cs
+++ b/IndicatorsTests/Test.Rsi.cs
@@ -21,8 +21,8 @@ namespace StockIndicators.Tests
             // proper quantities
             // should always be the same number of results as there is history
             Assert.AreEqual(502, results.Count());
-            Assert.AreEqual(502 - lookbackPeriod + 1, results.Where(x => x.Rsi != null).Count());
-            Assert.AreEqual(502 - lookbackPeriod + 1, results.Where(x => x.IsIncreasing != null).Count());
+            Assert.AreEqual(488, results.Where(x => x.Rsi != null).Count());
+            Assert.AreEqual(487, results.Where(x => x.IsIncreasing != null).Count());
 
             // sample value
             RsiResult r = results.Where(x => x.Date == DateTime.Parse("12/31/2018")).FirstOrDefault();

--- a/IndicatorsTests/Test.Stochastic.cs
+++ b/IndicatorsTests/Test.Stochastic.cs
@@ -31,7 +31,7 @@ namespace StockIndicators.Tests
 
             // sample value
             StochResult r = results.Where(x => x.Date == DateTime.Parse("12/31/2018")).FirstOrDefault();
-            Assert.AreEqual((decimal)43.1354, Math.Round((decimal)r.Oscillator, 4));
+            Assert.AreEqual((decimal)43.1353, Math.Round((decimal)r.Oscillator, 4));
             Assert.AreEqual((decimal)35.5674, Math.Round((decimal)r.Signal, 4));
             Assert.AreEqual(true, r.IsIncreasing);
         }

--- a/IndicatorsTests/Test.Stochastic.cs
+++ b/IndicatorsTests/Test.Stochastic.cs
@@ -11,36 +11,69 @@ namespace StockIndicators.Tests
     {
 
         [TestMethod()]
-        public void GetStochTest()
+        public void GetStochStandardTest()
         {
             int lookbackPeriod = 14;
             int signalPeriod = 3;
             int smoothPeriod = 3;
 
-            IEnumerable<StochResult> results = Indicator.GetStoch(history, lookbackPeriod, signalPeriod, smoothPeriod);
+            IEnumerable<StochResult> results = Indicator.GetStoch(
+                history, lookbackPeriod, signalPeriod, smoothPeriod);
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
             Assert.AreEqual(502, results.Count());
-            Assert.AreEqual(502 - lookbackPeriod - smoothPeriod + 1, results.Where(x => x.Oscillator != null).Count());
-            Assert.AreEqual(502 - lookbackPeriod - smoothPeriod - signalPeriod + 1, results.Where(x => x.Signal != null).Count());
-            Assert.AreEqual(502 - lookbackPeriod - smoothPeriod, results.Where(x => x.IsIncreasing != null).Count());
+            Assert.AreEqual(487, results.Where(x => x.Oscillator != null).Count());
+            Assert.AreEqual(485, results.Where(x => x.Signal != null).Count());
+            Assert.AreEqual(486, results.Where(x => x.IsIncreasing != null).Count());
 
             // sample value
+            StochResult r = results.Where(x => x.Date == DateTime.Parse("12/31/2018")).FirstOrDefault();
+            Assert.AreEqual((decimal)43.1354, Math.Round((decimal)r.Oscillator, 4));
+            Assert.AreEqual((decimal)35.5674, Math.Round((decimal)r.Signal, 4));
+            Assert.AreEqual(true, r.IsIncreasing);
+        }
+
+        [TestMethod()]
+        public void GetStochNoSignalTest()
+        {
+            int lookbackPeriod = 5;
+            int signalPeriod = 1;
+            int smoothPeriod = 3;
+
+            IEnumerable<StochResult> results = Indicator.GetStoch(
+                history, lookbackPeriod, signalPeriod, smoothPeriod);
+
+            // signal equals oscillator
             StochResult r1 = results.Where(x => x.Date == DateTime.Parse("12/31/2018")).FirstOrDefault();
-            Assert.AreEqual((decimal)43.1354, Math.Round((decimal)r1.Oscillator, 4));
-            Assert.AreEqual((decimal)35.5674, Math.Round((decimal)r1.Signal, 4));
+            Assert.AreEqual(r1.Oscillator, r1.Signal);
+
+            StochResult r2 = results.Where(x => x.Date == DateTime.Parse("12/10/2018")).FirstOrDefault();
+            Assert.AreEqual(r2.Oscillator, r2.Signal);
+        }
+
+        [TestMethod()]
+        public void GetStochFastTest()
+        {
+            int lookbackPeriod = 5;
+            int signalPeriod = 10;
+            int smoothPeriod = 1;
+
+            IEnumerable<StochResult> results = Indicator.GetStoch(
+                history, lookbackPeriod, signalPeriod, smoothPeriod);
+
+            // sample values
+            StochResult r1 = results.Where(x => x.Date == DateTime.Parse("12/31/2018")).FirstOrDefault();
+            Assert.AreEqual((decimal)91.6233, Math.Round((decimal)r1.Oscillator, 4));
+            Assert.AreEqual((decimal)36.0608, Math.Round((decimal)r1.Signal, 4));
             Assert.AreEqual(true, r1.IsIncreasing);
 
-            // no signal period
-            IEnumerable<StochResult> results2 = Indicator.GetStoch(history, 5, 1);
-            StochResult r2 = results2.Where(x => x.Date == DateTime.Parse("12/31/2018")).FirstOrDefault();
-            Assert.AreEqual(r2.Oscillator, r2.Signal);
-
-            StochResult r3 = results2.Where(x => x.Date == DateTime.Parse("12/10/2018")).FirstOrDefault();
-            Assert.AreEqual(r3.Oscillator, r3.Signal);
+            StochResult r2 = results.Where(x => x.Date == DateTime.Parse("12/10/2018")).FirstOrDefault();
+            Assert.AreEqual((decimal)25.0353, Math.Round((decimal)r2.Oscillator, 4));
+            Assert.AreEqual((decimal)60.5706, Math.Round((decimal)r2.Signal, 4));
+            Assert.AreEqual(true, r2.IsIncreasing);
         }
 
 

--- a/IndicatorsTests/Test.Stochastic.cs
+++ b/IndicatorsTests/Test.Stochastic.cs
@@ -24,8 +24,9 @@ namespace StockIndicators.Tests
             // proper quantities
             // should always be the same number of results as there is history
             Assert.AreEqual(502, results.Count());
-            Assert.AreEqual(502 - lookbackPeriod + 1 - smoothPeriod, results.Where(x => x.Oscillator != null).Count());
-            Assert.AreEqual(502 - lookbackPeriod + 1 - smoothPeriod - signalPeriod, results.Where(x => x.Signal != null).Count());
+            Assert.AreEqual(502 - lookbackPeriod - smoothPeriod + 1, results.Where(x => x.Oscillator != null).Count());
+            Assert.AreEqual(502 - lookbackPeriod - smoothPeriod - signalPeriod + 1, results.Where(x => x.Signal != null).Count());
+            Assert.AreEqual(502 - lookbackPeriod - smoothPeriod, results.Where(x => x.IsIncreasing != null).Count());
 
             // sample value
             StochResult r1 = results.Where(x => x.Date == DateTime.Parse("12/31/2018")).FirstOrDefault();
@@ -70,7 +71,7 @@ namespace StockIndicators.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetStoch(history.Where(x => x.Index < 30), 30);
+            Indicator.GetStoch(history.Where(x => x.Index < 33), 30, 3, 3);
         }
 
     }

--- a/IndicatorsTests/Test.StochasticRsi.cs
+++ b/IndicatorsTests/Test.StochasticRsi.cs
@@ -13,23 +13,57 @@ namespace StockIndicators.Tests
         [TestMethod()]
         public void GetStochRsiTest()
         {
-            int lookbackPeriod = 14;
+            int rsiPeriod = 14;
+            int stochPeriod = 14;
+            int signalPeriod = 3;
+            int smoothPeriod = 1;
 
-            IEnumerable<StochRsiResult> results = Indicator.GetStochRsi(history, lookbackPeriod);
+            IEnumerable<StochRsiResult> results = Indicator.GetStochRsi(
+                history, rsiPeriod, stochPeriod, signalPeriod, smoothPeriod);
 
             // assertions
 
             // proper quantities
-            // should always be the same number of results as there is history
             Assert.AreEqual(502, results.Count());
-            Assert.AreEqual(502 - 2 * lookbackPeriod + 1, results.Where(x => x.StochRsi != null).Count());
+            Assert.AreEqual(502 - rsiPeriod - stochPeriod - smoothPeriod + 2, results.Where(x => x.StochRsi != null).Count());
+            Assert.AreEqual(502 - rsiPeriod - stochPeriod - signalPeriod - smoothPeriod + 3, results.Where(x => x.Signal != null).Count());
 
             // this series starts with 4 periods of topped Stochastic RSI, so no direction can be determined
-            Assert.AreEqual(502 - 2 * lookbackPeriod + 1 - 4, results.Where(x => x.IsIncreasing != null).Count());
+            Assert.AreEqual(502 - rsiPeriod - stochPeriod - smoothPeriod + 2 - 4, results.Where(x => x.IsIncreasing != null).Count());
 
             // sample value
             StochRsiResult r = results.Where(x => x.Date == DateTime.Parse("12/31/2018")).FirstOrDefault();
-            Assert.AreEqual((decimal)0.9752, Math.Round((decimal)r.StochRsi, 4));
+            Assert.AreEqual((decimal)97.5244, Math.Round((decimal)r.StochRsi, 4));
+            Assert.AreEqual((decimal)89.8385, Math.Round((decimal)r.Signal, 4));
+            Assert.AreEqual(true, r.IsIncreasing);
+        }
+
+
+        [TestMethod()]
+        public void GetStochRsiSlowTest()
+        {
+            int rsiPeriod = 14;
+            int stochPeriod = 14;
+            int signalPeriod = 3;
+            int smoothPeriod = 3;
+
+            IEnumerable<StochRsiResult> results = Indicator.GetStochRsi(
+                history, rsiPeriod, stochPeriod, signalPeriod, smoothPeriod);
+
+            // assertions
+
+            // proper quantities
+            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502 - rsiPeriod - stochPeriod - smoothPeriod + 2, results.Where(x => x.StochRsi != null).Count());
+            Assert.AreEqual(502 - rsiPeriod - stochPeriod - signalPeriod - smoothPeriod + 3, results.Where(x => x.Signal != null).Count());
+
+            // this series starts with 2 periods of topped Stochastic RSI, so no direction can be determined
+            Assert.AreEqual(502 - rsiPeriod - stochPeriod - smoothPeriod + 2 - 2, results.Where(x => x.IsIncreasing != null).Count());
+
+            // sample value
+            StochRsiResult r = results.Where(x => x.Date == DateTime.Parse("12/31/2018")).FirstOrDefault();
+            Assert.AreEqual((decimal)89.8385, Math.Round((decimal)r.StochRsi, 4));
+            Assert.AreEqual((decimal)73.4176, Math.Round((decimal)r.Signal, 4));
             Assert.AreEqual(true, r.IsIncreasing);
         }
 
@@ -37,17 +71,38 @@ namespace StockIndicators.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback.")]
+        [ExpectedException(typeof(BadParameterException), "Bad RSI lookback.")]
+        public void BadRsiLookback()
+        {
+            Indicator.GetStochRsi(history, 0, 14, 3, 1);
+        }
+
+        [TestMethod()]
+        [ExpectedException(typeof(BadParameterException), "Bad STO lookback.")]
         public void BadLookback()
         {
-            Indicator.GetStochRsi(history, 0);
+            Indicator.GetStochRsi(history, 14, 0, 3, 3);
+        }
+
+        [TestMethod()]
+        [ExpectedException(typeof(BadParameterException), "Bad STO signal period.")]
+        public void BadSignal()
+        {
+            Indicator.GetStochRsi(history, 14, 14, 0);
+        }
+
+        [TestMethod()]
+        [ExpectedException(typeof(BadParameterException), "Bad STO smoothing period.")]
+        public void BadSmooth()
+        {
+            Indicator.GetStochRsi(history, 14, 14, 3, 0);
         }
 
         [TestMethod()]
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetStochRsi(history.Where(x => x.Index < 60), 30);
+            Indicator.GetStochRsi(history.Where(x => x.Index < 60), 30, 30, 5, 5);
         }
 
     }


### PR DESCRIPTION
BREAKING CHANGE

The prior implementation of `GetStochRSI` required only one lookback period parameter as we were using a more standard formula for the indicator (e.g. the stochastic lookback = rsi lookback, used the Fast stochastic variant, and did not include a signal line).

This update allows you to change those parameters to further customize the indicator's behavior and to have the additional smoothed signal line.

In other words, the profile changed from an equivalent `GetStochRSI(history,14)` to `GetStochRSI(history,14,14,3,1)`.  Here, you can have different lookback periods, smoothing factors, and signal lines.

[StochasticRSI.14.14.3.3-ManualCalc.xlsx](https://github.com/DaveSkender/Stock.Indicators/files/4905842/StochasticRSI.14.14.3.3-ManualCalc.xlsx)

Ref #64, [AB#650](https://dev.azure.com/skender/5123ca47-74f2-4d67-a5d4-c4d90b8d670a/_workitems/edit/650)