### PR TITLE
add back GitVersion library

### DIFF
--- a/Indicators/Indicators.csproj
+++ b/Indicators/Indicators.csproj
@@ -28,7 +28,11 @@ Please contribute to help us get to v1.0.0.  Feedback appreciated.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+      <PackageReference Include="GitVersionTask" Version="5.3.7">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+      <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Removed in [AB#650](https://dev.azure.com/skender/5123ca47-74f2-4d67-a5d4-c4d90b8d670a/_workitems/edit/650)
But this is the only way to get DLL version stamping coordinated with package and build numbering.
Adding it back, despite how often it blows up the build.