### PR TITLE
refactor: performance tuning

### DIFF
--- a/Indicators/Aroon/Aroon.cs
+++ b/Indicators/Aroon/Aroon.cs
@@ -31,8 +31,9 @@ namespace Skender.Stock.Indicators
                 // add aroons
                 if (h.Index >= lookbackPeriod)
                 {
-                    IEnumerable<Quote> period = history
-                        .Where(x => x.Index <= h.Index && x.Index > (h.Index - lookbackPeriod));
+                    List<Quote> period = history
+                        .Where(x => x.Index <= h.Index && x.Index > (h.Index - lookbackPeriod))
+                        .ToList();
 
                     decimal lastHighPrice = period.Select(x => x.High).Max();
                     decimal lastLowPrice = period.Select(x => x.Low).Min();

--- a/Indicators/BollingerBands/BollingerBands.cs
+++ b/Indicators/BollingerBands/BollingerBands.cs
@@ -31,9 +31,10 @@ namespace Skender.Stock.Indicators
 
                 if (h.Index >= lookbackPeriod)
                 {
-                    IEnumerable<double> periodClose = history
+                    double[] periodClose = history
                         .Where(x => x.Index > (h.Index - lookbackPeriod) && x.Index <= h.Index)
-                        .Select(x => (double)x.Close);
+                        .Select(x => (double)x.Close)
+                        .ToArray();
 
                     double stdDev = Functions.StdDev(periodClose);
 

--- a/Indicators/Cci/Cci.cs
+++ b/Indicators/Cci/Cci.cs
@@ -37,7 +37,9 @@ namespace Skender.Stock.Indicators
             // roll through interim results to calculate CCI
             foreach (CciResult result in results.Where(x => x.Index >= lookbackPeriod))
             {
-                IEnumerable<CciResult> period = results.Where(x => x.Index <= result.Index && x.Index > (result.Index - lookbackPeriod));
+                List<CciResult> period = results
+                    .Where(x => x.Index <= result.Index && x.Index > (result.Index - lookbackPeriod))
+                    .ToList();
 
                 decimal smaTp = (decimal)period.Select(x => x.Tp).Average();
                 decimal meanDv = 0;

--- a/Indicators/ChaikinMoneyFlow/Cmf.cs
+++ b/Indicators/ChaikinMoneyFlow/Cmf.cs
@@ -33,8 +33,9 @@ namespace Skender.Stock.Indicators
 
                 if (r.Index >= lookbackPeriod)
                 {
-                    IEnumerable<AdlResult> period = adlResults
-                        .Where(x => x.Index <= r.Index && x.Index > (r.Index - lookbackPeriod));
+                    List<AdlResult> period = adlResults
+                        .Where(x => x.Index <= r.Index && x.Index > (r.Index - lookbackPeriod))
+                        .ToList();
 
                     // simple moving average
                     result.Cmf = period

--- a/Indicators/Chandelier/Chandelier.cs
+++ b/Indicators/Chandelier/Chandelier.cs
@@ -34,11 +34,14 @@ namespace Skender.Stock.Indicators
                 // add exit values
                 if (h.Index >= lookbackPeriod)
                 {
-                    IEnumerable<Quote> period = history
-                        .Where(x => x.Index <= h.Index && x.Index > (h.Index - lookbackPeriod));
+                    List<Quote> period = history
+                        .Where(x => x.Index <= h.Index && x.Index > (h.Index - lookbackPeriod))
+                        .ToList();
 
                     decimal atr = (decimal)atrResult
-                        .Where(x => x.Index == h.Index).FirstOrDefault().Atr;
+                        .Where(x => x.Index == h.Index)
+                        .FirstOrDefault()
+                        .Atr;
 
                     switch (variant)
                     {
@@ -98,8 +101,8 @@ namespace Skender.Stock.Indicators
             if (qtyHistory < minHistory)
             {
                 throw new BadHistoryException("Insufficient history provided for Chandelier Exit.  " +
-                        string.Format(cultureProvider, 
-                        "You provided {0} periods of history when at least {1} is required.", 
+                        string.Format(cultureProvider,
+                        "You provided {0} periods of history when at least {1} is required.",
                         qtyHistory, minHistory));
             }
         }

--- a/Indicators/Correlation/Correlation.cs
+++ b/Indicators/Correlation/Correlation.cs
@@ -44,7 +44,9 @@ namespace Skender.Stock.Indicators
             // compute correlation
             foreach (CorrResult r in results.Where(x => x.Index >= lookbackPeriod))
             {
-                IEnumerable<CorrResult> period = results.Where(x => x.Index > (r.Index - lookbackPeriod) && x.Index <= r.Index);
+                List<CorrResult> period = results
+                    .Where(x => x.Index > (r.Index - lookbackPeriod) && x.Index <= r.Index)
+                    .ToList();
 
                 decimal avgA = period.Select(x => x.PriceA).Average();
                 decimal avgB = period.Select(x => x.PriceB).Average();

--- a/Indicators/Donchian/Donchian.cs
+++ b/Indicators/Donchian/Donchian.cs
@@ -31,8 +31,9 @@ namespace Skender.Stock.Indicators
 
                 if (h.Index >= lookbackPeriod)
                 {
-                    IEnumerable<Quote> period = history
-                        .Where(x => x.Index > (h.Index - lookbackPeriod) && x.Index <= h.Index);
+                    List<Quote> period = history
+                        .Where(x => x.Index > (h.Index - lookbackPeriod) && x.Index <= h.Index)
+                        .ToList();
 
                     result.UpperBand = period.Select(h => h.High).Max();
                     result.LowerBand = period.Select(l => l.Low).Min();

--- a/Indicators/Ema/Ema.cs
+++ b/Indicators/Ema/Ema.cs
@@ -34,6 +34,7 @@ namespace Skender.Stock.Indicators
             decimal k = 2 / (decimal)(lookbackPeriod + 1);
             decimal lastEma = basicData
                 .Where(x => x.Index < lookbackPeriod)
+                .ToList()
                 .Select(x => x.Value)
                 .Average();
 

--- a/Indicators/ParabolicSar/ParabolicSar.cs
+++ b/Indicators/ParabolicSar/ParabolicSar.cs
@@ -68,7 +68,12 @@ namespace Skender.Stock.Indicators
                         result.Sar = currentSar;
 
                         // SAR cannot be higher than last two lows
-                        decimal minLastTwo = history.Where(x => x.Index >= h.Index - 2 && x.Index < h.Index).Select(x => x.Low).Min();
+                        decimal minLastTwo = history
+                            .Where(x => x.Index >= h.Index - 2 && x.Index < h.Index)
+                            .ToList()
+                            .Select(x => x.Low)
+                            .Min();
+
                         result.Sar = Math.Min((decimal)result.Sar, minLastTwo);
 
                         if (h.High > extremePoint)
@@ -102,7 +107,12 @@ namespace Skender.Stock.Indicators
                         result.Sar = currentSar;
 
                         // SAR cannot be lower than last two highs
-                        decimal maxLastTwo = history.Where(x => x.Index >= h.Index - 2 && x.Index < h.Index).Select(x => x.High).Max();
+                        decimal maxLastTwo = history
+                            .Where(x => x.Index >= h.Index - 2 && x.Index < h.Index)
+                            .ToList()
+                            .Select(x => x.High)
+                            .Max();
+
                         result.Sar = Math.Max((decimal)result.Sar, maxLastTwo);
 
                         if (h.Low < extremePoint)

--- a/Indicators/Pmo/Pmo.cs
+++ b/Indicators/Pmo/Pmo.cs
@@ -49,8 +49,9 @@ namespace Skender.Stock.Indicators
                 }
                 else if (r.Index == startIndex)
                 {
-                    IEnumerable<RocResult> period = roc
-                        .Where(x => x.Index > r.Index - timePeriod && x.Index <= r.Index);
+                    List<RocResult> period = roc
+                        .Where(x => x.Index > r.Index - timePeriod && x.Index <= r.Index)
+                        .ToList();
 
                     result.RocEma = period.Select(x => x.Roc).Average();
                 }
@@ -71,8 +72,9 @@ namespace Skender.Stock.Indicators
                 }
                 else if (p.Index == startIndex)
                 {
-                    IEnumerable<PmoResult> period = results
-                        .Where(x => x.Index > p.Index - smoothingPeriod && x.Index <= p.Index);
+                    List<PmoResult> period = results
+                        .Where(x => x.Index > p.Index - smoothingPeriod && x.Index <= p.Index)
+                        .ToList();
 
                     p.Pmo = period.Select(x => x.RocEma).Average();
                 }
@@ -91,8 +93,9 @@ namespace Skender.Stock.Indicators
                 }
                 else if (p.Index == startIndex)
                 {
-                    IEnumerable<PmoResult> period = results
-                        .Where(x => x.Index > p.Index - signalPeriod && x.Index <= p.Index);
+                    List<PmoResult> period = results
+                        .Where(x => x.Index > p.Index - signalPeriod && x.Index <= p.Index)
+                        .ToList();
 
                     p.Signal = period.Select(x => x.Pmo).Average();
                 }

--- a/Indicators/Rsi/Rsi.cs
+++ b/Indicators/Rsi/Rsi.cs
@@ -58,7 +58,7 @@ namespace Skender.Stock.Indicators
             first.Rsi = lastRSI;
 
             // calculate RSI
-            foreach (RsiResult r in results.Where(x => x.Index > (lookbackPeriod + 1)).OrderBy(d => d.Index))
+            foreach (RsiResult r in results.Where(x => x.Index > (lookbackPeriod + 1)))
             {
                 avgGain = (avgGain * (lookbackPeriod - 1) + r.Gain) / lookbackPeriod;
                 avgLoss = (avgLoss * (lookbackPeriod - 1) + r.Loss) / lookbackPeriod;

--- a/Indicators/Sma/Sma.cs
+++ b/Indicators/Sma/Sma.cs
@@ -31,8 +31,9 @@ namespace Skender.Stock.Indicators
 
                 if (h.Index >= lookbackPeriod)
                 {
-                    IEnumerable<Quote> period = history
-                        .Where(x => x.Index <= h.Index && x.Index > (h.Index - lookbackPeriod));
+                    List<Quote> period = history
+                        .Where(x => x.Index <= h.Index && x.Index > (h.Index - lookbackPeriod))
+                        .ToList();
 
                     // simple moving average
                     result.Sma = period
@@ -78,8 +79,8 @@ namespace Skender.Stock.Indicators
             if (qtyHistory < minHistory)
             {
                 throw new BadHistoryException("Insufficient history provided for SMA.  " +
-                        string.Format(cultureProvider, 
-                        "You provided {0} periods of history when at least {1} is required.", 
+                        string.Format(cultureProvider,
+                        "You provided {0} periods of history when at least {1} is required.",
                         qtyHistory, minHistory));
             }
 

--- a/Indicators/StandardDev/StdDev.cs
+++ b/Indicators/StandardDev/StdDev.cs
@@ -41,9 +41,10 @@ namespace Skender.Stock.Indicators
                 if (h.Index >= lookbackPeriod)
                 {
                     // price based
-                    IEnumerable<double> period = basicData
+                    double[] period = basicData
                         .Where(x => x.Index > (h.Index - lookbackPeriod) && x.Index <= h.Index)
-                        .Select(x => (double)x.Value);
+                        .Select(x => (double)x.Value)
+                        .ToArray();
 
                     result.StdDev = (decimal)Functions.StdDev(period);
                     result.ZScore = (h.Value - (decimal)period.Average()) / result.StdDev;

--- a/Indicators/UlcerIndex/Ulcer.cs
+++ b/Indicators/UlcerIndex/Ulcer.cs
@@ -31,8 +31,9 @@ namespace Skender.Stock.Indicators
 
                 if (h.Index >= lookbackPeriod)
                 {
-                    IEnumerable<Quote> period = history
-                        .Where(x => x.Index > (h.Index - lookbackPeriod) && x.Index <= h.Index);
+                    List<Quote> period = history
+                        .Where(x => x.Index > (h.Index - lookbackPeriod) && x.Index <= h.Index)
+                        .ToList();
 
                     double sumSquared = 0;
 

--- a/Indicators/_Common/Functions.cs
+++ b/Indicators/_Common/Functions.cs
@@ -7,12 +7,12 @@ namespace Skender.Stock.Indicators
     internal static class Functions
     {
 
-        internal static double StdDev(IEnumerable<double> values)
+        internal static double StdDev(double[] values)
         {
             // ref: https://stackoverflow.com/questions/2253874/standard-deviation-in-linq
 
             double ret = 0;
-            int count = values.Count();
+            int count = values.Length;
             if (count > 1)
             {
                 //Compute the Average


### PR DESCRIPTION
- convert `IEnumerable` to `List` type when using Min, Max, Average (who would have thought?)
- convert StdDev to use `double[]` instead of `IEnumerable<double>`
- misc other tuning optimizations

This came out of conversation #88 for work item [AB#720](https://dev.azure.com/skender/5123ca47-74f2-4d67-a5d4-c4d90b8d670a/_workitems/edit/720)
Looks like this is an overall average 40% speed improvement on updated indicators, but at a slight memory utilization cost.