### PR TITLE
add IsReversal to PSAR

### DIFF
--- a/Indicators/ParabolicSar/ParabolicSar.Models.cs
+++ b/Indicators/ParabolicSar/ParabolicSar.Models.cs
@@ -6,5 +6,6 @@ namespace Skender.Stock.Indicators
     public class ParabolicSarResult : ResultBase
     {
         public decimal? Sar { get; set; }
+        public bool? IsReversal { get; set; }
     }
 }

--- a/Indicators/ParabolicSar/ParabolicSar.cs
+++ b/Indicators/ParabolicSar/ParabolicSar.cs
@@ -53,6 +53,7 @@ namespace Skender.Stock.Indicators
                     // turn down
                     if (h.Low < currentSar)
                     {
+                        result.IsReversal = true;
                         result.Sar = extremePoint;
 
                         isRising = false;
@@ -63,6 +64,7 @@ namespace Skender.Stock.Indicators
                     // continue rising
                     else
                     {
+                        result.IsReversal = false;
                         result.Sar = currentSar;
 
                         // SAR cannot be higher than last two lows
@@ -90,6 +92,7 @@ namespace Skender.Stock.Indicators
                     // turn up
                     if (h.High > currentSar)
                     {
+                        result.IsReversal = true;
                         result.Sar = extremePoint;
 
                         isRising = true;
@@ -100,6 +103,7 @@ namespace Skender.Stock.Indicators
                     // continue falling
                     else
                     {
+                        result.IsReversal = false;
                         result.Sar = currentSar;
 
                         // SAR cannot be lower than last two highs

--- a/Indicators/ParabolicSar/README.md
+++ b/Indicators/ParabolicSar/README.md
@@ -32,6 +32,7 @@ The first period will have `null` values since there's not enough data to calcul
 | -- |-- |--
 | `Date` | DateTime | Date
 | `Sar` | decimal | Stop and Reverse value
+| `IsReversal` | bool | Indicates a trend reversal
 
 ## Example
 

--- a/IndicatorsTests/Test.ParabolicSar.cs
+++ b/IndicatorsTests/Test.ParabolicSar.cs
@@ -28,6 +28,7 @@ namespace StockIndicators.Tests
             // sample value
             ParabolicSarResult r = results.Where(x => x.Index == 502).FirstOrDefault();
             Assert.AreEqual(229.7662m, Math.Round((decimal)r.Sar, 4));
+            Assert.AreEqual(false, r.IsReversal);
         }
 
 


### PR DESCRIPTION
I'm adding back the IsReversal flag on the PSAR indicator.  I believe this to be a fundamental element of the indicator.  It is called "stop and reverse", so makes sense to indicate the reversal.

I'm trying not to backslide on the goal of avoiding unneeded flourishes and analysis (#99); however, I'm comfortable with this addition as it's not really an analysis; rather, it is a core part of the indicator.