### PR TITLE
refactor: for MACD performance

### DIFF
--- a/Indicators/Ema/Ema.cs
+++ b/Indicators/Ema/Ema.cs
@@ -33,7 +33,7 @@ namespace Skender.Stock.Indicators
             // initialize EMA
             decimal k = 2 / (decimal)(lookbackPeriod + 1);
             decimal lastEma = basicData
-                .Where(x => x.Index < lookbackPeriod)
+                .Where(x => x.Index <= lookbackPeriod)
                 .ToList()
                 .Select(x => x.Value)
                 .Average();
@@ -48,10 +48,14 @@ namespace Skender.Stock.Indicators
                     Date = h.Date
                 };
 
-                if (h.Index >= lookbackPeriod)
+                if (h.Index > lookbackPeriod)
                 {
                     result.Ema = lastEma + k * (h.Value - lastEma);
                     lastEma = (decimal)result.Ema;
+                }
+                else if (h.Index == lookbackPeriod)
+                {
+                    result.Ema = lastEma;
                 }
 
                 results.Add(result);

--- a/Indicators/Macd/Macd.cs
+++ b/Indicators/Macd/Macd.cs
@@ -24,8 +24,8 @@ namespace Skender.Stock.Indicators
 
             foreach (Quote h in history)
             {
-                EmaResult df = emaFast.Where(x => x.Date == h.Date).FirstOrDefault();
-                EmaResult ds = emaSlow.Where(x => x.Date == h.Date).FirstOrDefault();
+                EmaResult df = emaFast.Where(x => x.Index == h.Index).FirstOrDefault();
+                EmaResult ds = emaSlow.Where(x => x.Index == h.Index).FirstOrDefault();
 
                 MacdResult result = new MacdResult
                 {
@@ -42,8 +42,8 @@ namespace Skender.Stock.Indicators
                     // temp data for interim EMA of macd
                     BasicData diff = new BasicData
                     {
+                        Index = h.Index - slowPeriod + 1,
                         Date = h.Date,
-                        Index = h.Index - slowPeriod,
                         Value = macd
                     };
 
@@ -58,7 +58,9 @@ namespace Skender.Stock.Indicators
             // add signal, histogram to result
             foreach (MacdResult r in results)
             {
-                EmaResult ds = emaSignal.Where(x => x.Date == r.Date).FirstOrDefault();
+                EmaResult ds = emaSignal
+                    .Where(x => x.Index == r.Index - slowPeriod + 1)
+                    .FirstOrDefault();
 
                 if (ds?.Ema == null)
                 {

--- a/Indicators/Macd/Macd.cs
+++ b/Indicators/Macd/Macd.cs
@@ -10,22 +10,24 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            Cleaners.PrepareHistory(history);
+            history = Cleaners.PrepareHistory(history);
 
             // check parameters
             ValidateMacd(history, fastPeriod, slowPeriod, signalPeriod);
 
             // initialize
-            IEnumerable<EmaResult> emaFast = GetEma(history, fastPeriod);
-            IEnumerable<EmaResult> emaSlow = GetEma(history, slowPeriod);
+            List<Quote> historyList = history.ToList();
+            List<EmaResult> emaFast = GetEma(history, fastPeriod).ToList();
+            List<EmaResult> emaSlow = GetEma(history, slowPeriod).ToList();
 
             List<BasicData> emaDiff = new List<BasicData>();
             List<MacdResult> results = new List<MacdResult>();
 
-            foreach (Quote h in history)
+            for (int i = 0; i < historyList.Count; i++)
             {
-                EmaResult df = emaFast.Where(x => x.Index == h.Index).FirstOrDefault();
-                EmaResult ds = emaSlow.Where(x => x.Index == h.Index).FirstOrDefault();
+                Quote h = historyList[i];
+                EmaResult df = emaFast[i];
+                EmaResult ds = emaSlow[i];
 
                 MacdResult result = new MacdResult
                 {
@@ -53,19 +55,12 @@ namespace Skender.Stock.Indicators
                 results.Add(result);
             }
 
-            IEnumerable<EmaResult> emaSignal = CalcEma(emaDiff, signalPeriod);
+            // add signal and histogram to result
+            List<EmaResult> emaSignal = CalcEma(emaDiff, signalPeriod).ToList();
 
-            // add signal, histogram to result
-            foreach (MacdResult r in results)
+            foreach (MacdResult r in results.Where(x => x.Index >= slowPeriod))
             {
-                EmaResult ds = emaSignal
-                    .Where(x => x.Index == r.Index - slowPeriod + 1)
-                    .FirstOrDefault();
-
-                if (ds?.Ema == null)
-                {
-                    continue;
-                }
+                EmaResult ds = emaSignal[r.Index - slowPeriod];
 
                 r.Signal = ds.Ema;
                 r.Histogram = r.Macd - r.Signal;

--- a/IndicatorsTests/Test.Macd.cs
+++ b/IndicatorsTests/Test.Macd.cs
@@ -24,15 +24,25 @@ namespace StockIndicators.Tests
             // proper quantities
             // should always be the same number of results as there is history
             Assert.AreEqual(502, results.Count());
-            Assert.AreEqual(502 - slowPeriod + 1, results.Where(x => x.Macd != null).Count());
-            Assert.AreEqual(502 - slowPeriod - signalPeriod + 1, results.Where(x => x.Signal != null).Count());
-            Assert.AreEqual(502 - slowPeriod - signalPeriod + 1, results.Where(x => x.Histogram != null).Count());
+            Assert.AreEqual(477, results.Where(x => x.Macd != null).Count());
+            Assert.AreEqual(469, results.Where(x => x.Signal != null).Count());
+            Assert.AreEqual(469, results.Where(x => x.Histogram != null).Count());
 
-            // sample value
-            MacdResult r = results.Where(x => x.Index == 502).FirstOrDefault();
-            Assert.AreEqual(-6.2198m, Math.Round((decimal)r.Macd, 4));
-            Assert.AreEqual(-5.8569m, Math.Round((decimal)r.Signal, 4));
-            Assert.AreEqual(-0.3629m, Math.Round((decimal)r.Histogram, 4));
+            // sample values
+            MacdResult r1 = results.Where(x => x.Index == 502).FirstOrDefault();
+            Assert.AreEqual(-6.2198m, Math.Round((decimal)r1.Macd, 4));
+            Assert.AreEqual(-5.8569m, Math.Round((decimal)r1.Signal, 4));
+            Assert.AreEqual(-0.3629m, Math.Round((decimal)r1.Histogram, 4));
+
+            MacdResult r2 = results.Where(x => x.Index == 50).FirstOrDefault();
+            Assert.AreEqual(1.7203m, Math.Round((decimal)r2.Macd, 4));
+            Assert.AreEqual(1.9675m, Math.Round((decimal)r2.Signal, 4));
+            Assert.AreEqual(-0.2472m, Math.Round((decimal)r2.Histogram, 4));
+
+            MacdResult r3 = results.Where(x => x.Index == 250).FirstOrDefault();
+            Assert.AreEqual(2.2353m, Math.Round((decimal)r3.Macd, 4));
+            Assert.AreEqual(2.3141m, Math.Round((decimal)r3.Signal, 4));
+            Assert.AreEqual(-0.0789m, Math.Round((decimal)r3.Histogram, 4));
         }
 
 

--- a/PerformanceBenchmarks/Program.cs
+++ b/PerformanceBenchmarks/Program.cs
@@ -19,192 +19,205 @@ namespace PerformanceBenchmarks
     [MarkdownExporterAttribute.GitHub]
     public class Marks
     {
-        private readonly IEnumerable<Quote> h = History.GetHistory();
+        private readonly IEnumerable<Quote> hm = History.GetHistory();
+        private readonly IEnumerable<Quote> ho = History.GetHistoryOther();
 
         [Benchmark]
         public void GetAdl()
         {
-            Indicator.GetAdl(h);
+            Indicator.GetAdl(hm);
         }
 
         [Benchmark]
         public void GetAroon()
         {
-            Indicator.GetAroon(h);
+            Indicator.GetAroon(hm);
         }
 
         [Benchmark]
         public void GetAdx()
         {
-            Indicator.GetAdx(h);
+            Indicator.GetAdx(hm);
         }
 
         [Benchmark]
         public void GetAtr()
         {
-            Indicator.GetAtr(h);
+            Indicator.GetAtr(hm);
+        }
+
+        [Benchmark]
+        public void GetBeta()
+        {
+            Indicator.GetBeta(hm, ho, 30);
         }
 
         [Benchmark]
         public void GetBollingerBands()
         {
-            Indicator.GetBollingerBands(h);
+            Indicator.GetBollingerBands(hm);
         }
 
         [Benchmark]
         public void GetCci()
         {
-            Indicator.GetCci(h);
+            Indicator.GetCci(hm);
         }
 
         [Benchmark]
         public void GetCmf()
         {
-            Indicator.GetCmf(h);
+            Indicator.GetCmf(hm);
         }
 
         [Benchmark]
         public void GetChaikinOsc()
         {
-            Indicator.GetChaikinOsc(h);
+            Indicator.GetChaikinOsc(hm);
         }
 
         [Benchmark]
         public void GetChandelier()
         {
-            Indicator.GetChandelier(h);
+            Indicator.GetChandelier(hm);
         }
 
         [Benchmark]
         public void GetConnorsRsi()
         {
-            Indicator.GetConnorsRsi(h);
+            Indicator.GetConnorsRsi(hm);
+        }
+
+        [Benchmark]
+        public void GetCorrelation()
+        {
+            Indicator.GetCorrelation(hm, ho, 30);
         }
 
         [Benchmark]
         public void GetDonchian()
         {
-            Indicator.GetDonchian(h);
+            Indicator.GetDonchian(hm);
         }
 
         [Benchmark]
         public void GetEma()
         {
-            Indicator.GetEma(h, 14);
+            Indicator.GetEma(hm, 14);
         }
 
         [Benchmark]
         public void GetHeikinAshi()
         {
-            Indicator.GetHeikinAshi(h);
+            Indicator.GetHeikinAshi(hm);
         }
 
         [Benchmark]
         public void GetHma()
         {
-            Indicator.GetHma(h, 14);
+            Indicator.GetHma(hm, 14);
         }
 
         [Benchmark]
         public void GetIchimoku()
         {
-            Indicator.GetIchimoku(h);
+            Indicator.GetIchimoku(hm);
         }
 
         [Benchmark]
         public void GetKeltner()
         {
-            Indicator.GetKeltner(h);
+            Indicator.GetKeltner(hm);
         }
 
         [Benchmark]
         public void GetMacd()
         {
-            Indicator.GetMacd(h);
+            Indicator.GetMacd(hm);
         }
 
         [Benchmark]
         public void GetMfi()
         {
-            Indicator.GetMfi(h);
+            Indicator.GetMfi(hm);
         }
 
         [Benchmark]
         public void GetObv()
         {
-            Indicator.GetObv(h);
+            Indicator.GetObv(hm);
         }
 
         [Benchmark]
         public void GetParabolicSar()
         {
-            Indicator.GetParabolicSar(h);
+            Indicator.GetParabolicSar(hm);
         }
 
         [Benchmark]
         public void GetPmo()
         {
-            Indicator.GetPmo(h);
+            Indicator.GetPmo(hm);
         }
 
         [Benchmark]
         public void GetRoc()
         {
-            Indicator.GetRoc(h, 20);
+            Indicator.GetRoc(hm, 20);
         }
 
         [Benchmark]
         public void GetRsi()
         {
-            Indicator.GetRsi(h);
+            Indicator.GetRsi(hm);
         }
 
         [Benchmark]
         public void GetSma()
         {
-            Indicator.GetSma(h, 10);
+            Indicator.GetSma(hm, 10);
         }
 
         [Benchmark]
         public void GetStdDev()
         {
-            Indicator.GetStdDev(h, 20);
+            Indicator.GetStdDev(hm, 20);
         }
 
         [Benchmark]
         public void GetStoch()
         {
-            Indicator.GetStoch(h);
+            Indicator.GetStoch(hm);
         }
 
         [Benchmark]
         public void GetStochRsi()
         {
-            Indicator.GetStochRsi(h, 14, 14, 3);
+            Indicator.GetStochRsi(hm, 14, 14, 3);
         }
 
         [Benchmark]
         public void GetUlcerIndex()
         {
-            Indicator.GetUlcerIndex(h);
+            Indicator.GetUlcerIndex(hm);
         }
 
         [Benchmark]
         public void GetWilliamR()
         {
-            Indicator.GetWilliamR(h);
+            Indicator.GetWilliamR(hm);
         }
 
         [Benchmark]
         public void GetWma()
         {
-            Indicator.GetWma(h, 30);
+            Indicator.GetWma(hm, 30);
         }
 
         [Benchmark]
         public void GetZigZag()
         {
-            Indicator.GetZigZag(h);
+            Indicator.GetZigZag(hm);
         }
     }
 }

--- a/PerformanceBenchmarks/README.md
+++ b/PerformanceBenchmarks/README.md
@@ -1,47 +1,48 @@
 # Performance benchmarks
 
-## for v0.10.6 (internal release)
+## for v0.10.7
 
-As a baseline, here is the starting point on the performance of the current indicators **using two years of historical daily stock quotes** (e.g. 502 periods) with default or typical parameters.  I believe the performance to be correlated with `history` length, so you can extrapolate based how much you use.
+These are the execution time for the current indicators **using two years of historical daily stock quotes** (e.g. 502 periods) with default or typical parameters.
 
-``` ini
-BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.450 (2004/?/20H1)
+``` bash
+BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.508 (2004/?/20H1)
 Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
-.NET Core SDK=3.1.401
-  [Host]     : .NET Core 3.1.7 (CoreCLR 4.700.20.36602, CoreFX 4.700.20.37001), X64 RyuJIT
-  DefaultJob : .NET Core 3.1.7 (CoreCLR 4.700.20.36602, CoreFX 4.700.20.37001), X64 RyuJIT
+.NET Core SDK=3.1.402
+  [Host]     : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT
+  DefaultJob : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT
 ```
-
 |            Method |        Mean |       Error |      StdDev |
 |------------------ |------------:|------------:|------------:|
-|            GetAdl |    335.2 μs |     3.92 μs |     3.27 μs |
-|          GetAroon | 24,933.9 μs |   363.25 μs |   303.33 μs |
-|            GetAdx |  2,311.2 μs |    42.90 μs |    35.83 μs |
-|            GetAtr |    380.2 μs |     7.38 μs |     9.59 μs |
-| GetBollingerBands | 23,738.6 μs |   310.69 μs |   290.62 μs |
-|            GetCci |  2,587.7 μs |    27.05 μs |    23.98 μs |
-|            GetCmf |  1,987.9 μs |    21.33 μs |    19.95 μs |
-|     GetChaikinOsc |  2,701.4 μs |    11.66 μs |    10.91 μs |
-|     GetChandelier | 26,071.7 μs |   153.06 μs |   135.68 μs |
-|     GetConnorsRsi |  5,362.2 μs |    47.29 μs |    39.49 μs |
-|       GetDonchian | 25,198.0 μs |   144.92 μs |   135.55 μs |
-|            GetEma |    387.5 μs |     2.85 μs |     2.53 μs |
-|     GetHeikinAshi |    374.2 μs |     3.81 μs |     3.38 μs |
-|            GetHma | 60,646.3 μs | 1,209.50 μs | 2,359.03 μs |
-|       GetIchimoku | 99,853.4 μs | 2,407.53 μs | 6,750.96 μs |
-|        GetKeltner |  3,105.3 μs |    18.69 μs |    16.57 μs |
-|           GetMacd |  3,584.8 μs |    67.56 μs |    63.20 μs |
-|            GetMfi |  8,464.6 μs |   125.72 μs |   117.60 μs |
-|            GetObv |    235.0 μs |     2.70 μs |     2.53 μs |
-|   GetParabolicSar | 22,322.4 μs |   184.00 μs |   143.66 μs |
-|            GetPmo | 24,433.4 μs |   245.61 μs |   229.74 μs |
-|            GetRoc | 21,636.6 μs |   145.37 μs |   128.87 μs |
-|            GetRsi |    682.6 μs |     9.08 μs |     8.49 μs |
-|            GetSma | 26,592.6 μs |   290.79 μs |   257.78 μs |
-|         GetStdDev |  2,147.0 μs |    29.63 μs |    26.26 μs |
-|          GetStoch | 26,191.8 μs |   184.06 μs |   163.17 μs |
-|       GetStochRsi |  4,671.5 μs |    31.04 μs |    27.51 μs |
-|     GetUlcerIndex | 28,494.0 μs |   442.06 μs |   391.87 μs |
-|       GetWilliamR | 25,799.3 μs |   281.23 μs |   219.56 μs |
-|            GetWma | 26,955.1 μs |   182.45 μs |   161.74 μs |
-|         GetZigZag |  1,599.9 μs |    31.77 μs |    69.74 μs |
+|            GetAdl |    330.6 μs |     4.37 μs |     4.09 μs |
+|          GetAroon | 25,331.6 μs |   131.59 μs |   109.88 μs |
+|            GetAdx |  2,221.6 μs |    26.82 μs |    25.09 μs |
+|            GetAtr |    365.5 μs |     4.89 μs |     4.58 μs |
+|           GetBeta |  6,004.8 μs |    58.12 μs |    54.36 μs |
+| GetBollingerBands | 23,928.9 μs |   301.26 μs |   281.80 μs |
+|            GetCci |  2,421.4 μs |    19.66 μs |    18.39 μs |
+|            GetCmf |  1,997.0 μs |    30.86 μs |    27.35 μs |
+|     GetChaikinOsc |  2,687.7 μs |    51.92 μs |    59.79 μs |
+|     GetChandelier | 26,586.2 μs |   279.97 μs |   261.88 μs |
+|     GetConnorsRsi |  5,249.0 μs |    54.26 μs |    50.75 μs |
+|    GetCorrelation |  4,803.9 μs |    55.58 μs |    51.99 μs |
+|       GetDonchian | 24,625.0 μs |   301.55 μs |   282.07 μs |
+|            GetEma |    386.8 μs |     3.80 μs |     3.56 μs |
+|     GetHeikinAshi |    376.9 μs |     5.77 μs |     5.12 μs |
+|            GetHma | 55,590.3 μs |   642.85 μs |   501.90 μs |
+|       GetIchimoku | 93,090.7 μs | 1,177.02 μs | 1,043.40 μs |
+|        GetKeltner |  3,190.5 μs |    34.21 μs |    32.00 μs |
+|           GetMacd |    621.0 μs |     6.02 μs |     5.63 μs |
+|            GetMfi |  9,389.9 μs |    56.31 μs |    49.92 μs |
+|            GetObv |    252.6 μs |     5.02 μs |     9.54 μs |
+|   GetParabolicSar | 32,957.5 μs | 1,329.52 μs | 3,920.11 μs |
+|            GetPmo | 38,080.1 μs |   748.88 μs | 1,460.64 μs |
+|            GetRoc | 32,278.3 μs |   630.76 μs |   647.74 μs |
+|            GetRsi |    945.4 μs |    15.41 μs |    13.66 μs |
+|            GetSma | 40,899.6 μs |   812.66 μs | 2,097.74 μs |
+|         GetStdDev |  3,417.5 μs |    64.90 μs |   115.36 μs |
+|          GetStoch | 42,766.5 μs |   835.11 μs | 1,462.63 μs |
+|       GetStochRsi |  7,986.5 μs |   152.54 μs |   350.48 μs |
+|     GetUlcerIndex | 43,950.7 μs |   863.87 μs | 1,622.55 μs |
+|       GetWilliamR | 42,279.5 μs |   829.55 μs | 1,049.11 μs |
+|            GetWma | 42,921.2 μs |   812.04 μs |   868.88 μs |
+|         GetZigZag |  2,430.3 μs |    48.48 μs |    63.03 μs |


### PR DESCRIPTION
- moving certain operations to array lookups to improve speed from 3.6ms to 621us.
- added more sampling to unit tests

[MACD-ManualCalc.xlsx](https://github.com/DaveSkender/Stock.Indicators/files/5192467/MACD-ManualCalc.xlsx)
