### PR TITLE
refactor: for PSAR performance

### DIFF
--- a/Indicators/ParabolicSar/README.md
+++ b/Indicators/ParabolicSar/README.md
@@ -16,7 +16,7 @@ IEnumerable<ParabolicSarResult> results = Indicator.GetParabolicSar(history, acc
 | `accelerationStep` | decimal | Incremental step size.  Must be greater than 0.  Default is 0.02
 | `maxAccelerationFactor` | decimal | Maximimum step limit.  Must be greater than 0 and larger than `accelerationStep`.  Default is 0.2
 
-NOTE: Initial Parabolic SAR values before the first reversal are not accurate.
+NOTE: Initial Parabolic SAR values before the first reversal are not accurate and is excluded from the results.
 
 ## Response
 
@@ -24,7 +24,7 @@ NOTE: Initial Parabolic SAR values before the first reversal are not accurate.
 IEnumerable<ParabolicSarResult>
 ```
 
-The first period will have `null` values since there's not enough data to calculate.  We always return the same number of elements as there are in the historical quotes.
+The first trend will have `null` values since it is not accurate and based on an initial guess.  We always return the same number of elements as there are in the historical quotes.
 
 ### ParabolicSarResult
 

--- a/IndicatorsTests/Test.ParabolicSar.cs
+++ b/IndicatorsTests/Test.ParabolicSar.cs
@@ -23,12 +23,20 @@ namespace StockIndicators.Tests
             // proper quantities
             // should always be the same number of results as there is history
             Assert.AreEqual(502, results.Count());
-            Assert.AreEqual(501, results.Where(x => x.Sar != null).Count());
+            Assert.AreEqual(488, results.Where(x => x.Sar != null).Count());
 
-            // sample value
-            ParabolicSarResult r = results.Where(x => x.Index == 502).FirstOrDefault();
-            Assert.AreEqual(229.7662m, Math.Round((decimal)r.Sar, 4));
-            Assert.AreEqual(false, r.IsReversal);
+            // sample values
+            ParabolicSarResult r1 = results.Where(x => x.Index == 15).FirstOrDefault();
+            Assert.AreEqual(212.83m, Math.Round((decimal)r1.Sar, 4));
+            Assert.AreEqual(true, r1.IsReversal);
+
+            ParabolicSarResult r2 = results.Where(x => x.Index == 17).FirstOrDefault();
+            Assert.AreEqual(212.9924m, Math.Round((decimal)r2.Sar, 4));
+            Assert.AreEqual(false, r2.IsReversal);
+
+            ParabolicSarResult r3 = results.Where(x => x.Index == 502).FirstOrDefault();
+            Assert.AreEqual(229.7662m, Math.Round((decimal)r3.Sar, 4));
+            Assert.AreEqual(false, r3.IsReversal);
         }
 
 

--- a/PerformanceBenchmarks/README.md
+++ b/PerformanceBenchmarks/README.md
@@ -2,7 +2,7 @@
 
 ## for v0.10.7
 
-These are the execution time for the current indicators **using two years of historical daily stock quotes** (e.g. 502 periods) with default or typical parameters.
+These are the execution times for the current indicators using two years of historical daily stock quotes (502 periods) with default or typical parameters.
 
 ``` bash
 BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.508 (2004/?/20H1)
@@ -34,7 +34,7 @@ Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical co
 |           GetMacd |    621.0 μs |     6.02 μs |     5.63 μs |
 |            GetMfi |  9,389.9 μs |    56.31 μs |    49.92 μs |
 |            GetObv |    252.6 μs |     5.02 μs |     9.54 μs |
-|   GetParabolicSar | 32,957.5 μs | 1,329.52 μs | 3,920.11 μs |
+|   GetParabolicSar |    299.8 μs |      TBD μs |      TBD μs |
 |            GetPmo | 38,080.1 μs |   748.88 μs | 1,460.64 μs |
 |            GetRoc | 32,278.3 μs |   630.76 μs |   647.74 μs |
 |            GetRsi |    945.4 μs |    15.41 μs |    13.66 μs |


### PR DESCRIPTION
- moving certain operations to array lookups to improve speed from 33ms to 300us.
- added more sampling to unit tests
- removed the first trend period since it's invalid
(#114)