### PR TITLE
remove protection on UI property

### DIFF
--- a/indicators/UlcerIndex/Ulcer.Models.cs
+++ b/indicators/UlcerIndex/Ulcer.Models.cs
@@ -5,6 +5,6 @@ namespace Skender.Stock.Indicators
     [Serializable]
     public class UlcerIndexResult : ResultBase
     {
-        public decimal? UI { get; internal set; }
+        public decimal? UI { get; set; }
     }
 }


### PR DESCRIPTION
`UI` property on `UlcerIndexResult` should not be protected to support derived classes.