### PR TITLE
check first Index value

### DIFF
--- a/indicators/_Common/Cleaners.cs
+++ b/indicators/_Common/Cleaners.cs
@@ -49,6 +49,24 @@ namespace Skender.Stock.Indicators
         }
 
 
+        public static IEnumerable<Quote> RemoveIndex(this IEnumerable<Quote> history)
+        {
+            // validate
+            if (history == null)
+            {
+                return history;
+            }
+
+            // reset the internal index
+            foreach (Quote h in history)
+            {
+                h.Index = null;
+            }
+
+            return history;
+        }
+
+
         internal static List<BasicData> PrepareBasicData(IEnumerable<BasicData> basicData)
         {
             // we cannot rely on date consistency when looking back, so we add an index and sort

--- a/indicators/_Common/Cleaners.cs
+++ b/indicators/_Common/Cleaners.cs
@@ -61,7 +61,7 @@ namespace Skender.Stock.Indicators
             }
 
             // return if already processed (no missing indexes)
-            if (!bdList.Any(x => x.Index == null))
+            if (!bdList.Any(x => x.Index == null) && bdList[0].Index == 1)
             {
                 return bdList;
             }

--- a/indicators/_Common/Cleaners.cs
+++ b/indicators/_Common/Cleaners.cs
@@ -24,7 +24,7 @@ namespace Skender.Stock.Indicators
             }
 
             // return if already processed (no missing indexes)
-            if (!historyList.Any(x => x.Index == null))
+            if (!historyList.Any(x => x.Index == null) && historyList[0] == 1)
             {
                 return historyList;
             }

--- a/indicators/_Common/Cleaners.cs
+++ b/indicators/_Common/Cleaners.cs
@@ -24,7 +24,7 @@ namespace Skender.Stock.Indicators
             }
 
             // return if already processed (no missing indexes)
-            if (!historyList.Any(x => x.Index == null) && historyList[0] == 1)
+            if (!historyList.Any(x => x.Index == null) && historyList[0].Index == 1)
             {
                 return historyList;
             }

--- a/tests/indicators/common/Test.Cleaner.cs
+++ b/tests/indicators/common/Test.Cleaner.cs
@@ -67,6 +67,55 @@ namespace Internal.Tests
 
 
         [TestMethod()]
+        public void CutHistoryTest()
+        {
+            // if history post-cleaning, is cut down in size it should not corrupt the results
+
+            int i = 0;
+            IEnumerable<Quote> history = History.GetHistory(200);
+            IEnumerable<Quote> h = Cleaners.PrepareHistory(history);
+
+            // assertions
+
+            // should be 200 periods, initially
+            Assert.AreEqual(200, h.Count());
+
+            // should always have index
+            Assert.IsFalse(h.Where(x => x.Index == null || x.Index <= 0).Any());
+
+
+            // should be 20 results and no index corruption
+            IEnumerable<RsiResult> r1 = Indicator.GetRsi(h.TakeLast(20), 14);
+            Assert.AreEqual(20, r1.Count());
+
+            i = 1;
+            foreach (RsiResult x in r1)
+            {
+                Assert.AreEqual(i++, x.Index);
+            }
+
+            // should be 50 results and no index corruption
+            IEnumerable<RsiResult> r2 = Indicator.GetRsi(h.TakeLast(50), 14);
+            Assert.AreEqual(50, r2.Count());
+
+            i = 1;
+            foreach (RsiResult x in r2)
+            {
+                Assert.AreEqual(i++, x.Index);
+            }
+
+            // should be original 200 periods and no index corruption, after temp mods
+            Assert.AreEqual(200, h.Count());
+
+            i = 1;
+            foreach(Quote x in h)
+            {
+                Assert.AreEqual(i++, x.Index);
+            }
+        }
+
+
+        [TestMethod()]
         public void CleanBasicDataTest()
         {
             // compose basic data

--- a/tests/indicators/common/Test.Cleaner.cs
+++ b/tests/indicators/common/Test.Cleaner.cs
@@ -30,11 +30,18 @@ namespace Internal.Tests
             Assert.IsFalse(h.Where(x => x.Index == null || x.Index <= 0).Any());
 
             // last index should be 502
-            Quote r = newHistory
+            Quote r1 = h
                 .Where(x => x.Date == DateTime.ParseExact("12/31/2018", "MM/dd/yyyy", englishCulture))
                 .FirstOrDefault();
 
-            Assert.AreEqual(502, r.Index);
+            Assert.AreEqual(502, r1.Index);
+
+            // spot check an out of sequence date
+            Quote r2 = h
+                .Where(x => x.Date == DateTime.ParseExact("02/01/2017", "MM/dd/yyyy", englishCulture))
+                .FirstOrDefault();
+
+            Assert.AreEqual(21, r2.Index);
 
             // ensure expected List address
             List<Quote> historyList = h.ToList();
@@ -112,6 +119,29 @@ namespace Internal.Tests
             {
                 Assert.AreEqual(i++, x.Index);
             }
+        }
+
+
+        [TestMethod()]
+        public void ResetHistoryTest()
+        {
+            // if history post-cleaning, is cut down in size it should not corrupt the results
+
+            IEnumerable<Quote> history = History.GetHistory(200);
+            IEnumerable<Quote> h = Cleaners.PrepareHistory(history);
+
+            // assertions
+
+            // should be 200 periods, initially
+            Assert.AreEqual(200, h.Count());
+
+            // should always have index
+            Assert.IsFalse(h.Where(x => x.Index == null || x.Index <= 0).Any());
+
+            h.RemoveIndex();
+
+            // should not have index after reset
+            Assert.IsFalse(h.Where(x => x.Index != null).Any());
         }
 
 


### PR DESCRIPTION
Fix for reported bug #170.  A library internal error occurs when a user modifies `history` length after it was previously used or cleaned.  The fix allows the internal cleaner to recompose an internal Index if it detects a bad starting value, which can occur if you decide to reuse and cut down `history` with methods such as `TakeLast`.

I'm also adding an *undocumented* `history.RemoveIndex()` extension that will allow a user to remove the internal index from a previously utilized or cleaned `history`.  With this fix, you would not need this extension; however, I'm adding it in case there are unidentified reasons for a user to need to remove the internal indexing.