### PR TITLE
add .NET 5.0 framework targeting

### DIFF
--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -13,9 +13,9 @@ variables:
 
 steps:
   - task: UseDotNet@2
-    displayName: 'use .Net Core SDK 3.1.x'
+    displayName: 'use .Net Core SDK 5.0.x'
     inputs:
-      version: 3.1.x
+      version: 5.0.x
 
   - task: DotNetCoreCLI@2
     displayName: 'use GitVersion'

--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -13,7 +13,7 @@ variables:
 
 steps:
   - task: UseDotNet@2
-    displayName: 'use .Net Core SDK 5.0.x'
+    displayName: 'use .Net SDK 5.0.x'
     inputs:
       version: 5.0.x
 

--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -6,71 +6,76 @@ pr:
 
 pool:
   name: Azure Pipelines
-  vmImage: 'windows-2019'
+  vmImage: "windows-2019"
 
 variables:
-  BuildConfiguration: 'Release'
+  BuildConfiguration: "Release"
 
 steps:
   - task: UseDotNet@2
-    displayName: 'use .Net SDK 5.0.x'
+    displayName: "use .Net SDK 3.1.x"
+    inputs:
+      version: 3.1.x
+
+  - task: DotNetCoreCLI@2
+    displayName: "use GitVersion"
+    inputs:
+      command: custom
+      custom: tool
+      arguments: "install -g gitversion.tool --version 5.5.0"
+
+  - task: DotNetCoreCLI@2
+    displayName: "run GitVersion"
+    inputs:
+      command: custom
+      custom: gitversion
+      arguments: "/output buildserver"
+
+  - task: UseDotNet@2
+    displayName: "use .Net SDK 5.0.x"
     inputs:
       version: 5.0.x
 
   - task: DotNetCoreCLI@2
-    displayName: 'use GitVersion'
-    inputs:
-      command: custom
-      custom: tool
-      arguments: 'install -g gitversion.tool --version 5.5.0'
-
-  - task: DotNetCoreCLI@2
-    displayName: 'run GitVersion'
-    inputs:
-      command: custom
-      custom: gitversion
-      arguments: '/output buildserver'
-
-  - task: DotNetCoreCLI@2
     displayName: build
     inputs:
-      projects: '**/*.csproj'
-      arguments: '--disable-parallel --configuration $(BuildConfiguration) /p:Version=$(GitVersion.NuGetVersion)'
+      projects: "**/*.csproj"
+      arguments: "--disable-parallel --configuration $(BuildConfiguration) /p:Version=$(GitVersion.NuGetVersion)"
 
   - task: DotNetCoreCLI@2
-    displayName: 'test internal'
+    displayName: "test internal"
     inputs:
       command: test
-      projects: '**/Tests.Indicators.csproj'
-      arguments: '--configuration $(BuildConfiguration) --no-restore --no-build /p:Version=$(GitVersion.NuGetVersion) /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura'
-      testRunTitle: 'Library Internal Tests'
+      projects: "**/Tests.Indicators.csproj"
+      arguments: "--configuration $(BuildConfiguration) --no-restore --no-build /p:Version=$(GitVersion.NuGetVersion) /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura"
+      testRunTitle: "Library Internal Tests"
 
   - task: DotNetCoreCLI@2
-    displayName: 'test external'
+    displayName: "test external"
     inputs:
       command: test
-      projects: '**/Tests.External.csproj'
-      arguments: '--configuration $(BuildConfiguration) --no-restore --no-build  /p:Version=$(GitVersion.NuGetVersion) /p:CollectCoverage=false'
+      projects: "**/Tests.External.csproj"
+      arguments: "--configuration $(BuildConfiguration) --no-restore --no-build  /p:Version=$(GitVersion.NuGetVersion) /p:CollectCoverage=false"
       publishTestResults: false
-      testRunTitle: 'Library External Tests'
+      testRunTitle: "Library External Tests"
 
   - task: Palmmedia.reportgenerator.reportgenerator-build-release-task.reportgenerator@4
-    displayName: 'format code coverage'
+    displayName: "format code coverage"
     inputs:
-      reports: '**/coverage.cobertura.xml'
-      targetdir: '$(Build.ArtifactStagingDirectory)/TestResults'
-      reporttypes: 'HtmlInline_AzurePipelines;Cobertura;Badges'
-      title: 'Stock.Indicators Library Tests'
+      reports: "**/coverage.cobertura.xml"
+      targetdir: "$(Build.ArtifactStagingDirectory)/TestResults"
+      reporttypes: "HtmlInline_AzurePipelines;Cobertura;Badges"
+      title: "Stock.Indicators Library Tests"
 
   - task: PublishCodeCoverageResults@1
-    displayName: 'publish code coverage'
+    displayName: "publish code coverage"
     inputs:
       codeCoverageTool: Cobertura
-      summaryFileLocation: '$(Build.ArtifactStagingDirectory)/TestResults/cobertura.xml'
-      reportDirectory: '$(Build.ArtifactStagingDirectory)/TestResults'
+      summaryFileLocation: "$(Build.ArtifactStagingDirectory)/TestResults/cobertura.xml"
+      reportDirectory: "$(Build.ArtifactStagingDirectory)/TestResults"
 
   - task: DotNetCoreCLI@2
-    displayName: 'pack for NuGet'
+    displayName: "pack for NuGet"
     inputs:
       command: pack
       packagesToPack: indicators/Indicators.csproj
@@ -78,16 +83,16 @@ steps:
       versionEnvVar: GitVersion.NuGetVersion
 
   - task: CopyFiles@2
-    displayName: 'stage artifacts'
+    displayName: "stage artifacts"
     inputs:
-      SourceFolder: 'indicators'
-      Contents: '**/*.nupkg'
-      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+      SourceFolder: "indicators"
+      Contents: "**/*.nupkg"
+      TargetFolder: "$(Build.ArtifactStagingDirectory)"
       CleanTargetFolder: true
       OverWrite: true
       flattenFolders: true
 
   - task: PublishBuildArtifacts@1
-    displayName: 'save artifacts'
+    displayName: "save artifacts"
     inputs:
       ArtifactName: packages

--- a/.github/build.performance.yml
+++ b/.github/build.performance.yml
@@ -12,9 +12,9 @@ jobs:
     vmImage: 'windows-2019'
   steps:
   - task: UseDotNet@2
-    displayName: 'use .Net Core SDK 3.1.x'
+    displayName: 'use .Net Core SDK 5.0.x'
     inputs:
-      version: 3.1.x
+      version: 5.0.x
 
   - task: DotNetCoreCLI@2
     displayName: 'use GitVersion'

--- a/.github/build.performance.yml
+++ b/.github/build.performance.yml
@@ -1,58 +1,65 @@
 trigger:
   - master
-  
+
 # no PR triggers
 pr: none
 
 jobs:
-- job: PerformanceBenchmarks
-  timeoutInMinutes: 100
-  pool:
-    name: Azure Pipelines
-    vmImage: 'windows-2019'
-  steps:
-  - task: UseDotNet@2
-    displayName: 'use .Net SDK 5.0.x'
-    inputs:
-      version: 5.0.x
+  - job: PerformanceBenchmarks
+    timeoutInMinutes: 100
 
-  - task: DotNetCoreCLI@2
-    displayName: 'use GitVersion'
-    inputs:
-      command: custom
-      custom: tool
-      arguments: 'install -g gitversion.tool --version 5.5.0'
+    pool:
+      name: Azure Pipelines
+      vmImage: "windows-2019"
 
-  - task: DotNetCoreCLI@2
-    displayName: 'run GitVersion'
-    inputs:
-      command: custom
-      custom: gitversion
-      arguments: '/output buildserver'
+    steps:
+      - task: UseDotNet@2
+        displayName: "use .Net SDK 3.1.x"
+        inputs:
+          version: 3.1.x
 
-  - task: DotNetCoreCLI@2
-    displayName: build
-    inputs:
-      projects: '**/Tests.Performance.csproj'
-      arguments: '--configuration Release /p:Version=$(GitVersion.NuGetVersion)'
+      - task: DotNetCoreCLI@2
+        displayName: "use GitVersion"
+        inputs:
+          command: custom
+          custom: tool
+          arguments: "install -g gitversion.tool --version 5.5.0"
 
-  - task: DotNetCoreCLI@2
-    displayName: 'run benchmarks'
-    inputs:
-      command: run
-      projects: '**/Tests.Performance.csproj'
-      arguments: '--configuration Release --no-restore --no-build'
+      - task: DotNetCoreCLI@2
+        displayName: "run GitVersion"
+        inputs:
+          command: custom
+          custom: gitversion
+          arguments: "/output buildserver"
 
-  - task: CopyFiles@2
-    displayName: 'stage artifacts'
-    inputs:
-      SourceFolder: 'BenchmarkDotNet.Artifacts\results'
-      Contents: '**'
-      TargetFolder: '$(Build.ArtifactStagingDirectory)'
-      CleanTargetFolder: true
-      OverWrite: true
+      - task: UseDotNet@2
+        displayName: "use .Net SDK 5.0.x"
+        inputs:
+          version: 5.0.x
 
-  - task: PublishBuildArtifacts@1
-    displayName: 'save artifacts'
-    inputs:
-      ArtifactName: results
+      - task: DotNetCoreCLI@2
+        displayName: build
+        inputs:
+          projects: "**/Tests.Performance.csproj"
+          arguments: "--configuration Release /p:Version=$(GitVersion.NuGetVersion)"
+
+      - task: DotNetCoreCLI@2
+        displayName: "run benchmarks"
+        inputs:
+          command: run
+          projects: "**/Tests.Performance.csproj"
+          arguments: "--configuration Release --no-restore --no-build"
+
+      - task: CopyFiles@2
+        displayName: "stage artifacts"
+        inputs:
+          SourceFolder: 'BenchmarkDotNet.Artifacts\results'
+          Contents: "**"
+          TargetFolder: "$(Build.ArtifactStagingDirectory)"
+          CleanTargetFolder: true
+          OverWrite: true
+
+      - task: PublishBuildArtifacts@1
+        displayName: "save artifacts"
+        inputs:
+          ArtifactName: results

--- a/.github/build.performance.yml
+++ b/.github/build.performance.yml
@@ -12,7 +12,7 @@ jobs:
     vmImage: 'windows-2019'
   steps:
   - task: UseDotNet@2
-    displayName: 'use .Net Core SDK 5.0.x'
+    displayName: 'use .Net SDK 5.0.x'
     inputs:
       version: 5.0.x
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,12 +2,12 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master, ]
+    branches: [master]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [master]
   schedule:
-    - cron: '0 10 15 * *'
+    - cron: "0 10 15 * *"
 
 jobs:
   analyse:
@@ -15,50 +15,50 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - name: configure Pagefile
-      uses: al-cheb/configure-pagefile-action@v1.2
-      with:
-         minimum-size: 8GB
-         maximum-size: 32GB
-         disk-root: "D:"
+      - name: configure Pagefile
+        uses: al-cheb/configure-pagefile-action@v1.2
+        with:
+          minimum-size: 8GB
+          maximum-size: 32GB
+          disk-root: "D:"
 
-    - name: Checkout repository
-      uses: actions/checkout@v2
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          # We must fetch at least the immediate parents so that if this is
+          # a pull request then we can checkout the head.
+          fetch-depth: 2
 
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
+      # If this run was triggered by a pull request event, then checkout
+      # the head of the pull request instead of the merge commit.
+      - run: git checkout HEAD^2
+        if: ${{ github.event_name == 'pull_request' }}
 
-    # this is required for GitVersion to analyze version number
-    - name: Fetch all history for GitVersion
-      run: git fetch --prune --unshallow
+      # this is required for GitVersion to analyze version number
+      - name: Fetch all history for GitVersion
+        run: git fetch --prune --unshallow
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: csharp
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: csharp
 
-    - name: Install .Net SDK
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '5.0.x'  
-    
-    - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v0.9.2
-      with: 
-        versionSpec: '5.5.0'
+      - name: Install .Net SDK
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "5.0.x"
 
-    - name: Restore packages
-      run: dotnet restore
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v0.9.5
+        with:
+          versionSpec: "5.5.0"
 
-    - name: Build software
-      run: dotnet build --disable-parallel --configuration Release --no-restore
+      - name: Restore packages
+        run: dotnet restore
 
-    - name: Perform CodeQL analysis
-      uses: github/codeql-action/analyze@v1
+      - name: Build software
+        run: dotnet build --disable-parallel --configuration Release --no-restore
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,7 +44,7 @@ jobs:
       with:
         languages: csharp
 
-    - name: Install .NET Core SDK
+    - name: Install .Net SDK
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '5.0.x'  

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Install .NET Core SDK
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1.301'  
+        dotnet-version: '5.0.x'  
     
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v0.9.2

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ See [individual indicator pages](https://daveskender.github.io/Stock.Indicators/
 
 ## Frameworks targeted
 
+- .NET 5.0
 - .NET Core 3.1
 - .NET Standard 2.0, 2.1
 - .NET Framework 4.6.1

--- a/indicators/Indicators.csproj
+++ b/indicators/Indicators.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.0;netstandard2.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>Dave Skender</Authors>
     <Product>Stock Indicators</Product>

--- a/indicators/Indicators.csproj
+++ b/indicators/Indicators.csproj
@@ -16,13 +16,14 @@
     <AssemblyName>Skender.Stock.Indicators</AssemblyName>
     <Copyright>@2020 Dave Skender</Copyright>
     <RootNamespace>Skender.Stock.Indicators</RootNamespace>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageLicenseExpression></PackageLicenseExpression>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <PackageIcon>icon.png</PackageIcon>
     <RunAnalyzersDuringLiveAnalysis>true</RunAnalyzersDuringLiveAnalysis>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>
@@ -30,10 +31,6 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/external/Tests.External.csproj
+++ b/tests/external/Tests.External.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
         <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
         <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
         <PackageReference Include="coverlet.collector" Version="1.3.0">

--- a/tests/indicators/Tests.Indicators.csproj
+++ b/tests/indicators/Tests.Indicators.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="coverlet.collector" Version="1.3.0">

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -1,75 +1,73 @@
-# Performance benchmarks
-
-Updated for v1.0.0
+# Performance benchmarks for v1.1.0
 
 These are the execution times for the current indicators using two years of historical daily stock quotes (502 periods) with default or typical parameters.
 
 ``` bash
 BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.572 (2004/?/20H1)
 Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
-.NET Core SDK=3.1.403
-  [Host]     : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
-  DefaultJob : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
+.NET Core SDK=5.0.100
+  [Host]     : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
+  DefaultJob : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
 ```
 
 ## indicators
 
 |             Method |        Mean |     Error |    StdDev |      Median |
 |------------------- |------------:|----------:|----------:|------------:|
-|             GetAdl |   167.24 μs |  1.787 μs |  1.492 μs |   167.20 μs |
-|      GetAdlWithSma |   455.23 μs |  7.843 μs |  6.953 μs |   452.40 μs |
-|             GetAdx |   855.60 μs |  8.082 μs |  7.560 μs |   857.01 μs |
-|           GetAroon |   355.76 μs |  4.947 μs |  4.859 μs |   355.15 μs |
-|             GetAtr |   200.16 μs |  2.224 μs |  1.857 μs |   199.26 μs |
-|            GetBeta | 1,239.95 μs |  3.319 μs |  2.771 μs | 1,240.02 μs |
-|  GetBollingerBands |   524.79 μs |  3.694 μs |  3.085 μs |   524.77 μs |
-|             GetCci | 1,106.68 μs | 11.180 μs |  9.335 μs | 1,102.47 μs |
-|      GetChaikinOsc |   431.92 μs |  2.981 μs |  2.489 μs |   432.03 μs |
-|      GetChandelier |   409.24 μs |  3.950 μs |  3.298 μs |   408.91 μs |
-|             GetCmf |   733.20 μs |  8.408 μs |  7.865 μs |   730.07 μs |
-|      GetConnorsRsi | 1,652.26 μs | 18.406 μs | 17.217 μs | 1,642.92 μs |
-|     GetCorrelation | 1,094.46 μs |  2.129 μs |  1.887 μs | 1,094.06 μs |
-|        GetDonchian |   347.98 μs |  3.658 μs |  3.242 μs |   346.65 μs |
-|       GetDoubleEma |   291.68 μs |  3.956 μs |  3.507 μs |   290.22 μs |
-|             GetEma |   151.47 μs |  0.752 μs |  0.667 μs |   151.33 μs |
-|      GetHeikinAshi |   220.23 μs |  5.598 μs | 16.239 μs |   209.94 μs |
-|             GetHma | 1,695.43 μs |  4.669 μs |  3.645 μs | 1,694.16 μs |
-|        GetIchimoku |   959.77 μs |  5.060 μs |  4.485 μs |   959.35 μs |
-|         GetKeltner |   616.94 μs |  8.850 μs |  7.390 μs |   615.32 μs |
-|            GetMacd |   464.52 μs |  3.691 μs |  3.453 μs |   462.54 μs |
-|             GetMfi |   544.27 μs | 10.676 μs | 17.540 μs |   534.62 μs |
-|             GetObv |    82.03 μs |  0.345 μs |  0.306 μs |    81.93 μs |
-|      GetObvWithSma |   198.84 μs |  2.002 μs |  1.873 μs |   197.91 μs |
-|    GetParabolicSar |   113.55 μs |  0.709 μs |  0.592 μs |   113.33 μs |
-|             GetPmo |   363.58 μs |  5.214 μs |  4.878 μs |   360.75 μs |
-|             GetPrs |   146.59 μs |  1.937 μs |  1.717 μs |   145.79 μs |
-|      GetPrsWithSma |   237.48 μs |  3.367 μs |  3.877 μs |   236.03 μs |
-|             GetRoc |   106.25 μs |  0.843 μs |  0.747 μs |   106.20 μs |
-|      GetRocWithSma |   387.87 μs |  5.278 μs |  4.937 μs |   385.15 μs |
-|             GetRsi |   413.49 μs |  3.968 μs |  3.313 μs |   412.55 μs |
-|           GetSlope | 1,180.92 μs | 11.240 μs |  9.964 μs | 1,176.32 μs |
-|             GetSma |   140.17 μs |  0.570 μs |  0.476 μs |   139.98 μs |
-|     GetSmaExtended | 1,166.91 μs |  4.267 μs |  3.332 μs | 1,165.93 μs |
-|          GetStdDev |   374.02 μs |  3.497 μs |  3.100 μs |   373.65 μs |
-|   GetStdDevWithSma |   533.23 μs |  1.620 μs |  1.353 μs |   533.39 μs |
-|           GetStoch |   404.15 μs |  3.478 μs |  3.083 μs |   402.51 μs |
-|        GetStochRsi |   820.39 μs |  7.537 μs |  6.682 μs |   817.24 μs |
-|       GetTripleEma |   429.46 μs |  3.667 μs |  3.062 μs |   428.15 μs |
-|            GetTrix |   489.86 μs |  2.185 μs |  1.937 μs |   489.31 μs |
-|     GetTrixWithSma |   597.82 μs | 11.434 μs | 21.475 μs |   588.12 μs |
-|      GetUlcerIndex | 1,553.59 μs | 11.438 μs |  9.551 μs | 1,549.02 μs |
-|        GetUltimate |   982.79 μs |  4.019 μs |  3.563 μs |   981.74 μs |
-|          GetVolSma |   166.87 μs |  1.230 μs |  1.150 μs |   166.56 μs |
-|        GetWilliamR |   323.22 μs |  1.461 μs |  1.295 μs |   322.73 μs |
-|             GetWma |   908.22 μs | 11.714 μs |  9.145 μs |   906.89 μs |
-|          GetZigZag |   264.63 μs |  4.154 μs |  7.165 μs |   261.03 μs |
+|             GetAdl |   166.29 μs |  3.317 μs |  9.356 μs |   163.07 μs |
+|      GetAdlWithSma |   428.63 μs |  3.787 μs |  3.163 μs |   427.75 μs |
+|             GetAdx |   845.12 μs | 10.864 μs | 12.933 μs |   843.00 μs |
+|           GetAroon |   337.13 μs |  3.841 μs |  3.405 μs |   337.53 μs |
+|             GetAtr |   184.31 μs |  3.653 μs |  5.239 μs |   183.19 μs |
+|            GetBeta | 1,049.45 μs | 12.113 μs |  9.457 μs | 1,050.90 μs |
+|  GetBollingerBands |   442.86 μs |  5.722 μs |  4.468 μs |   442.49 μs |
+|             GetCci |   910.38 μs | 22.144 μs | 64.946 μs |   879.66 μs |
+|      GetChaikinOsc |   377.55 μs |  1.668 μs |  1.478 μs |   376.92 μs |
+|      GetChandelier |   363.40 μs |  3.433 μs |  3.043 μs |   362.35 μs |
+|             GetCmf |   662.24 μs |  2.385 μs |  1.991 μs |   661.99 μs |
+|      GetConnorsRsi | 1,279.67 μs |  3.615 μs |  3.019 μs | 1,279.85 μs |
+|     GetCorrelation |   817.38 μs |  7.546 μs |  6.301 μs |   814.70 μs |
+|        GetDonchian |   302.10 μs |  1.735 μs |  1.354 μs |   301.92 μs |
+|       GetDoubleEma |   253.41 μs |  3.928 μs |  3.482 μs |   252.23 μs |
+|             GetEma |   139.20 μs |  0.670 μs |  0.559 μs |   139.08 μs |
+|      GetHeikinAshi |   183.00 μs |  0.617 μs |  0.515 μs |   183.01 μs |
+|             GetHma | 1,426.38 μs |  6.791 μs |  6.020 μs | 1,423.66 μs |
+|        GetIchimoku |   877.50 μs |  4.985 μs |  4.419 μs |   876.12 μs |
+|         GetKeltner |   526.29 μs |  1.989 μs |  1.553 μs |   526.26 μs |
+|            GetMacd |   418.10 μs |  3.455 μs |  2.697 μs |   417.17 μs |
+|             GetMfi |   498.57 μs |  7.252 μs |  9.429 μs |   496.00 μs |
+|             GetObv |    66.55 μs |  0.549 μs |  0.514 μs |    66.41 μs |
+|      GetObvWithSma |   192.81 μs |  7.121 μs | 20.771 μs |   187.22 μs |
+|    GetParabolicSar |   141.38 μs |  2.811 μs |  4.697 μs |   141.78 μs |
+|             GetPmo |   398.54 μs |  7.699 μs | 11.041 μs |   395.49 μs |
+|             GetPrs |   201.48 μs |  4.013 μs |  8.466 μs |   201.01 μs |
+|      GetPrsWithSma |   273.75 μs |  5.403 μs |  8.571 μs |   271.70 μs |
+|             GetRoc |   143.71 μs |  2.868 μs |  8.044 μs |   142.89 μs |
+|      GetRocWithSma |   401.29 μs |  5.310 μs |  4.967 μs |   399.92 μs |
+|             GetRsi |   482.43 μs |  6.164 μs |  5.766 μs |   481.19 μs |
+|           GetSlope |   997.45 μs | 19.623 μs | 40.525 μs | 1,001.09 μs |
+|             GetSma |   164.34 μs |  3.247 μs |  7.127 μs |   163.61 μs |
+|     GetSmaExtended | 1,136.51 μs | 22.495 μs | 22.093 μs | 1,131.39 μs |
+|          GetStdDev |   482.58 μs |  8.562 μs |  8.793 μs |   482.03 μs |
+|   GetStdDevWithSma |   594.46 μs | 11.689 μs | 10.933 μs |   594.59 μs |
+|           GetStoch |   493.60 μs |  7.157 μs |  6.695 μs |   495.79 μs |
+|        GetStochRsi |   741.82 μs |  9.198 μs | 21.859 μs |   737.06 μs |
+|       GetTripleEma |   364.59 μs |  1.909 μs |  1.692 μs |   364.03 μs |
+|            GetTrix |   435.09 μs |  1.952 μs |  1.731 μs |   434.60 μs |
+|     GetTrixWithSma |   491.33 μs |  2.010 μs |  1.678 μs |   491.30 μs |
+|      GetUlcerIndex | 1,380.28 μs |  6.563 μs |  5.481 μs | 1,378.85 μs |
+|        GetUltimate |   600.91 μs |  4.134 μs |  3.452 μs |   602.13 μs |
+|          GetVolSma |   121.56 μs |  0.691 μs |  0.613 μs |   121.65 μs |
+|        GetWilliamR |   292.65 μs |  1.621 μs |  1.517 μs |   292.32 μs |
+|             GetWma |   756.90 μs |  2.817 μs |  2.353 μs |   757.01 μs |
+|          GetZigZag |   232.81 μs |  3.206 μs |  2.503 μs |   232.23 μs |
 
 ## internal cleaners
 
-|           Method |     Mean |    Error |   StdDev |   Median |
-|----------------- |---------:|---------:|---------:|---------:|
-|   PrepareHistory | 47.90 μs | 0.875 μs | 2.337 μs | 46.95 μs |
-| PrepareBasicData | 33.88 μs | 0.595 μs | 1.058 μs | 33.42 μs |
+|           Method |     Mean |    Error |   StdDev |
+|----------------- |---------:|---------:|---------:|
+|   PrepareHistory | 42.15 μs | 0.483 μs | 0.452 μs |
+| PrepareBasicData | 30.35 μs | 0.221 μs | 0.196 μs |
 
 ## internal math functions
 

--- a/tests/performance/Tests.Performance.csproj
+++ b/tests/performance/Tests.Performance.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closing #164 - adding .NET 5.0 framework target library to NuGet package

Side note:

- .NET Core was > 50% faster than .NET Framework 4.x
- .NET 5.0 is now 1 to 25% faster than .NET Core (observed in this library)