### PR TITLE
fix: ADX initialization

### DIFF
--- a/indicators/Adx/Adx.cs
+++ b/indicators/Adx/Adx.cs
@@ -149,7 +149,7 @@ namespace Skender.Stock.Indicators
 
             // check history
             int qtyHistory = history.Count();
-            int minHistory = 2 * lookbackPeriod + 1;
+            int minHistory = 2 * lookbackPeriod + 150;
             if (qtyHistory < minHistory)
             {
                 throw new BadHistoryException("Insufficient history provided for ADX.  " +

--- a/indicators/Adx/Adx.cs
+++ b/indicators/Adx/Adx.cs
@@ -82,9 +82,9 @@ namespace Skender.Stock.Indicators
 
                 if (h.Index == lookbackPeriod + 1)
                 {
-                    trs = sumTr / lookbackPeriod;
-                    pdm = sumPdm / lookbackPeriod;
-                    mdm = sumMdm / lookbackPeriod;
+                    trs = sumTr;
+                    pdm = sumPdm;
+                    mdm = sumMdm;
                 }
                 else
                 {

--- a/indicators/Adx/README.md
+++ b/indicators/Adx/README.md
@@ -13,7 +13,7 @@ IEnumerable<AdxResult> results = Indicator.GetAdx(history, lookbackPeriod);
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least 2×`N`+1 periods of `history` to get any results; however, since this uses a smoothing technique, we recommend you use at least 250 data points prior to the intended usage date for maximum precision.
+| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least 2×`N`+150 periods of `history` to allow for smoothing convergence; however, we recommend you use at least 250 data points prior to the intended usage date for maximum precision.
 | `lookbackPeriod` | int | Number of periods (`N`) to consider.  Must be greater than 1.  Default is 14.
 
 ## Response
@@ -22,7 +22,7 @@ IEnumerable<AdxResult> results = Indicator.GetAdx(history, lookbackPeriod);
 IEnumerable<AdxResult>
 ```
 
-The first `2×N-1` periods will have `null` values for ADX since there's not enough data to calculate.  We always return the same number of elements as there are in the historical quotes.
+The first `2×N-1` periods will have `null` values for ADX since there's not enough data to calculate.  The first 150 values will be less precise due to smoothing convergence.  We always return the same number of elements as there are in the historical quotes.
 
 ### AdxResult
 

--- a/indicators/Adx/README.md
+++ b/indicators/Adx/README.md
@@ -13,7 +13,7 @@ IEnumerable<AdxResult> results = Indicator.GetAdx(history, lookbackPeriod);
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least 2×`N`+150 periods of `history` to allow for smoothing convergence; however, we recommend you use at least 250 data points prior to the intended usage date for maximum precision.
+| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `2×N+150` periods of `history` to allow for smoothing convergence.  We generally recommend you use at least 250 data points prior to the intended usage date for maximum precision.
 | `lookbackPeriod` | int | Number of periods (`N`) to consider.  Must be greater than 1.  Default is 14.
 
 ## Response
@@ -22,7 +22,7 @@ IEnumerable<AdxResult> results = Indicator.GetAdx(history, lookbackPeriod);
 IEnumerable<AdxResult>
 ```
 
-The first `2×N-1` periods will have `null` values for ADX since there's not enough data to calculate.  The first 150 values will be less precise due to smoothing convergence.  We always return the same number of elements as there are in the historical quotes.
+The first `2×N-1` periods will have `null` values for ADX since there's not enough data to calculate.  The first `2×N+150` values will be less precise due to smoothing convergence.  We always return the same number of elements as there are in the historical quotes.
 
 ### AdxResult
 

--- a/tests/indicators/Test.Adx.cs
+++ b/tests/indicators/Test.Adx.cs
@@ -21,13 +21,28 @@ namespace Internal.Tests
             // proper quantities
             // should always be the same number of results as there is history
             Assert.AreEqual(502, results.Count());
-            Assert.AreEqual(502 - 2 * lookbackPeriod + 1, results.Where(x => x.Adx != null).Count());
+            Assert.AreEqual(475, results.Where(x => x.Adx != null).Count());
 
-            // sample value
+            // sample values
             AdxResult r1 = results.Where(x => x.Index == 502).FirstOrDefault();
             Assert.AreEqual(17.7565m, Math.Round((decimal)r1.Pdi, 4));
             Assert.AreEqual(31.1510m, Math.Round((decimal)r1.Mdi, 4));
             Assert.AreEqual(34.2987m, Math.Round((decimal)r1.Adx, 4));
+
+            AdxResult r2 = results.Where(x => x.Index == 249).FirstOrDefault();
+            Assert.AreEqual(32.3167m, Math.Round((decimal)r2.Pdi, 4));
+            Assert.AreEqual(18.2471m, Math.Round((decimal)r2.Mdi, 4));
+            Assert.AreEqual(30.5903m, Math.Round((decimal)r2.Adx, 4));
+
+            AdxResult r3 = results.Where(x => x.Index == 20).FirstOrDefault();
+            Assert.AreEqual(21.0361m, Math.Round((decimal)r3.Pdi, 4));
+            Assert.AreEqual(25.0124m, Math.Round((decimal)r3.Mdi, 4));
+            Assert.AreEqual(null, r3.Adx);
+
+            AdxResult r4 = results.Where(x => x.Index == 30).FirstOrDefault();
+            Assert.AreEqual(37.9719m, Math.Round((decimal)r4.Pdi, 4));
+            Assert.AreEqual(14.1658m, Math.Round((decimal)r4.Mdi, 4));
+            Assert.AreEqual(19.7949m, Math.Round((decimal)r4.Adx, 4));
         }
 
 

--- a/tests/indicators/Test.Adx.cs
+++ b/tests/indicators/Test.Adx.cs
@@ -24,10 +24,10 @@ namespace Internal.Tests
             Assert.AreEqual(502 - 2 * lookbackPeriod + 1, results.Where(x => x.Adx != null).Count());
 
             // sample value
-            AdxResult r = results.Where(x => x.Index == 502).FirstOrDefault();
-            Assert.AreEqual(17.7565m, Math.Round((decimal)r.Pdi, 4));
-            Assert.AreEqual(31.1510m, Math.Round((decimal)r.Mdi, 4));
-            Assert.AreEqual(34.2987m, Math.Round((decimal)r.Adx, 4));
+            AdxResult r1 = results.Where(x => x.Index == 502).FirstOrDefault();
+            Assert.AreEqual(17.7565m, Math.Round((decimal)r1.Pdi, 4));
+            Assert.AreEqual(31.1510m, Math.Round((decimal)r1.Mdi, 4));
+            Assert.AreEqual(34.2987m, Math.Round((decimal)r1.Adx, 4));
         }
 
 
@@ -44,7 +44,7 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetAdx(history.Where(x => x.Index < 61), 30);
+            Indicator.GetAdx(history.Where(x => x.Index < 210), 30);
         }
 
     }


### PR DESCRIPTION
Minor fix to resolve #173 where the initialization period values were slightly off.  This bug did not impact the accuracy of values after the initialization period.  I also increased the minimum required history from `2×N+1` to `2×N+150` to ensure users are aware of the initialization period where values are less precise and that this indicator needs more runway.

[ADX-ManualCalc.xlsx](https://github.com/DaveSkender/Stock.Indicators/files/5527960/ADX-ManualCalc.xlsx)