### PR TITLE
refactor: Exceptions

### DIFF
--- a/indicators/Adl/Adl.cs
+++ b/indicators/Adl/Adl.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Skender.Stock.Indicators
@@ -61,7 +62,8 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (smaPeriod != null && smaPeriod <= 0)
             {
-                throw new BadParameterException("SMA period must be greater than 0 for ADL.");
+                throw new ArgumentOutOfRangeException(nameof(smaPeriod), smaPeriod,
+                    "SMA period must be greater than 0 for ADL.");
             }
 
             // check history
@@ -69,10 +71,13 @@ namespace Skender.Stock.Indicators
             int minHistory = 2;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for Accumulation Distribution Line.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                         qtyHistory, minHistory));
+                string message =
+                    "Insufficient history provided for Accumulation Distribution Line.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
 
         }

--- a/indicators/Adx/Adx.cs
+++ b/indicators/Adx/Adx.cs
@@ -144,20 +144,23 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (lookbackPeriod <= 1)
             {
-                throw new BadParameterException("Lookback period must be greater than 1 for ADX.");
+                throw new ArgumentOutOfRangeException(nameof(lookbackPeriod), lookbackPeriod,
+                    "Lookback period must be greater than 1 for ADX.");
             }
 
             // check history
             int qtyHistory = history.Count();
-            int minHistory = 2 * lookbackPeriod + 150;
+            int minHistory = 2 * lookbackPeriod + 100;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for ADX.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.  "
-                          + "Since this uses a smoothing technique, "
-                          + "we recommend you use at least 250 data points prior to the intended "
-                          + "usage date for maximum precision.", qtyHistory, minHistory));
+                string message = "Insufficient history provided for ADX.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.  "
+                    + "Since this uses a smoothing technique, "
+                    + "we recommend you use at least 250 data points prior to the intended "
+                    + "usage date for maximum precision.", qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
         }
     }

--- a/indicators/Adx/README.md
+++ b/indicators/Adx/README.md
@@ -13,7 +13,7 @@ IEnumerable<AdxResult> results = Indicator.GetAdx(history, lookbackPeriod);
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `2×N+150` periods of `history` to allow for smoothing convergence.  We generally recommend you use at least 250 data points prior to the intended usage date for maximum precision.
+| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `2×N+100` periods of `history` to allow for smoothing convergence.  We generally recommend you use at least 250 data points prior to the intended usage date for maximum precision.
 | `lookbackPeriod` | int | Number of periods (`N`) to consider.  Must be greater than 1.  Default is 14.
 
 ## Response
@@ -22,7 +22,7 @@ IEnumerable<AdxResult> results = Indicator.GetAdx(history, lookbackPeriod);
 IEnumerable<AdxResult>
 ```
 
-The first `2×N-1` periods will have `null` values for ADX since there's not enough data to calculate.  The first `2×N+150` values will be less precise due to smoothing convergence.  We always return the same number of elements as there are in the historical quotes.
+The first `2×N-1` periods will have `null` values for ADX since there's not enough data to calculate.  The first `2×N+100` values will be less precise due to smoothing convergence.  We always return the same number of elements as there are in the historical quotes.
 
 ### AdxResult
 

--- a/indicators/Aroon/Aroon.cs
+++ b/indicators/Aroon/Aroon.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Skender.Stock.Indicators
@@ -71,7 +72,8 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (lookbackPeriod <= 0)
             {
-                throw new BadParameterException("Lookback period must be greater than 0 for Aroon.");
+                throw new ArgumentOutOfRangeException(nameof(lookbackPeriod), lookbackPeriod,
+                    "Lookback period must be greater than 0 for Aroon.");
             }
 
             // checked history
@@ -79,10 +81,12 @@ namespace Skender.Stock.Indicators
             int minHistory = lookbackPeriod;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for Aroon.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                        qtyHistory, minHistory));
+                string message = "Insufficient history provided for Aroon.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
         }
     }

--- a/indicators/Atr/Atr.cs
+++ b/indicators/Atr/Atr.cs
@@ -77,7 +77,8 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (lookbackPeriod <= 1)
             {
-                throw new BadParameterException("Lookback period must be greater than 1 for Average True Range.");
+                throw new ArgumentOutOfRangeException(nameof(lookbackPeriod), lookbackPeriod,
+                    "Lookback period must be greater than 1 for Average True Range.");
             }
 
             // check history
@@ -85,10 +86,12 @@ namespace Skender.Stock.Indicators
             int minHistory = lookbackPeriod + 1;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for ATR.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                        qtyHistory, minHistory));
+                string message = "Insufficient history provided for ATR.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
         }
     }

--- a/indicators/Beta/Beta.cs
+++ b/indicators/Beta/Beta.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Skender.Stock.Indicators
@@ -54,7 +55,8 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (lookbackPeriod <= 0)
             {
-                throw new BadParameterException("Lookback period must be greater than 0 for Beta.");
+                throw new ArgumentOutOfRangeException(nameof(lookbackPeriod), lookbackPeriod,
+                    "Lookback period must be greater than 0 for Beta.");
             }
 
             // check history
@@ -62,16 +64,18 @@ namespace Skender.Stock.Indicators
             int minHistoryMarket = lookbackPeriod;
             if (qtyHistoryMarket < minHistoryMarket)
             {
-                throw new BadHistoryException("Insufficient history provided for Beta.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                        qtyHistoryMarket, minHistoryMarket));
+                string message = "Insufficient history provided for Beta.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistoryMarket, minHistoryMarket);
+
+                throw new BadHistoryException(nameof(historyMarket), message);
             }
 
             int qtyHistoryEval = historyEval.Count();
             if (qtyHistoryEval < qtyHistoryMarket)
             {
-                throw new BadHistoryException(
+                throw new BadHistoryException(nameof(historyEval),
                     "Eval history should have at least as many records as Market history for Beta.");
             }
 

--- a/indicators/BollingerBands/BollingerBands.cs
+++ b/indicators/BollingerBands/BollingerBands.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Skender.Stock.Indicators
@@ -70,12 +71,14 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (lookbackPeriod <= 1)
             {
-                throw new BadParameterException("Lookback period must be greater than 1 for Bollinger Bands.");
+                throw new ArgumentOutOfRangeException(nameof(lookbackPeriod), lookbackPeriod,
+                    "Lookback period must be greater than 1 for Bollinger Bands.");
             }
 
             if (standardDeviations <= 0)
             {
-                throw new BadParameterException("Standard Deviations must be greater than 0 for Bollinger Bands.");
+                throw new ArgumentOutOfRangeException(nameof(standardDeviations), standardDeviations,
+                    "Standard Deviations must be greater than 0 for Bollinger Bands.");
             }
 
             // check history
@@ -83,10 +86,12 @@ namespace Skender.Stock.Indicators
             int minHistory = lookbackPeriod;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for Bollinger Bands.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                        qtyHistory, minHistory));
+                string message = "Insufficient history provided for Bollinger Bands.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
         }
 

--- a/indicators/Cci/Cci.cs
+++ b/indicators/Cci/Cci.cs
@@ -67,19 +67,21 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (lookbackPeriod <= 0)
             {
-                throw new BadParameterException("Lookback period must be greater than 0 for Commodity Channel Index.");
+                throw new ArgumentOutOfRangeException(nameof(lookbackPeriod), lookbackPeriod,
+                    "Lookback period must be greater than 0 for Commodity Channel Index.");
             }
-
 
             // check history
             int qtyHistory = history.Count();
             int minHistory = lookbackPeriod + 1;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for Commodity Channel Index.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                        qtyHistory, minHistory));
+                string message = "Insufficient history provided for Commodity Channel Index.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
         }
     }

--- a/indicators/ChaikinOsc/ChaikinOsc.cs
+++ b/indicators/ChaikinOsc/ChaikinOsc.cs
@@ -59,28 +59,31 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (fastPeriod <= 0)
             {
-                throw new BadParameterException("Fast lookback period must be greater than 0 for Chaikin Oscillator.");
+                throw new ArgumentOutOfRangeException(nameof(fastPeriod), fastPeriod,
+                    "Fast lookback period must be greater than 0 for Chaikin Oscillator.");
             }
 
             // check parameters
             if (slowPeriod <= fastPeriod)
             {
-                throw new BadParameterException("Slow lookback period must be greater than Fast lookback period for Chaikin Oscillator.");
+                throw new ArgumentOutOfRangeException(nameof(slowPeriod), slowPeriod,
+                    "Slow lookback period must be greater than Fast lookback period for Chaikin Oscillator.");
             }
-
 
             // check history
             int qtyHistory = history.Count();
             int minHistory = Math.Max(2 * slowPeriod, slowPeriod + 100);
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for Chaikin Oscillator.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.  "
-                          + "Since this uses a smoothing technique, for a slow period of {2}, "
-                          + "we recommend you use at least {3} data points prior to the intended "
-                          + "usage date for maximum precision.",
-                          qtyHistory, minHistory, slowPeriod, slowPeriod + 250));
+                string message = "Insufficient history provided for Chaikin Oscillator.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.  "
+                    + "Since this uses a smoothing technique, for a slow period of {2}, "
+                    + "we recommend you use at least {3} data points prior to the intended "
+                    + "usage date for maximum precision.",
+                    qtyHistory, minHistory, slowPeriod, slowPeriod + 250);
+
+                throw new BadHistoryException(nameof(history), message);
             }
 
         }

--- a/indicators/Chandelier/Chandelier.cs
+++ b/indicators/Chandelier/Chandelier.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Skender.Stock.Indicators
@@ -89,12 +90,14 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (lookbackPeriod <= 0)
             {
-                throw new BadParameterException("Lookback period must be greater than 0 for Chandelier Exit.");
+                throw new ArgumentOutOfRangeException(nameof(lookbackPeriod), lookbackPeriod,
+                    "Lookback period must be greater than 0 for Chandelier Exit.");
             }
 
             if (multiplier <= 0)
             {
-                throw new BadParameterException("Multiplier must be greater than 0 for Chandelier Exit.");
+                throw new ArgumentOutOfRangeException(nameof(multiplier), multiplier,
+                    "Multiplier must be greater than 0 for Chandelier Exit.");
             }
 
             // check history
@@ -102,10 +105,12 @@ namespace Skender.Stock.Indicators
             int minHistory = lookbackPeriod + 1;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for Chandelier Exit.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                        qtyHistory, minHistory));
+                string message = "Insufficient history provided for Chandelier Exit.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
         }
     }

--- a/indicators/Cmf/Cmf.cs
+++ b/indicators/Cmf/Cmf.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Skender.Stock.Indicators
@@ -68,7 +69,8 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (lookbackPeriod <= 0)
             {
-                throw new BadParameterException("Lookback period must be greater than 0 for Chaikin Money Flow.");
+                throw new ArgumentOutOfRangeException(nameof(lookbackPeriod), lookbackPeriod,
+                    "Lookback period must be greater than 0 for Chaikin Money Flow.");
             }
 
             // check history
@@ -76,10 +78,12 @@ namespace Skender.Stock.Indicators
             int minHistory = lookbackPeriod + 1;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for Chaikin Money Flow.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                        qtyHistory, minHistory));
+                string message = "Insufficient history provided for Chaikin Money Flow.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
 
         }

--- a/indicators/ConnorsRsi/ConnorsRsi.cs
+++ b/indicators/ConnorsRsi/ConnorsRsi.cs
@@ -135,37 +135,41 @@ namespace Skender.Stock.Indicators
 
 
         private static void ValidateConnorsRsi(
-            IEnumerable<BasicData> basicData, int rsiPeriod, int streakPeriod, int rankPeriod)
+            IEnumerable<BasicData> history, int rsiPeriod, int streakPeriod, int rankPeriod)
         {
 
             // check parameters
             if (rsiPeriod <= 1)
             {
-                throw new BadParameterException("RSI period for Close price must be greater than 1 for ConnorsRsi.");
+                throw new ArgumentOutOfRangeException(nameof(rsiPeriod), rsiPeriod,
+                    "RSI period for Close price must be greater than 1 for ConnorsRsi.");
             }
 
             if (streakPeriod <= 1)
             {
-                throw new BadParameterException("RSI period for Streak must be greater than 1 for ConnorsRsi.");
+                throw new ArgumentOutOfRangeException(nameof(streakPeriod), streakPeriod,
+                    "RSI period for Streak must be greater than 1 for ConnorsRsi.");
             }
 
             if (rankPeriod <= 1)
             {
-                throw new BadParameterException("Percent Rank period must be greater than 1 for ConnorsRsi.");
+                throw new ArgumentOutOfRangeException(nameof(rankPeriod), rankPeriod,
+                    "Percent Rank period must be greater than 1 for ConnorsRsi.");
             }
 
-
             // check history
-            int qtyHistory = basicData.Count();
+            int qtyHistory = history.Count();
             int minHistory = Math.Max(rsiPeriod, Math.Max(streakPeriod, rankPeriod + 2));
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for ConnorsRsi.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.  "
-                          + "Since this uses a smoothing technique, "
-                          + "we recommend you use at least 250 data points prior to the intended "
-                          + "usage date for maximum precision.", qtyHistory, minHistory));
+                string message = "Insufficient history provided for ConnorsRsi.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.  "
+                    + "Since this uses a smoothing technique, "
+                    + "we recommend you use at least 250 data points prior to the intended "
+                    + "usage date for maximum precision.", qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
         }
     }

--- a/indicators/Correlation/Correlation.cs
+++ b/indicators/Correlation/Correlation.cs
@@ -29,7 +29,7 @@ namespace Skender.Stock.Indicators
 
                 if (a.Date != b.Date)
                 {
-                    throw new BadHistoryException(
+                    throw new BadHistoryException(nameof(historyA), a.Date,
                         "Date sequence does not match.  Correlation requires matching dates in provided histories.");
                 }
 
@@ -86,7 +86,8 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (lookbackPeriod <= 0)
             {
-                throw new BadParameterException("Lookback period must be greater than 0 for Correlation.");
+                throw new ArgumentOutOfRangeException(nameof(lookbackPeriod), lookbackPeriod,
+                    "Lookback period must be greater than 0 for Correlation.");
             }
 
             // check history
@@ -94,16 +95,18 @@ namespace Skender.Stock.Indicators
             int minHistoryA = lookbackPeriod;
             if (qtyHistoryA < minHistoryA)
             {
-                throw new BadHistoryException("Insufficient history provided for Correlation.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                        qtyHistoryA, minHistoryA));
+                string message = "Insufficient history provided for Correlation.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistoryA, minHistoryA);
+
+                throw new BadHistoryException(nameof(historyA), message);
             }
 
             int qtyHistoryB = historyB.Count();
             if (qtyHistoryB != qtyHistoryA)
             {
-                throw new BadHistoryException(
+                throw new BadHistoryException(nameof(historyB),
                     "B history should have at least as many records as A history for Correlation.");
             }
         }

--- a/indicators/Donchian/Donchian.cs
+++ b/indicators/Donchian/Donchian.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Skender.Stock.Indicators
@@ -70,7 +71,8 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (lookbackPeriod <= 1)
             {
-                throw new BadParameterException("Lookback period must be greater than 1 for Donchian Channel.");
+                throw new ArgumentOutOfRangeException(nameof(lookbackPeriod), lookbackPeriod,
+                    "Lookback period must be greater than 1 for Donchian Channel.");
             }
 
             // check history
@@ -78,10 +80,12 @@ namespace Skender.Stock.Indicators
             int minHistory = lookbackPeriod;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for Donchian Channel.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                        qtyHistory, minHistory));
+                string message = "Insufficient history provided for Donchian Channel.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
         }
 

--- a/indicators/Ema/DoubleEma.cs
+++ b/indicators/Ema/DoubleEma.cs
@@ -51,27 +51,30 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateDema(IEnumerable<BasicData> basicData, int lookbackPeriod)
+        private static void ValidateDema(IEnumerable<BasicData> history, int lookbackPeriod)
         {
 
             // check parameters
             if (lookbackPeriod <= 0)
             {
-                throw new BadParameterException("Lookback period must be greater than 0 for DEMA.");
+                throw new ArgumentOutOfRangeException(nameof(lookbackPeriod), lookbackPeriod,
+                    "Lookback period must be greater than 0 for DEMA.");
             }
 
             // check history
-            int qtyHistory = basicData.Count();
+            int qtyHistory = history.Count();
             int minHistory = Math.Max(3 * lookbackPeriod, 2 * lookbackPeriod + 100);
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for DEMA.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.  "
-                          + "Since this uses a smoothing technique, for a lookback period of {2}, "
-                          + "we recommend you use at least {3} data points prior to the intended "
-                          + "usage date for maximum precision.",
-                          qtyHistory, minHistory, lookbackPeriod, 2 * lookbackPeriod + 250));
+                string message = "Insufficient history provided for DEMA.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.  "
+                    + "Since this uses a smoothing technique, for a lookback period of {2}, "
+                    + "we recommend you use at least {3} data points prior to the intended "
+                    + "usage date for maximum precision.",
+                    qtyHistory, minHistory, lookbackPeriod, 2 * lookbackPeriod + 250);
+
+                throw new BadHistoryException(nameof(history), message);
             }
 
         }

--- a/indicators/Ema/Ema.cs
+++ b/indicators/Ema/Ema.cs
@@ -65,29 +65,31 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateEma(IEnumerable<BasicData> basicData, int lookbackPeriod)
+        private static void ValidateEma(IEnumerable<BasicData> history, int lookbackPeriod)
         {
 
             // check parameters
             if (lookbackPeriod <= 0)
             {
-                throw new BadParameterException("Lookback period must be greater than 0 for EMA.");
+                throw new ArgumentOutOfRangeException(nameof(lookbackPeriod), lookbackPeriod,
+                    "Lookback period must be greater than 0 for EMA.");
             }
 
             // check history
-            int qtyHistory = basicData.Count();
+            int qtyHistory = history.Count();
             int minHistory = Math.Max(2 * lookbackPeriod, lookbackPeriod + 100);
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for EMA.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.  "
-                          + "Since this uses a smoothing technique, for a lookback period of {2}, "
-                          + "we recommend you use at least {3} data points prior to the intended "
-                          + "usage date for maximum precision.",
-                          qtyHistory, minHistory, lookbackPeriod, lookbackPeriod + 250));
-            }
+                string message = "Insufficient history provided for EMA.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.  "
+                    + "Since this uses a smoothing technique, for a lookback period of {2}, "
+                    + "we recommend you use at least {3} data points prior to the intended "
+                    + "usage date for maximum precision.",
+                    qtyHistory, minHistory, lookbackPeriod, lookbackPeriod + 250);
 
+                throw new BadHistoryException(nameof(history), message);
+            }
         }
 
     }

--- a/indicators/Ema/TripleEma.cs
+++ b/indicators/Ema/TripleEma.cs
@@ -60,27 +60,30 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateTema(IEnumerable<BasicData> basicData, int lookbackPeriod)
+        private static void ValidateTema(IEnumerable<BasicData> history, int lookbackPeriod)
         {
 
             // check parameters
             if (lookbackPeriod <= 0)
             {
-                throw new BadParameterException("Lookback period must be greater than 0 for TEMA.");
+                throw new ArgumentOutOfRangeException(nameof(lookbackPeriod), lookbackPeriod,
+                    "Lookback period must be greater than 0 for TEMA.");
             }
 
             // check history
-            int qtyHistory = basicData.Count();
+            int qtyHistory = history.Count();
             int minHistory = Math.Max(4 * lookbackPeriod, 3 * lookbackPeriod + 100);
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for TEMA.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.  "
-                          + "Since this uses a smoothing technique, for a lookback period of {2}, "
-                          + "we recommend you use at least {3} data points prior to the intended "
-                          + "usage date for maximum precision.",
-                          qtyHistory, minHistory, lookbackPeriod, 3 * lookbackPeriod + 250));
+                string message = "Insufficient history provided for TEMA.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.  "
+                    + "Since this uses a smoothing technique, for a lookback period of {2}, "
+                    + "we recommend you use at least {3} data points prior to the intended "
+                    + "usage date for maximum precision.",
+                    qtyHistory, minHistory, lookbackPeriod, 3 * lookbackPeriod + 250);
+
+                throw new BadHistoryException(nameof(history), message);
             }
 
         }

--- a/indicators/HeikinAshi/HeikinAshi.cs
+++ b/indicators/HeikinAshi/HeikinAshi.cs
@@ -67,10 +67,12 @@ namespace Skender.Stock.Indicators
             int minHistory = 2;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for Heikin-Ashi.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                        qtyHistory, minHistory));
+                string message = "Insufficient history provided for Heikin-Ashi.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
 
         }

--- a/indicators/Hma/Hma.cs
+++ b/indicators/Hma/Hma.cs
@@ -80,7 +80,8 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (lookbackPeriod <= 1)
             {
-                throw new BadParameterException("Lookback period must be greater than 1 for HMA.");
+                throw new ArgumentOutOfRangeException(nameof(lookbackPeriod), lookbackPeriod,
+                    "Lookback period must be greater than 1 for HMA.");
             }
 
             // check history
@@ -88,10 +89,12 @@ namespace Skender.Stock.Indicators
             int minHistory = lookbackPeriod;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for HMA.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                        qtyHistory, minHistory));
+                string message = "Insufficient history provided for HMA.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
 
         }

--- a/indicators/Ichimoku/Ichimoku.cs
+++ b/indicators/Ichimoku/Ichimoku.cs
@@ -94,8 +94,8 @@ namespace Skender.Stock.Indicators
 
 
         private static void CalcIchimokuKijunSen(
-            List<Quote> historyList, 
-            IchimokuResult result, 
+            List<Quote> historyList,
+            IchimokuResult result,
             Quote h, int shortSpanPeriod)
         {
             if (h.Index >= shortSpanPeriod)
@@ -161,17 +161,20 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (signalPeriod <= 0)
             {
-                throw new BadParameterException("Signal period must be greater than 0 for ICHIMOKU.");
+                throw new ArgumentOutOfRangeException(nameof(signalPeriod), signalPeriod,
+                    "Signal period must be greater than 0 for ICHIMOKU.");
             }
 
             if (shortSpanPeriod <= 0)
             {
-                throw new BadParameterException("Short span period must be greater than 0 for ICHIMOKU.");
+                throw new ArgumentOutOfRangeException(nameof(shortSpanPeriod), shortSpanPeriod,
+                    "Short span period must be greater than 0 for ICHIMOKU.");
             }
 
             if (longSpanPeriod <= shortSpanPeriod)
             {
-                throw new BadParameterException("Long span period must be greater than small span period for ICHIMOKU.");
+                throw new ArgumentOutOfRangeException(nameof(longSpanPeriod), longSpanPeriod,
+                    "Long span period must be greater than small span period for ICHIMOKU.");
             }
 
             // check history
@@ -179,10 +182,12 @@ namespace Skender.Stock.Indicators
             int minHistory = Math.Max(signalPeriod, Math.Max(shortSpanPeriod, longSpanPeriod));
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for ICHIMOKU.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                        qtyHistory, minHistory));
+                string message = "Insufficient history provided for ICHIMOKU.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
 
         }

--- a/indicators/Keltner/Keltner.cs
+++ b/indicators/Keltner/Keltner.cs
@@ -59,17 +59,20 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (emaPeriod <= 1)
             {
-                throw new BadParameterException("EMA period must be greater than 1 for Keltner Channel.");
+                throw new ArgumentOutOfRangeException(nameof(emaPeriod), emaPeriod,
+                    "EMA period must be greater than 1 for Keltner Channel.");
             }
 
             if (atrPeriod <= 1)
             {
-                throw new BadParameterException("ATR period must be greater than 1 for Keltner Channel.");
+                throw new ArgumentOutOfRangeException(nameof(atrPeriod), atrPeriod,
+                    "ATR period must be greater than 1 for Keltner Channel.");
             }
 
             if (multiplier <= 0)
             {
-                throw new BadParameterException("Multiplier must be greater than 0 for Keltner Channel.");
+                throw new ArgumentOutOfRangeException(nameof(multiplier), multiplier,
+                    "Multiplier must be greater than 0 for Keltner Channel.");
             }
 
             // check history
@@ -78,13 +81,15 @@ namespace Skender.Stock.Indicators
             int minHistory = Math.Max(2 * lookbackPeriod, lookbackPeriod + 100);
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for Keltner Channel.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.  "
-                          + "Since this uses a smoothing technique, for a lookback period of {2}, "
-                          + "we recommend you use at least {3} data points prior to the intended "
-                          + "usage date for maximum precision.",
-                          qtyHistory, minHistory, lookbackPeriod, lookbackPeriod + 250));
+                string message = "Insufficient history provided for Keltner Channel.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.  "
+                    + "Since this uses a smoothing technique, for a lookback period of {2}, "
+                    + "we recommend you use at least {3} data points prior to the intended "
+                    + "usage date for maximum precision.",
+                    qtyHistory, minHistory, lookbackPeriod, lookbackPeriod + 250);
+
+                throw new BadHistoryException(nameof(history), message);
             }
         }
 

--- a/indicators/Macd/Macd.cs
+++ b/indicators/Macd/Macd.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Skender.Stock.Indicators
@@ -76,23 +77,27 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (fastPeriod <= 0)
             {
-                throw new BadParameterException("Fast period must be greater than 0 for MACD.");
+                throw new ArgumentOutOfRangeException(nameof(fastPeriod), fastPeriod,
+                    "Fast period must be greater than 0 for MACD.");
             }
 
             if (slowPeriod <= 0)
             {
-                throw new BadParameterException("Slow period must be greater than 0 for MACD.");
+                throw new ArgumentOutOfRangeException(nameof(slowPeriod), slowPeriod,
+                    "Slow period must be greater than 0 for MACD.");
             }
 
             if (signalPeriod < 0)
             {
-                throw new BadParameterException("Signal period must be greater than or equal to 0 for MACD.");
+                throw new ArgumentOutOfRangeException(nameof(signalPeriod), signalPeriod,
+                    "Signal period must be greater than or equal to 0 for MACD.");
             }
 
 
             if (slowPeriod < fastPeriod)
             {
-                throw new BadParameterException("Fast period must be smaller than the slow period for MACD.");
+                throw new ArgumentOutOfRangeException(nameof(fastPeriod), fastPeriod,
+                    "Fast period must be smaller than the slow period for MACD.");
             }
 
             // check history
@@ -100,12 +105,14 @@ namespace Skender.Stock.Indicators
             int minHistory = 2 * slowPeriod + signalPeriod;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for MACD.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.  "
-                          + "Since this uses a smoothing technique, "
-                          + "we recommend you use at least 250 data points prior to the intended "
-                          + "usage date for maximum precision.", qtyHistory, minHistory));
+                string message = "Insufficient history provided for MACD.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.  "
+                    + "Since this uses a smoothing technique, "
+                    + "we recommend you use at least 250 data points prior to the intended "
+                    + "usage date for maximum precision.", qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
 
         }

--- a/indicators/Mfi/Mfi.cs
+++ b/indicators/Mfi/Mfi.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Skender.Stock.Indicators
@@ -98,7 +99,8 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (lookbackPeriod <= 1)
             {
-                throw new BadParameterException("Lookback period must be greater than 1 for MFI.");
+                throw new ArgumentOutOfRangeException(nameof(lookbackPeriod), lookbackPeriod,
+                    "Lookback period must be greater than 1 for MFI.");
             }
 
             // check history
@@ -106,10 +108,12 @@ namespace Skender.Stock.Indicators
             int minHistory = lookbackPeriod + 1;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for Money Flow Index.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                        qtyHistory, minHistory));
+                string message = "Insufficient history provided for Money Flow Index.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
 
         }

--- a/indicators/Obv/Obv.cs
+++ b/indicators/Obv/Obv.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Skender.Stock.Indicators
@@ -69,7 +70,8 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (smaPeriod != null && smaPeriod <= 0)
             {
-                throw new BadParameterException("SMA period must be greater than 0 for ADL.");
+                throw new ArgumentOutOfRangeException(nameof(smaPeriod), smaPeriod,
+                    "SMA period must be greater than 0 for ADL.");
             }
 
             // check history
@@ -77,10 +79,12 @@ namespace Skender.Stock.Indicators
             int minHistory = 2;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for On-balance Volume.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                        qtyHistory, minHistory));
+                string message = "Insufficient history provided for On-balance Volume.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
 
         }

--- a/indicators/ParabolicSar/ParabolicSar.cs
+++ b/indicators/ParabolicSar/ParabolicSar.cs
@@ -160,17 +160,23 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (accelerationStep <= 0)
             {
-                throw new BadParameterException("Acceleration Step must be greater than 0 for Parabolic SAR.");
+                throw new ArgumentOutOfRangeException(nameof(accelerationStep), accelerationStep,
+                    "Acceleration Step must be greater than 0 for Parabolic SAR.");
             }
 
             if (maxAccelerationFactor <= 0)
             {
-                throw new BadParameterException("Max Acceleration Factor must be greater than 0 for Parabolic SAR.");
+                throw new ArgumentOutOfRangeException(nameof(maxAccelerationFactor), maxAccelerationFactor,
+                    "Max Acceleration Factor must be greater than 0 for Parabolic SAR.");
             }
 
             if (accelerationStep > maxAccelerationFactor)
             {
-                throw new BadParameterException("Acceleration Step must be smaller than Max Accleration Factor for Parabolic SAR.");
+                string message = string.Format(englishCulture,
+                    "Acceleration Step must be smaller than provided Max Accleration Factor ({0}) for Parabolic SAR.",
+                    maxAccelerationFactor);
+
+                throw new ArgumentOutOfRangeException(nameof(accelerationStep), accelerationStep, message);
             }
 
             // check history
@@ -178,10 +184,12 @@ namespace Skender.Stock.Indicators
             int minHistory = 2;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for Parabolic SAR.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                        qtyHistory, minHistory));
+                string message = "Insufficient history provided for Parabolic SAR.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
 
         }

--- a/indicators/Pmo/Pmo.cs
+++ b/indicators/Pmo/Pmo.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Skender.Stock.Indicators
@@ -148,17 +149,20 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (timePeriod <= 1)
             {
-                throw new BadParameterException("Time period must be greater than 1 for PMO.");
+                throw new ArgumentOutOfRangeException(nameof(timePeriod), timePeriod,
+                    "Time period must be greater than 1 for PMO.");
             }
 
             if (smoothingPeriod <= 0)
             {
-                throw new BadParameterException("Smoothing period must be greater than 0 for PMO.");
+                throw new ArgumentOutOfRangeException(nameof(smoothingPeriod), smoothingPeriod,
+                    "Smoothing period must be greater than 0 for PMO.");
             }
 
             if (signalPeriod <= 0)
             {
-                throw new BadParameterException("Signal period must be greater than 0 for PMO.");
+                throw new ArgumentOutOfRangeException(nameof(signalPeriod), signalPeriod,
+                    "Signal period must be greater than 0 for PMO.");
             }
 
             // check history
@@ -166,13 +170,15 @@ namespace Skender.Stock.Indicators
             int minHistory = timePeriod + smoothingPeriod;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for PMO.  " +
-                       string.Format(englishCulture,
-                       "You provided {0} periods of history when at least {1} is required.  "
-                         + "Since this uses a several smoothing operations, "
-                         + "we recommend you use at least {2} data points prior to the intended "
-                         + "usage date for maximum precision.",
-                         qtyHistory, minHistory, minHistory + signalPeriod + 250));
+                string message = "Insufficient history provided for PMO.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.  "
+                    + "Since this uses a several smoothing operations, "
+                    + "we recommend you use at least {2} data points prior to the intended "
+                    + "usage date for maximum precision.",
+                    qtyHistory, minHistory, minHistory + signalPeriod + 250);
+
+                throw new BadHistoryException(nameof(history), message);
             }
 
         }

--- a/indicators/Prs/Prs.cs
+++ b/indicators/Prs/Prs.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Skender.Stock.Indicators
@@ -28,7 +29,7 @@ namespace Skender.Stock.Indicators
 
                 if (ei.Date != bi.Date)
                 {
-                    throw new BadHistoryException(
+                    throw new BadHistoryException(nameof(historyEval), ei.Date,
                         "Date sequence does not match.  Price Relative requires matching dates in provided histories.");
                 }
 
@@ -79,12 +80,14 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (lookbackPeriod != null && lookbackPeriod <= 0)
             {
-                throw new BadParameterException("Lookback period must be greater than 0 for Price Relative Strength.");
+                throw new ArgumentOutOfRangeException(nameof(lookbackPeriod), lookbackPeriod,
+                    "Lookback period must be greater than 0 for Price Relative Strength.");
             }
 
             if (smaPeriod != null && smaPeriod <= 0)
             {
-                throw new BadParameterException("SMA period must be greater than 0 for Price Relative Strength.");
+                throw new ArgumentOutOfRangeException(nameof(smaPeriod), smaPeriod,
+                    "SMA period must be greater than 0 for Price Relative Strength.");
             }
 
             // check history
@@ -95,15 +98,17 @@ namespace Skender.Stock.Indicators
             int? minHistory = lookbackPeriod;
             if (minHistory != null && qtyHistoryEval < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for Price Relative Strength.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                        qtyHistoryEval, minHistory));
+                string message = "Insufficient history provided for Price Relative Strength.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistoryEval, minHistory);
+
+                throw new BadHistoryException(nameof(historyEval), message);
             }
 
             if (qtyHistoryBase != qtyHistoryEval)
             {
-                throw new BadHistoryException(
+                throw new BadHistoryException(nameof(historyBase),
                     "Base history should have at least as many records as Eval history for Price Relative.");
             }
 

--- a/indicators/Roc/Roc.cs
+++ b/indicators/Roc/Roc.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Skender.Stock.Indicators
@@ -61,12 +62,14 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (lookbackPeriod <= 0)
             {
-                throw new BadParameterException("Lookback period must be greater than 0 for ROC.");
+                throw new ArgumentOutOfRangeException(nameof(lookbackPeriod), lookbackPeriod,
+                    "Lookback period must be greater than 0 for ROC.");
             }
 
             if (smaPeriod != null && smaPeriod <= 0)
             {
-                throw new BadParameterException("SMA period must be greater than 0 for ROC.");
+                throw new ArgumentOutOfRangeException(nameof(smaPeriod), smaPeriod,
+                    "SMA period must be greater than 0 for ROC.");
             }
 
             // check history
@@ -74,10 +77,12 @@ namespace Skender.Stock.Indicators
             int minHistory = lookbackPeriod + 1;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for ROC.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                        qtyHistory, minHistory));
+                string message = "Insufficient history provided for ROC.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
 
         }

--- a/indicators/Rsi/Rsi.cs
+++ b/indicators/Rsi/Rsi.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Skender.Stock.Indicators
@@ -87,26 +88,29 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateRsi(IEnumerable<BasicData> basicData, int lookbackPeriod)
+        private static void ValidateRsi(IEnumerable<BasicData> history, int lookbackPeriod)
         {
 
             // check parameters
             if (lookbackPeriod < 1)
             {
-                throw new BadParameterException("Lookback period must be greater than 0 for RSI.");
+                throw new ArgumentOutOfRangeException(nameof(lookbackPeriod), lookbackPeriod,
+                    "Lookback period must be greater than 0 for RSI.");
             }
 
             // check history
-            int qtyHistory = basicData.Count();
+            int qtyHistory = history.Count();
             int minHistory = lookbackPeriod;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for RSI.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.  "
-                          + "Since this uses a smoothing technique, "
-                          + "we recommend you use at least 250 data points prior to the intended "
-                          + "usage date for maximum precision.", qtyHistory, minHistory));
+                string message = "Insufficient history provided for RSI.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.  "
+                    + "Since this uses a smoothing technique, "
+                    + "we recommend you use at least 250 data points prior to the intended "
+                    + "usage date for maximum precision.", qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
         }
     }

--- a/indicators/Slope/Slope.cs
+++ b/indicators/Slope/Slope.cs
@@ -103,7 +103,8 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (lookbackPeriod <= 0)
             {
-                throw new BadParameterException("Lookback period must be greater than 0 for Slope/Linear Regression.");
+                throw new ArgumentOutOfRangeException(nameof(lookbackPeriod), lookbackPeriod,
+                    "Lookback period must be greater than 0 for Slope/Linear Regression.");
             }
 
             // check history
@@ -111,10 +112,12 @@ namespace Skender.Stock.Indicators
             int minHistory = lookbackPeriod;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for Slope/Linear Regression.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                        qtyHistory, minHistory));
+                string message = "Insufficient history provided for Slope/Linear Regression.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
         }
     }

--- a/indicators/Sma/Sma.cs
+++ b/indicators/Sma/Sma.cs
@@ -81,7 +81,8 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (lookbackPeriod <= 0)
             {
-                throw new BadParameterException("Lookback period must be greater than 0 for SMA.");
+                throw new ArgumentOutOfRangeException(nameof(lookbackPeriod), lookbackPeriod,
+                    "Lookback period must be greater than 0 for SMA.");
             }
 
             // check history
@@ -89,10 +90,12 @@ namespace Skender.Stock.Indicators
             int minHistory = lookbackPeriod;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for SMA.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                        qtyHistory, minHistory));
+                string message = "Insufficient history provided for SMA.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
 
         }

--- a/indicators/StdDev/StdDev.cs
+++ b/indicators/StdDev/StdDev.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Skender.Stock.Indicators
@@ -62,7 +63,7 @@ namespace Skender.Stock.Indicators
                 results.Add(result);
 
                 // optional SMA
-                if (smaPeriod != null && bd.Index >= lookbackPeriod + smaPeriod-1)
+                if (smaPeriod != null && bd.Index >= lookbackPeriod + smaPeriod - 1)
                 {
                     decimal sumSma = 0m;
                     for (int p = (int)bd.Index - (int)smaPeriod; p < bd.Index; p++)
@@ -78,30 +79,35 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateStdDev(IEnumerable<BasicData> basicData, int lookbackPeriod, int? smaPeriod)
+        private static void ValidateStdDev(IEnumerable<BasicData> history, int lookbackPeriod, int? smaPeriod)
         {
 
             // check parameters
             if (lookbackPeriod <= 1)
             {
-                throw new BadParameterException("Lookback period must be greater than 1 for Standard Deviation.");
+                throw new ArgumentOutOfRangeException(nameof(lookbackPeriod), lookbackPeriod,
+                    "Lookback period must be greater than 1 for Standard Deviation.");
             }
 
             if (smaPeriod != null && smaPeriod <= 0)
             {
-                throw new BadParameterException("SMA period must be greater than 0 for Standard Deviation.");
+                throw new ArgumentOutOfRangeException(nameof(smaPeriod), smaPeriod,
+                    "SMA period must be greater than 0 for Standard Deviation.");
             }
 
             // check history
-            int qtyHistory = basicData.Count();
+            int qtyHistory = history.Count();
             int minHistory = lookbackPeriod;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for Standard Deviation.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                        qtyHistory, minHistory));
+                string message = "Insufficient history provided for Standard Deviation.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
+
         }
     }
 

--- a/indicators/Stoch/Stoch.cs
+++ b/indicators/Stoch/Stoch.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Skender.Stock.Indicators
@@ -135,17 +136,20 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (lookbackPeriod <= 0)
             {
-                throw new BadParameterException("Lookback period must be greater than 0 for Stochastic.");
+                throw new ArgumentOutOfRangeException(nameof(lookbackPeriod), lookbackPeriod,
+                    "Lookback period must be greater than 0 for Stochastic.");
             }
 
             if (signalPeriod <= 0)
             {
-                throw new BadParameterException("Signal period must be greater than 0 for Stochastic.");
+                throw new ArgumentOutOfRangeException(nameof(signalPeriod), signalPeriod,
+                    "Signal period must be greater than 0 for Stochastic.");
             }
 
             if (smoothPeriod <= 0)
             {
-                throw new BadParameterException("Smooth period must be greater than 0 for Stochastic.");
+                throw new ArgumentOutOfRangeException(nameof(smoothPeriod), smoothPeriod,
+                    "Smooth period must be greater than 0 for Stochastic.");
             }
 
             // check history
@@ -153,10 +157,12 @@ namespace Skender.Stock.Indicators
             int minHistory = lookbackPeriod + smoothPeriod;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for Stochastic.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                        qtyHistory, minHistory));
+                string message = "Insufficient history provided for Stochastic.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
         }
     }

--- a/indicators/StochRsi/StochRsi.cs
+++ b/indicators/StochRsi/StochRsi.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Skender.Stock.Indicators
@@ -71,22 +72,26 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (rsiPeriod <= 0)
             {
-                throw new BadParameterException("RSI period must be greater than 0 for Stochastic RSI.");
+                throw new ArgumentOutOfRangeException(nameof(rsiPeriod), rsiPeriod,
+                    "RSI period must be greater than 0 for Stochastic RSI.");
             }
 
             if (stochPeriod <= 0)
             {
-                throw new BadParameterException("STOCH period must be greater than 0 for Stochastic RSI.");
+                throw new ArgumentOutOfRangeException(nameof(stochPeriod), stochPeriod,
+                    "STOCH period must be greater than 0 for Stochastic RSI.");
             }
 
             if (signalPeriod <= 0)
             {
-                throw new BadParameterException("Signal period must be greater than 0 for Stochastic RSI.");
+                throw new ArgumentOutOfRangeException(nameof(signalPeriod), signalPeriod,
+                    "Signal period must be greater than 0 for Stochastic RSI.");
             }
 
             if (smoothPeriod <= 0)
             {
-                throw new BadParameterException("Smooth period must be greater than 0 for Stochastic RSI.");
+                throw new ArgumentOutOfRangeException(nameof(smoothPeriod), smoothPeriod,
+                    "Smooth period must be greater than 0 for Stochastic RSI.");
             }
 
             // check history
@@ -94,10 +99,12 @@ namespace Skender.Stock.Indicators
             int minHistory = rsiPeriod + stochPeriod;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for Stochastic RSI.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                        qtyHistory, minHistory));
+                string message = "Insufficient history provided for Stochastic RSI.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
         }
     }

--- a/indicators/Trix/Trix.cs
+++ b/indicators/Trix/Trix.cs
@@ -82,27 +82,30 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateTrix(IEnumerable<BasicData> basicData, int lookbackPeriod)
+        private static void ValidateTrix(IEnumerable<BasicData> history, int lookbackPeriod)
         {
 
             // check parameters
             if (lookbackPeriod <= 0)
             {
-                throw new BadParameterException("Lookback period must be greater than 0 for TRIX.");
+                throw new ArgumentOutOfRangeException(nameof(lookbackPeriod), lookbackPeriod,
+                    "Lookback period must be greater than 0 for TRIX.");
             }
 
             // check history
-            int qtyHistory = basicData.Count();
+            int qtyHistory = history.Count();
             int minHistory = Math.Max(4 * lookbackPeriod, 3 * lookbackPeriod + 100);
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for TRIX.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.  "
-                          + "Since this uses a smoothing technique, for a lookback period of {2}, "
-                          + "we recommend you use at least {3} data points prior to the intended "
-                          + "usage date for maximum precision.",
-                          qtyHistory, minHistory, lookbackPeriod, 3 * lookbackPeriod + 250));
+                string message = "Insufficient history provided for TRIX.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.  "
+                    + "Since this uses a smoothing technique, for a lookback period of {2}, "
+                    + "we recommend you use at least {3} data points prior to the intended "
+                    + "usage date for maximum precision.",
+                    qtyHistory, minHistory, lookbackPeriod, 3 * lookbackPeriod + 250);
+
+                throw new BadHistoryException(nameof(history), message);
             }
 
         }

--- a/indicators/UlcerIndex/Ulcer.cs
+++ b/indicators/UlcerIndex/Ulcer.cs
@@ -66,7 +66,8 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (lookbackPeriod <= 0)
             {
-                throw new BadParameterException("Lookback period must be greater than 0 for Ulcer Index.");
+                throw new ArgumentOutOfRangeException(nameof(lookbackPeriod), lookbackPeriod,
+                    "Lookback period must be greater than 0 for Ulcer Index.");
             }
 
             // check history
@@ -74,10 +75,12 @@ namespace Skender.Stock.Indicators
             int minHistory = lookbackPeriod;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for Ulcer Index.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                        qtyHistory, minHistory));
+                string message = "Insufficient history provided for Ulcer Index.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
 
         }

--- a/indicators/Ultimate/Ultimate.cs
+++ b/indicators/Ultimate/Ultimate.cs
@@ -93,12 +93,14 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (shortPeriod <= 0 || middleAverage <= 0 || longPeriod <= 0)
             {
-                throw new BadParameterException("Average periods must be greater than 0 for Ultimate Oscillator.");
+                throw new ArgumentOutOfRangeException(nameof(longPeriod), longPeriod,
+                    "Average periods must be greater than 0 for Ultimate Oscillator.");
             }
 
             if (shortPeriod >= middleAverage || middleAverage >= longPeriod)
             {
-                throw new BadParameterException("Average periods must be increasingly larger than each other for Ultimate Oscillator.");
+                throw new ArgumentOutOfRangeException(nameof(middleAverage), middleAverage,
+                    "Average periods must be increasingly larger than each other for Ultimate Oscillator.");
             }
 
             // check history
@@ -106,10 +108,12 @@ namespace Skender.Stock.Indicators
             int minHistory = longPeriod + 1;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for Ultimate.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                        qtyHistory, minHistory));
+                string message = "Insufficient history provided for Ultimate.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
 
         }

--- a/indicators/VolSma/VolSma.cs
+++ b/indicators/VolSma/VolSma.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Skender.Stock.Indicators
@@ -28,7 +29,7 @@ namespace Skender.Stock.Indicators
                 VolSmaResult h = results[i];
 
                 decimal sumVolSma = 0m;
-                for (int p = (int)h.Index - lookbackPeriod; p < h.Index; p++)
+                for (int p = h.Index - lookbackPeriod; p < h.Index; p++)
                 {
                     VolSmaResult q = results[p];
                     sumVolSma += q.Volume;
@@ -47,7 +48,8 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (lookbackPeriod <= 0)
             {
-                throw new BadParameterException("Lookback period must be greater than 0 for VolSma.");
+                throw new ArgumentOutOfRangeException(nameof(lookbackPeriod), lookbackPeriod,
+                    "Lookback period must be greater than 0 for VolSma.");
             }
 
             // check history
@@ -55,10 +57,12 @@ namespace Skender.Stock.Indicators
             int minHistory = lookbackPeriod;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for VolSma.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                        qtyHistory, minHistory));
+                string message = "Insufficient history provided for VolSma.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
 
         }

--- a/indicators/WilliamsR/WilliamsR.cs
+++ b/indicators/WilliamsR/WilliamsR.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Skender.Stock.Indicators
@@ -33,7 +34,8 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (lookbackPeriod <= 0)
             {
-                throw new BadParameterException("Lookback period must be greater than 0 for William %R.");
+                throw new ArgumentOutOfRangeException(nameof(lookbackPeriod), lookbackPeriod,
+                    "Lookback period must be greater than 0 for William %R.");
             }
 
             // check history
@@ -41,10 +43,12 @@ namespace Skender.Stock.Indicators
             int minHistory = lookbackPeriod;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for William %R.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                        qtyHistory, minHistory));
+                string message = "Insufficient history provided for William %R.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
         }
     }

--- a/indicators/Wma/Wma.cs
+++ b/indicators/Wma/Wma.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Skender.Stock.Indicators
@@ -55,7 +56,8 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (lookbackPeriod <= 0)
             {
-                throw new BadParameterException("Lookback period must be greater than 0 for WMA.");
+                throw new ArgumentOutOfRangeException(nameof(lookbackPeriod), lookbackPeriod,
+                    "Lookback period must be greater than 0 for WMA.");
             }
 
             // check history
@@ -63,10 +65,12 @@ namespace Skender.Stock.Indicators
             int minHistory = lookbackPeriod;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for WMA.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                        qtyHistory, minHistory));
+                string message = "Insufficient history provided for WMA.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
 
         }

--- a/indicators/ZigZag/ZigZag.cs
+++ b/indicators/ZigZag/ZigZag.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Skender.Stock.Indicators
@@ -290,7 +291,8 @@ namespace Skender.Stock.Indicators
             // check parameters
             if (percentChange <= 0)
             {
-                throw new BadParameterException("Percent change must be greater than 0 for ZIGZAG.");
+                throw new ArgumentOutOfRangeException(nameof(percentChange), percentChange,
+                    "Percent change must be greater than 0 for ZIGZAG.");
             }
 
             // check histor
@@ -298,10 +300,12 @@ namespace Skender.Stock.Indicators
             int minHistory = 2;
             if (qtyHistory < minHistory)
             {
-                throw new BadHistoryException("Insufficient history provided for ZIGZAG.  " +
-                        string.Format(englishCulture,
-                        "You provided {0} periods of history when at least {1} is required.",
-                        qtyHistory, minHistory));
+                string message = "Insufficient history provided for ZIGZAG.  " +
+                    string.Format(englishCulture,
+                    "You provided {0} periods of history when at least {1} is required.",
+                    qtyHistory, minHistory);
+
+                throw new BadHistoryException(nameof(history), message);
             }
 
         }

--- a/indicators/_Common/Cleaners.cs
+++ b/indicators/_Common/Cleaners.cs
@@ -20,7 +20,7 @@ namespace Skender.Stock.Indicators
 
             if (historyList == null || historyList.Count == 0)
             {
-                throw new BadHistoryException("No historical quotes provided.");
+                throw new BadHistoryException(nameof(history), "No historical quotes provided.");
             }
 
             // return if already processed (no missing indexes)
@@ -67,15 +67,15 @@ namespace Skender.Stock.Indicators
         }
 
 
-        internal static List<BasicData> PrepareBasicData(IEnumerable<BasicData> basicData)
+        internal static List<BasicData> PrepareBasicData(IEnumerable<BasicData> history)
         {
             // we cannot rely on date consistency when looking back, so we add an index and sort
 
-            List<BasicData> bdList = basicData?.OrderBy(x => x.Date).ToList();
+            List<BasicData> bdList = history?.OrderBy(x => x.Date).ToList();
 
             if (bdList == null || bdList.Count == 0)
             {
-                throw new BadHistoryException("No historical quotes provided.");
+                throw new BadHistoryException(nameof(history), "No historical quotes provided.");
             }
 
             // return if already processed (no missing indexes)

--- a/indicators/_Common/Exceptions.cs
+++ b/indicators/_Common/Exceptions.cs
@@ -1,32 +1,32 @@
 ﻿using System;
 using System.Runtime.Serialization;
 
+#nullable enable
+
 namespace Skender.Stock.Indicators
 {
     // ref: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/exceptions/creating-and-throwing-exceptions#defining-exception-classes
 
     [Serializable()]
-    public class BadHistoryException : Exception
+    public class BadHistoryException : ArgumentOutOfRangeException
     {
         public BadHistoryException() { }
-        public BadHistoryException(string message) : base(message) { }
-        public BadHistoryException(string message, Exception innerException) : base(message, innerException) { }
+
+        public BadHistoryException(string? paramName)
+            : base(paramName) { }
+
+        public BadHistoryException(string? message, Exception? innerException)
+            : base(message, innerException) { }
+
+        public BadHistoryException(string? paramName, string? message)
+            : base(paramName, message) { }
+
+        public BadHistoryException(string? paramName, object? actualValue, string? message)
+            : base(paramName, actualValue, message) { }
 
         // A constructor is needed for serialization when an
         // exception propagates from a remoting server to the client. 
-        protected BadHistoryException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+        protected BadHistoryException(SerializationInfo info, StreamingContext context)
+            : base(info, context) { }
     }
-
-    [Serializable()]
-    public class BadParameterException : Exception
-    {
-        public BadParameterException() { }
-        public BadParameterException(string message) : base(message) { }
-        public BadParameterException(string message, Exception innerException) : base(message, innerException) { }
-
-        // A constructor is needed for serialization when an
-        // exception propagates from a remoting server to the client. 
-        protected BadParameterException(SerializationInfo info, StreamingContext context) : base(info, context) { }
-    }
-
 }

--- a/indicators/_Common/Exceptions.cs
+++ b/indicators/_Common/Exceptions.cs
@@ -5,7 +5,6 @@ using System.Runtime.Serialization;
 
 namespace Skender.Stock.Indicators
 {
-    // ref: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/exceptions/creating-and-throwing-exceptions#defining-exception-classes
 
     [Serializable()]
     public class BadHistoryException : ArgumentOutOfRangeException

--- a/tests/indicators/Test.Adl.cs
+++ b/tests/indicators/Test.Adl.cs
@@ -60,7 +60,7 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad SMA period.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad SMA period.")]
         public void BadSmaPeriod()
         {
             Indicator.GetAdl(history, 0);

--- a/tests/indicators/Test.Adx.cs
+++ b/tests/indicators/Test.Adx.cs
@@ -49,8 +49,8 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback period.")]
-        public void BadLookback()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad lookback period.")]
+        public void BadLookbackPeriod()
         {
             Indicator.GetAdx(history, 1);
         }
@@ -59,7 +59,7 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetAdx(history.Where(x => x.Index < 210), 30);
+            Indicator.GetAdx(history.Where(x => x.Index < 160), 30);
         }
 
     }

--- a/tests/indicators/Test.Aroon.cs
+++ b/tests/indicators/Test.Aroon.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Skender.Stock.Indicators;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -55,8 +56,8 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback period.")]
-        public void BadLookback()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad lookback period.")]
+        public void BadLookbackPeriod()
         {
             Indicator.GetAroon(history, 0);
         }

--- a/tests/indicators/Test.Atr.cs
+++ b/tests/indicators/Test.Atr.cs
@@ -34,8 +34,8 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback.")]
-        public void BadLookback()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad lookback.")]
+        public void BadLookbackPeriod()
         {
             Indicator.GetAtr(history, 1);
         }

--- a/tests/indicators/Test.Beta.cs
+++ b/tests/indicators/Test.Beta.cs
@@ -52,8 +52,8 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback.")]
-        public void BadLookback()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad lookback.")]
+        public void BadLookbackPeriod()
         {
             Indicator.GetBeta(history, historyOther, 0);
         }

--- a/tests/indicators/Test.BollingerBands.cs
+++ b/tests/indicators/Test.BollingerBands.cs
@@ -54,14 +54,14 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback period.")]
-        public void BadLookback()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad lookback period.")]
+        public void BadLookbackPeriod()
         {
             Indicator.GetBollingerBands(history, 1);
         }
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad standard deviations.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad standard deviations.")]
         public void InsufficientStandardDeviations()
         {
             Indicator.GetBollingerBands(history, 2, 0);

--- a/tests/indicators/Test.Cci.cs
+++ b/tests/indicators/Test.Cci.cs
@@ -33,8 +33,8 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback period.")]
-        public void BadLookback()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad lookback period.")]
+        public void BadLookbackPeriod()
         {
             Indicator.GetCci(history, 0);
         }

--- a/tests/indicators/Test.ChaikinOsc.cs
+++ b/tests/indicators/Test.ChaikinOsc.cs
@@ -36,14 +36,14 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad fast lookback.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad fast lookback.")]
         public void BadFastLookback()
         {
             Indicator.GetChaikinOsc(history, 0);
         }
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad slow lookback.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad slow lookback.")]
         public void BadSlowLookback()
         {
             Indicator.GetChaikinOsc(history, 10, 5);

--- a/tests/indicators/Test.Chandelier.cs
+++ b/tests/indicators/Test.Chandelier.cs
@@ -41,14 +41,14 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback period.")]
-        public void BadLookback()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad lookback period.")]
+        public void BadLookbackPeriod()
         {
             Indicator.GetChandelier(history, 0);
         }
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad multiplier.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad multiplier.")]
         public void BadMultiplier()
         {
             Indicator.GetChandelier(history, 25, 0);

--- a/tests/indicators/Test.Cmf.cs
+++ b/tests/indicators/Test.Cmf.cs
@@ -47,8 +47,8 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback.")]
-        public void BadLookback()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad lookback.")]
+        public void BadLookbackPeriod()
         {
             Indicator.GetCmf(history, 0);
         }

--- a/tests/indicators/Test.ConnorsRsi.cs
+++ b/tests/indicators/Test.ConnorsRsi.cs
@@ -48,22 +48,22 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad RSI period.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad RSI period.")]
         public void BadRsiPeriod()
         {
             Indicator.GetConnorsRsi(history, 1, 2, 100);
         }
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad Streak period.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad Streak period.")]
         public void BadStreakPeriod()
         {
             Indicator.GetConnorsRsi(history, 3, 1, 100);
         }
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad Rank period.")]
-        public void BadPctRankPeriods()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad Rank period.")]
+        public void BadPctRankPeriod()
         {
             Indicator.GetConnorsRsi(history, 3, 2, 1);
         }

--- a/tests/indicators/Test.Correlation.cs
+++ b/tests/indicators/Test.Correlation.cs
@@ -32,8 +32,8 @@ namespace Internal.Tests
 
         /* EXCEPTIONS */
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback.")]
-        public void BadLookback()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad lookback.")]
+        public void BadLookbackPeriod()
         {
             Indicator.GetCorrelation(history, historyOther, 0);
         }

--- a/tests/indicators/Test.Donchian.cs
+++ b/tests/indicators/Test.Donchian.cs
@@ -44,8 +44,8 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback period.")]
-        public void BadLookback()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad lookback period.")]
+        public void BadLookbackPeriod()
         {
             Indicator.GetDonchian(history, 1);
         }

--- a/tests/indicators/Test.DoubleEma.cs
+++ b/tests/indicators/Test.DoubleEma.cs
@@ -38,8 +38,8 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback.")]
-        public void BadLookback()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad lookback.")]
+        public void BadLookbackPeriod()
         {
             Indicator.GetDoubleEma(history, 0);
         }

--- a/tests/indicators/Test.Ema.cs
+++ b/tests/indicators/Test.Ema.cs
@@ -38,8 +38,8 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback.")]
-        public void BadLookback()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad lookback.")]
+        public void BadLookbackPeriod()
         {
             Indicator.GetEma(history, 0);
         }

--- a/tests/indicators/Test.Hma.cs
+++ b/tests/indicators/Test.Hma.cs
@@ -40,8 +40,8 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback.")]
-        public void BadLookback()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad lookback.")]
+        public void BadLookbackPeriod()
         {
             Indicator.GetHma(history, 0);
         }

--- a/tests/indicators/Test.Ichimoku.cs
+++ b/tests/indicators/Test.Ichimoku.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Skender.Stock.Indicators;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -50,21 +51,21 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad signal period.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad signal period.")]
         public void BadSignalPeriod()
         {
             Indicator.GetIchimoku(history, 0);
         }
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad short span period.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad short span period.")]
         public void BadShortSpanPeriod()
         {
             Indicator.GetIchimoku(history, 9, 0, 52);
         }
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad long span period.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad long span period.")]
         public void BadLongSpanPeriod()
         {
             Indicator.GetIchimoku(history, 9, 26, 26);

--- a/tests/indicators/Test.Keltner.cs
+++ b/tests/indicators/Test.Keltner.cs
@@ -47,21 +47,21 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad EMA period.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad EMA period.")]
         public void BadEmaPeriod()
         {
             Indicator.GetKeltner(history, 1, 2, 10);
         }
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad ATR period.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad ATR period.")]
         public void BadAtrPeriod()
         {
             Indicator.GetKeltner(history, 20, 2, 1);
         }
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad multiplier.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad multiplier.")]
         public void BadMultiplier()
         {
             Indicator.GetKeltner(history, 20, 0, 10);

--- a/tests/indicators/Test.Macd.cs
+++ b/tests/indicators/Test.Macd.cs
@@ -49,28 +49,28 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Fast period must be greater than 0.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Fast period must be greater than 0.")]
         public void BadFastPeriod()
         {
             Indicator.GetMacd(history, 0, 26, 9);
         }
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Slow period must be greater than 0.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Slow period must be greater than 0.")]
         public void BadSlowPeriod()
         {
             Indicator.GetMacd(history, 12, 0, 9);
         }
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Signal period must be greater than or equal to 0.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Signal period must be greater than or equal to 0.")]
         public void BadSignalPeriod()
         {
             Indicator.GetMacd(history, 12, 26, -1);
         }
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Slow smaller than Fast period.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Slow smaller than Fast period.")]
         public void BadFastAndSlowCombo()
         {
             Indicator.GetMacd(history, 26, 20, 9);

--- a/tests/indicators/Test.Mfi.cs
+++ b/tests/indicators/Test.Mfi.cs
@@ -56,8 +56,8 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback.")]
-        public void BadLookback()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad lookback.")]
+        public void BadLookbackPeriod()
         {
             Indicator.GetMfi(history, 1);
         }

--- a/tests/indicators/Test.Obv.cs
+++ b/tests/indicators/Test.Obv.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Skender.Stock.Indicators;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -53,7 +54,7 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad SMA period.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad SMA period.")]
         public void BadSmaPeriod()
         {
             Indicator.GetObv(history, 0);

--- a/tests/indicators/Test.ParabolicSar.cs
+++ b/tests/indicators/Test.ParabolicSar.cs
@@ -43,21 +43,21 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Acc Step must be greater than 0.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Acc Step must be greater than 0.")]
         public void BadAccelerationStep()
         {
             Indicator.GetParabolicSar(history, 0, 1);
         }
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Max Acc Factor must be greater than 0.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Max Acc Factor must be greater than 0.")]
         public void BadMaxAcclerationFactor()
         {
             Indicator.GetParabolicSar(history, 0.02m, 0);
         }
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Step larger than Factor.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Step larger than Factor.")]
         public void BadParameterCombo()
         {
             Indicator.GetParabolicSar(history, 6, 2);

--- a/tests/indicators/Test.Pmo.cs
+++ b/tests/indicators/Test.Pmo.cs
@@ -37,21 +37,21 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad time period.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad time period.")]
         public void BadTimePeriod()
         {
             Indicator.GetPmo(history, 1);
         }
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad smoothing period.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad smoothing period.")]
         public void BadSmoothingPeriod()
         {
             Indicator.GetPmo(history, 5, 0);
         }
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad signal period.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad signal period.")]
         public void BadSignalPeriod()
         {
             Indicator.GetPmo(history, 5, 5, 0);

--- a/tests/indicators/Test.Prs.cs
+++ b/tests/indicators/Test.Prs.cs
@@ -46,14 +46,14 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback period.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad lookback period.")]
         public void BadLookbackPeriod()
         {
             Indicator.GetPrs(history, historyOther, 0);
         }
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad SMA period.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad SMA period.")]
         public void BadSmaPeriod()
         {
             Indicator.GetPrs(history, historyOther, 14, 0);

--- a/tests/indicators/Test.Roc.cs
+++ b/tests/indicators/Test.Roc.cs
@@ -63,14 +63,14 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback.")]
-        public void BadLookback()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad lookback.")]
+        public void BadLookbackPeriod()
         {
             Indicator.GetRoc(history, 0);
         }
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad SMA period.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad SMA period.")]
         public void BadSmaPeriod()
         {
             Indicator.GetRoc(history, 14, 0);

--- a/tests/indicators/Test.Rsi.cs
+++ b/tests/indicators/Test.Rsi.cs
@@ -53,8 +53,8 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback.")]
-        public void BadLookback()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad lookback.")]
+        public void BadLookbackPeriod()
         {
             Indicator.GetRsi(history, 0);
         }

--- a/tests/indicators/Test.Slope.cs
+++ b/tests/indicators/Test.Slope.cs
@@ -51,8 +51,8 @@ namespace Internal.Tests
 
         /* EXCEPTIONS */
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback.")]
-        public void BadLookback()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad lookback.")]
+        public void BadLookbackPeriod()
         {
             Indicator.GetSlope(history, 0);
         }

--- a/tests/indicators/Test.Sma.cs
+++ b/tests/indicators/Test.Sma.cs
@@ -35,8 +35,8 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback.")]
-        public void BadLookback()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad lookback.")]
+        public void BadLookbackPeriod()
         {
             Indicator.GetSma(history, 0);
         }

--- a/tests/indicators/Test.StdDev.cs
+++ b/tests/indicators/Test.StdDev.cs
@@ -69,14 +69,14 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback.")]
-        public void BadLookback()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad lookback.")]
+        public void BadLookbackPeriod()
         {
             Indicator.GetStdDev(history, 1);
         }
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad SMA period.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad SMA period.")]
         public void BadSmaPeriod()
         {
             Indicator.GetStdDev(history, 14, 0);

--- a/tests/indicators/Test.Stoch.cs
+++ b/tests/indicators/Test.Stoch.cs
@@ -94,21 +94,21 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback.")]
-        public void BadLookback()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad lookback.")]
+        public void BadLookbackPeriod()
         {
             Indicator.GetStoch(history, 0);
         }
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad signal period.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad signal period.")]
         public void BadSignal()
         {
             Indicator.GetStoch(history, 14, 0);
         }
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad smoothing period.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad smoothing period.")]
         public void BadSmooth()
         {
             Indicator.GetStoch(history, 14, 3, 0);

--- a/tests/indicators/Test.StochRsi.cs
+++ b/tests/indicators/Test.StochRsi.cs
@@ -63,28 +63,28 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad RSI lookback.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad RSI lookback.")]
         public void BadRsiLookback()
         {
             Indicator.GetStochRsi(history, 0, 14, 3, 1);
         }
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad STO lookback.")]
-        public void BadLookback()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad STO lookback.")]
+        public void BadLookbackPeriod()
         {
             Indicator.GetStochRsi(history, 14, 0, 3, 3);
         }
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad STO signal period.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad STO signal period.")]
         public void BadSignal()
         {
             Indicator.GetStochRsi(history, 14, 14, 0);
         }
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad STO smoothing period.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad STO smoothing period.")]
         public void BadSmooth()
         {
             Indicator.GetStochRsi(history, 14, 14, 3, 0);

--- a/tests/indicators/Test.TripleEma.cs
+++ b/tests/indicators/Test.TripleEma.cs
@@ -38,8 +38,8 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback.")]
-        public void BadLookback()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad lookback.")]
+        public void BadLookbackPeriod()
         {
             Indicator.GetTripleEma(history, 0);
         }

--- a/tests/indicators/Test.Trix.cs
+++ b/tests/indicators/Test.Trix.cs
@@ -45,8 +45,8 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback.")]
-        public void BadLookback()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad lookback.")]
+        public void BadLookbackPeriod()
         {
             Indicator.GetTrix(history, 0);
         }

--- a/tests/indicators/Test.UlcerIndex.cs
+++ b/tests/indicators/Test.UlcerIndex.cs
@@ -33,8 +33,8 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback.")]
-        public void BadLookback()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad lookback.")]
+        public void BadLookbackPeriod()
         {
             Indicator.GetUlcerIndex(history, 0);
         }

--- a/tests/indicators/Test.Ultimate.cs
+++ b/tests/indicators/Test.Ultimate.cs
@@ -38,21 +38,21 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad short period.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad short period.")]
         public void BadShortPeriod()
         {
             Indicator.GetUltimate(history, 0);
         }
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad middle period.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad middle period.")]
         public void BadMiddlePeriod()
         {
             Indicator.GetUltimate(history, 7, 6);
         }
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad long period.")]
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad long period.")]
         public void BadLongPeriod()
         {
             Indicator.GetUltimate(history, 7, 14, 11);

--- a/tests/indicators/Test.VolSma.cs
+++ b/tests/indicators/Test.VolSma.cs
@@ -40,8 +40,8 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback.")]
-        public void BadLookback()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad lookback.")]
+        public void BadLookbackPeriod()
         {
             Indicator.GetVolSma(history, 0);
         }

--- a/tests/indicators/Test.WilliamsR.cs
+++ b/tests/indicators/Test.WilliamsR.cs
@@ -35,8 +35,8 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback.")]
-        public void BadLookback()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad lookback.")]
+        public void BadLookbackPeriod()
         {
             Indicator.GetWilliamsR(history, 0);
         }

--- a/tests/indicators/Test.Wma.cs
+++ b/tests/indicators/Test.Wma.cs
@@ -35,8 +35,8 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback.")]
-        public void BadLookback()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad lookback.")]
+        public void BadLookbackPeriod()
         {
             Indicator.GetWma(history, 0);
         }

--- a/tests/indicators/Test.ZigZag.cs
+++ b/tests/indicators/Test.ZigZag.cs
@@ -122,8 +122,8 @@ namespace Internal.Tests
         /* EXCEPTIONS */
 
         [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad lookback.")]
-        public void BadLookback()
+        [ExpectedException(typeof(ArgumentOutOfRangeException), "Bad lookback.")]
+        public void BadLookbackPeriod()
         {
             Indicator.GetZigZag(history, ZigZagType.Close, 0);
         }

--- a/tests/indicators/common/Test.Cleaner.cs
+++ b/tests/indicators/common/Test.Cleaner.cs
@@ -123,7 +123,7 @@ namespace Internal.Tests
 
 
         [TestMethod()]
-        public void ResetHistoryTest()
+        public void RemoveHistoryTest()
         {
             // if history post-cleaning, is cut down in size it should not corrupt the results
 
@@ -142,6 +142,12 @@ namespace Internal.Tests
 
             // should not have index after reset
             Assert.IsFalse(h.Where(x => x.Index != null).Any());
+
+            // test for null handling
+            h = null;
+            h.RemoveIndex();
+
+            Assert.AreEqual(null, h);
         }
 
 

--- a/tests/indicators/common/Test.Exceptions.cs
+++ b/tests/indicators/common/Test.Exceptions.cs
@@ -8,29 +8,6 @@ namespace Internal.Tests
     public class ExceptionTests : TestBase
     {
 
-        // bad parameter exceptions
-        [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad parameter without message.")]
-        public void BadParameter()
-        {
-            throw new BadParameterException();
-        }
-
-        [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad parameter with message.")]
-        public void BadParameterWithMessage()
-        {
-            throw new BadParameterException("This is a parameter exception.");
-        }
-
-        [TestMethod()]
-        [ExpectedException(typeof(BadParameterException), "Bad parameter with inner Exception.")]
-        public void BadParameterWithInner()
-        {
-            throw new BadParameterException("This has an inner Exception.", new Exception());
-        }
-
-
         // bad history exceptions
         [TestMethod()]
         [ExpectedException(typeof(BadHistoryException), "Bad history without message.")]
@@ -52,6 +29,5 @@ namespace Internal.Tests
         {
             throw new BadHistoryException("This has an inner Exception.", new Exception());
         }
-
     }
 }


### PR DESCRIPTION
- use standard `ArgumentOutOfRangeException` instead of custom `BadParametersException` as it will provide more and better information to the user (developer)
- derive `BadHistoryException` from `ArgumentOutOfRangeException` instead of generic `Exception`

I'm refactoring Exceptions so we're not "reinventing the wheel" with custom variants.  I'm keeping the custom `BadHistoryException` since it's unique to potential issues with data feeds and may need to be [error] handled differently.  Bad arguments provided in other parameters should get the standard `ArgumentOutOfRangeException` since this is something the developer needs to resolve and should not `try/catch` it.  [AB#773](https://dev.azure.com/skender/5123ca47-74f2-4d67-a5d4-c4d90b8d670a/_workitems/edit/773)

- [ ] Wait for resolution of #176 before merging as there may be some different `BadHistoryException` for `history` evaluations.