### PR TITLE
revert bug fix: cut history

### DIFF
--- a/indicators/_Common/Cleaners.cs
+++ b/indicators/_Common/Cleaners.cs
@@ -24,7 +24,7 @@ namespace Skender.Stock.Indicators
             }
 
             // return if already processed (no missing indexes)
-            if (!historyList.Any(x => x.Index == null) && historyList[0].Index == 1)
+            if (!historyList.Any(x => x.Index == null))
             {
                 return historyList;
             }
@@ -79,7 +79,7 @@ namespace Skender.Stock.Indicators
             }
 
             // return if already processed (no missing indexes)
-            if (!bdList.Any(x => x.Index == null) && bdList[0].Index == 1)
+            if (!bdList.Any(x => x.Index == null))
             {
                 return bdList;
             }

--- a/tests/indicators/common/Test.Cleaner.cs
+++ b/tests/indicators/common/Test.Cleaner.cs
@@ -73,53 +73,54 @@ namespace Internal.Tests
         }
 
 
-        [TestMethod()]
-        public void CutHistoryTest()
-        {
-            // if history post-cleaning, is cut down in size it should not corrupt the results
+        //[TestMethod()]
+        //public void CutHistoryTest()
+        //{
+        //    // TODO: remove internal Index, then restore this test
+        //    // if history post-cleaning, is cut down in size it should not corrupt the results
 
-            int i = 0;
-            IEnumerable<Quote> history = History.GetHistory(200);
-            IEnumerable<Quote> h = Cleaners.PrepareHistory(history);
+        //    int i = 0;
+        //    IEnumerable<Quote> history = History.GetHistory(200);
+        //    IEnumerable<Quote> h = Cleaners.PrepareHistory(history);
 
-            // assertions
+        //    // assertions
 
-            // should be 200 periods, initially
-            Assert.AreEqual(200, h.Count());
+        //    // should be 200 periods, initially
+        //    Assert.AreEqual(200, h.Count());
 
-            // should always have index
-            Assert.IsFalse(h.Where(x => x.Index == null || x.Index <= 0).Any());
+        //    // should always have index
+        //    Assert.IsFalse(h.Where(x => x.Index == null || x.Index <= 0).Any());
 
 
-            // should be 20 results and no index corruption
-            IEnumerable<RsiResult> r1 = Indicator.GetRsi(h.TakeLast(20), 14);
-            Assert.AreEqual(20, r1.Count());
+        //    // should be 20 results and no index corruption
+        //    IEnumerable<RsiResult> r1 = Indicator.GetRsi(h.TakeLast(20), 14);
+        //    Assert.AreEqual(20, r1.Count());
 
-            i = 1;
-            foreach (RsiResult x in r1)
-            {
-                Assert.AreEqual(i++, x.Index);
-            }
+        //    i = 1;
+        //    foreach (RsiResult x in r1)
+        //    {
+        //        Assert.AreEqual(i++, x.Index);
+        //    }
 
-            // should be 50 results and no index corruption
-            IEnumerable<RsiResult> r2 = Indicator.GetRsi(h.TakeLast(50), 14);
-            Assert.AreEqual(50, r2.Count());
+        //    // should be 50 results and no index corruption
+        //    IEnumerable<RsiResult> r2 = Indicator.GetRsi(h.TakeLast(50), 14);
+        //    Assert.AreEqual(50, r2.Count());
 
-            i = 1;
-            foreach (RsiResult x in r2)
-            {
-                Assert.AreEqual(i++, x.Index);
-            }
+        //    i = 1;
+        //    foreach (RsiResult x in r2)
+        //    {
+        //        Assert.AreEqual(i++, x.Index);
+        //    }
 
-            // should be original 200 periods and no index corruption, after temp mods
-            Assert.AreEqual(200, h.Count());
+        //    // should be original 200 periods and no index corruption, after temp mods
+        //    Assert.AreEqual(200, h.Count());
 
-            i = 1;
-            foreach(Quote x in h)
-            {
-                Assert.AreEqual(i++, x.Index);
-            }
-        }
+        //    i = 1;
+        //    foreach(Quote x in h)
+        //    {
+        //        Assert.AreEqual(i++, x.Index);
+        //    }
+        //}
 
 
         [TestMethod()]


### PR DESCRIPTION
See #170.  I'm reverting this and refocusing on #180 to resolve this problem.  This original fix is more risky than having an error in this use case.  

**Workaround:**

If you are re-using `history` after manipulating the length, use the `history.RemoveIndex()` extension method to reset it before calling your next indicator method.