### PR TITLE
refactor: remove internal index

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -4,7 +4,7 @@
 - [Prerequisite data](#prerequisite-data)
 - [Example usage](#example-usage)
 - [About historical quotes](#quote)
-- [Pre-cleaning history](#cleaning-history)
+- [Validating history](#validating-history)
 - [Using derived classes](#using-derived-classes)
 - [Generating indicator of indicators](#generating-indicator-of-indicators)
 - [Contributing guidelines](CONTRIBUTING.md)
@@ -59,7 +59,10 @@ Historical quotes should be of consistent time frequency (e.g. per minute, hour,
 | `Close` | decimal | Close price
 | `Volume` | decimal | Volume
 
-See [Pre-cleaning History](#cleaning-history) section below if you want to pre-clean the history (optional).  You can also derive and extend classes (optional), see the [Using derived classes](#using-derived-classes) section below.
+More information:
+
+- See [Validating history](#validating-history) to learn about optional pre-validation your historical data with the `ValidateHistory` helper function.  The indicator methods will re-sort your historical quotes, but it will not check for duplicates and other bad data.  This function will do that, but it is optional as it can impede performance if used in higher frequency applications.
+- See [Using derived classes](#using-derived-classes) to learn how you can extend these classes.
 
 ### Where can I get historical quote data?
 
@@ -73,18 +76,16 @@ Note that some indicators, especially those that are derived from [Exponential M
 
 For example, if you are using daily data and want one year of precise EMA(250) data, you need to provide 3 years of total historical quotes (1 extra year for the lookback period and 1 extra year for convergence); thereafter, you would discard or not use the first two years of results.
 
-## Cleaning history
+## Validating history
 
-Historical quotes are automatically cleaned on every call to the library.  This is needed to do minimal basic data quality checks and to ensure that it is sequenced properly.  **You do not need to pre-clean your historical quotes**; however, there are some scenarios where it may be advantageous.  While the library is quite fast, there is a very small performance cost to cleaning that can add up if you are doing massive bulk operations on a given static `history`, such as computing every indicator or every possible permutation of an indicator.
-
-If you intend to use the same composed `IEnumerable<Quote> history` in multiple calls and want to optimize speed, we recommend you pre-clean it so that it does not perform that operation on every call to the library.  If you pre-clean, the provided `history` will be used as-is without re-cleaning.
+Historical quotes are automatically re-sorted [ascending by date] on every call to the library.  This is needed to ensure that it is sequenced properly.  If you want to do a more advanced check of your `IEnumerable<Quote> history` (historical quotes) you can validate it with the helper cleaner, to check for duplicate dates and other bad data.  This comes at a small performance cost, so we did not automatically include it.
 
 ```csharp
 // fetch historical quotes from your favorite feed, in Quote format
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
-// pre-clean
-history = Cleaners.PrepareHistory(history);
+// advanced cleaning
+List<Quote> validatedHistory = Cleaners.ValidateHistory(history);
 ```
 
 ## Using derived classes

--- a/indicators/Adl/Adl.cs
+++ b/indicators/Adl/Adl.cs
@@ -11,7 +11,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            List<Quote> historyList = Cleaners.PrepareHistory(history).ToList();
+            List<Quote> historyList = history.Sort();
 
             // check parameters
             ValidateAdl(history, smaPeriod);

--- a/indicators/Adl/Adl.cs
+++ b/indicators/Adl/Adl.cs
@@ -11,7 +11,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            history = Cleaners.PrepareHistory(history);
+            List<Quote> historyList = Cleaners.PrepareHistory(history).ToList();
 
             // check parameters
             ValidateAdl(history, smaPeriod);
@@ -21,15 +21,17 @@ namespace Skender.Stock.Indicators
             decimal prevAdl = 0;
 
             // get money flow multiplier
-            foreach (Quote h in history)
+            for (int i = 0; i < historyList.Count; i++)
             {
+                Quote h = historyList[i];
+                int index = i + 1;
+
                 decimal mfm = (h.High == h.Low) ? 0 : ((h.Close - h.Low) - (h.High - h.Close)) / (h.High - h.Low);
                 decimal mfv = mfm * h.Volume;
                 decimal adl = mfv + prevAdl;
 
                 AdlResult result = new AdlResult
                 {
-                    Index = (int)h.Index,
                     Date = h.Date,
                     MoneyFlowMultiplier = mfm,
                     MoneyFlowVolume = mfv,
@@ -40,10 +42,10 @@ namespace Skender.Stock.Indicators
                 prevAdl = adl;
 
                 // optional SMA
-                if (smaPeriod != null && h.Index >= smaPeriod)
+                if (smaPeriod != null && index >= smaPeriod)
                 {
                     decimal sumSma = 0m;
-                    for (int p = (int)h.Index - (int)smaPeriod; p < h.Index; p++)
+                    for (int p = index - (int)smaPeriod; p < index; p++)
                     {
                         sumSma += results[p].Adl;
                     }

--- a/indicators/Adx/Adx.cs
+++ b/indicators/Adx/Adx.cs
@@ -11,7 +11,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            List<Quote> historyList = Cleaners.PrepareHistory(history).ToList();
+            List<Quote> historyList = history.Sort();
 
             // verify parameters
             ValidateAdx(history, lookbackPeriod);

--- a/indicators/Adx/Adx.cs
+++ b/indicators/Adx/Adx.cs
@@ -36,15 +36,15 @@ namespace Skender.Stock.Indicators
             for (int i = 0; i < historyList.Count; i++)
             {
                 Quote h = historyList[i];
+                int index = i + 1;
 
                 AdxResult result = new AdxResult
                 {
-                    Index = (int)h.Index,
                     Date = h.Date
                 };
 
                 // skip first period
-                if (h.Index == 1)
+                if (index == 1)
                 {
                     results.Add(result);
                     prevHigh = h.High;
@@ -60,7 +60,7 @@ namespace Skender.Stock.Indicators
                 prevLow = h.Low;
 
                 // initialization period
-                if (h.Index <= lookbackPeriod + 1)
+                if (index <= lookbackPeriod + 1)
                 {
                     sumTr += tr;
                     sumPdm += pdm1;
@@ -68,7 +68,7 @@ namespace Skender.Stock.Indicators
                 }
 
                 // skip DM initialization period
-                if (h.Index <= lookbackPeriod)
+                if (index <= lookbackPeriod)
                 {
                     results.Add(result);
                     continue;
@@ -80,7 +80,7 @@ namespace Skender.Stock.Indicators
                 decimal pdm;
                 decimal mdm;
 
-                if (h.Index == lookbackPeriod + 1)
+                if (index == lookbackPeriod + 1)
                 {
                     trs = sumTr;
                     pdm = sumPdm;
@@ -110,7 +110,7 @@ namespace Skender.Stock.Indicators
                 // calculate ADX
                 decimal adx;
 
-                if (h.Index > 2 * lookbackPeriod)
+                if (index > 2 * lookbackPeriod)
                 {
                     adx = (prevAdx * (lookbackPeriod - 1) + dx) / lookbackPeriod;
                     result.Adx = adx;
@@ -118,7 +118,7 @@ namespace Skender.Stock.Indicators
                 }
 
                 // initial ADX
-                else if (h.Index == 2 * lookbackPeriod)
+                else if (index == 2 * lookbackPeriod)
                 {
                     sumDx += dx;
                     adx = sumDx / lookbackPeriod;

--- a/indicators/Aroon/Aroon.cs
+++ b/indicators/Aroon/Aroon.cs
@@ -23,40 +23,40 @@ namespace Skender.Stock.Indicators
             for (int i = 0; i < historyList.Count; i++)
             {
                 Quote h = historyList[i];
+                int index = i + 1;
 
                 AroonResult result = new AroonResult
                 {
-                    Index = (int)h.Index,
                     Date = h.Date
                 };
 
                 // add aroons
-                if (h.Index > lookbackPeriod)
+                if (index > lookbackPeriod)
                 {
                     decimal lastHighPrice = 0;
                     decimal lastLowPrice = decimal.MaxValue;
                     int lastHighIndex = 0;
                     int lastLowIndex = 0;
 
-                    for (int p = (int)h.Index - lookbackPeriod - 1; p < h.Index; p++)
+                    for (int p = index - lookbackPeriod - 1; p < index; p++)
                     {
                         Quote d = historyList[p];
 
                         if (d.High > lastHighPrice)
                         {
                             lastHighPrice = d.High;
-                            lastHighIndex = (int)d.Index;
+                            lastHighIndex = p + 1;
                         }
 
                         if (d.Low < lastLowPrice)
                         {
                             lastLowPrice = d.Low;
-                            lastLowIndex = (int)d.Index;
+                            lastLowIndex = p + 1;
                         }
                     }
 
-                    result.AroonUp = 100 * (decimal)(lookbackPeriod - (h.Index - lastHighIndex)) / lookbackPeriod;
-                    result.AroonDown = 100 * (decimal)(lookbackPeriod - (h.Index - lastLowIndex)) / lookbackPeriod;
+                    result.AroonUp = 100 * (decimal)(lookbackPeriod - (index - lastHighIndex)) / lookbackPeriod;
+                    result.AroonDown = 100 * (decimal)(lookbackPeriod - (index - lastLowIndex)) / lookbackPeriod;
                     result.Oscillator = result.AroonUp - result.AroonDown;
                 }
 

--- a/indicators/Aroon/Aroon.cs
+++ b/indicators/Aroon/Aroon.cs
@@ -11,7 +11,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            List<Quote> historyList = Cleaners.PrepareHistory(history).ToList();
+            List<Quote> historyList = history.Sort();
 
             // validate parameters
             ValidateAroon(history, lookbackPeriod);

--- a/indicators/Atr/Atr.cs
+++ b/indicators/Atr/Atr.cs
@@ -11,7 +11,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            history = Cleaners.PrepareHistory(history);
+            List<Quote> historyList = Cleaners.PrepareHistory(history).ToList();
 
             // validate parameters
             ValidateAtr(history, lookbackPeriod);
@@ -25,16 +25,17 @@ namespace Skender.Stock.Indicators
             decimal sumTr = 0;
 
             // roll through history
-            foreach (Quote h in history)
+            for (int i = 0; i < historyList.Count; i++)
             {
+                Quote h = historyList[i];
+                int index = i + 1;
 
                 AtrResult result = new AtrResult
                 {
-                    Index = (int)h.Index,
                     Date = h.Date
                 };
 
-                if (h.Index > 1)
+                if (index > 1)
                 {
                     highMinusPrevClose = Math.Abs(h.High - prevClose);
                     lowMinusPrevClose = Math.Abs(h.Low - prevClose);
@@ -43,14 +44,14 @@ namespace Skender.Stock.Indicators
                 decimal tr = Math.Max((h.High - h.Low), Math.Max(highMinusPrevClose, lowMinusPrevClose));
                 result.Tr = tr;
 
-                if (h.Index > lookbackPeriod)
+                if (index > lookbackPeriod)
                 {
                     // calculate ATR
                     result.Atr = (prevAtr * (lookbackPeriod - 1) + tr) / lookbackPeriod;
                     result.Atrp = (h.Close == 0) ? null : (result.Atr / h.Close) * 100;
                     prevAtr = (decimal)result.Atr;
                 }
-                else if (h.Index == lookbackPeriod)
+                else if (index == lookbackPeriod)
                 {
                     // initialize ATR
                     sumTr += tr;

--- a/indicators/Atr/Atr.cs
+++ b/indicators/Atr/Atr.cs
@@ -11,7 +11,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            List<Quote> historyList = Cleaners.PrepareHistory(history).ToList();
+            List<Quote> historyList = history.Sort();
 
             // validate parameters
             ValidateAtr(history, lookbackPeriod);

--- a/indicators/Beta/Beta.cs
+++ b/indicators/Beta/Beta.cs
@@ -11,8 +11,7 @@ namespace Skender.Stock.Indicators
             IEnumerable<Quote> historyMarket, IEnumerable<Quote> historyEval, int lookbackPeriod)
         {
             // clean quotes
-            historyMarket = Cleaners.PrepareHistory(historyMarket);
-            List<Quote> historyEvalList = Cleaners.PrepareHistory(historyEval).ToList();
+            List<Quote> historyEvalList = historyEval.Sort();
 
             // validate parameters
             ValidateBeta(historyMarket, historyEval, lookbackPeriod);

--- a/indicators/Beta/Beta.cs
+++ b/indicators/Beta/Beta.cs
@@ -30,7 +30,6 @@ namespace Skender.Stock.Indicators
 
                 BetaResult result = new BetaResult
                 {
-                    Index = (int)e.Index,
                     Date = e.Date
                 };
 

--- a/indicators/BollingerBands/BollingerBands.cs
+++ b/indicators/BollingerBands/BollingerBands.cs
@@ -24,20 +24,20 @@ namespace Skender.Stock.Indicators
             for (int i = 0; i < historyList.Count; i++)
             {
                 Quote h = historyList[i];
+                int index = i + 1;
 
                 BollingerBandsResult r = new BollingerBandsResult
                 {
-                    Index = (int)h.Index,
                     Date = h.Date
                 };
 
-                if (h.Index >= lookbackPeriod)
+                if (index >= lookbackPeriod)
                 {
                     double[] periodClose = new double[lookbackPeriod];
                     decimal sum = 0m;
                     int n = 0;
 
-                    for (int p = (int)h.Index - lookbackPeriod; p < h.Index; p++)
+                    for (int p = index - lookbackPeriod; p < index; p++)
                     {
                         Quote d = historyList[p];
                         periodClose[n] = (double)d.Close;

--- a/indicators/BollingerBands/BollingerBands.cs
+++ b/indicators/BollingerBands/BollingerBands.cs
@@ -12,7 +12,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            List<Quote> historyList = Cleaners.PrepareHistory(history).ToList();
+            List<Quote> historyList = history.Sort();
 
             // validate parameters
             ValidateBollingerBands(history, lookbackPeriod, standardDeviations);

--- a/indicators/Cci/Cci.cs
+++ b/indicators/Cci/Cci.cs
@@ -24,20 +24,20 @@ namespace Skender.Stock.Indicators
             for (int i = 0; i < historyList.Count; i++)
             {
                 Quote h = historyList[i];
+                int index = i + 1;
 
                 CciResult result = new CciResult
                 {
-                    Index = (int)h.Index,
                     Date = h.Date,
                     Tp = (h.High + h.Low + h.Close) / 3
                 };
                 results.Add(result);
 
-                if (h.Index >= lookbackPeriod)
+                if (index >= lookbackPeriod)
                 {
                     // average TP over lookback
                     decimal avgTp = 0;
-                    for (int p = (int)h.Index - lookbackPeriod; p < h.Index; p++)
+                    for (int p = index - lookbackPeriod; p < index; p++)
                     {
                         CciResult d = results[p];
                         avgTp += (decimal)d.Tp;
@@ -46,7 +46,7 @@ namespace Skender.Stock.Indicators
 
                     // average Deviation over lookback
                     decimal avgDv = 0;
-                    for (int p = (int)h.Index - lookbackPeriod; p < h.Index; p++)
+                    for (int p = index - lookbackPeriod; p < index; p++)
                     {
                         CciResult d = results[p];
                         avgDv += Math.Abs(avgTp - (decimal)d.Tp);

--- a/indicators/Cci/Cci.cs
+++ b/indicators/Cci/Cci.cs
@@ -11,7 +11,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            List<Quote> historyList = Cleaners.PrepareHistory(history).ToList();
+            List<Quote> historyList = history.Sort();
 
             // validate parameters
             ValidateCci(history, lookbackPeriod);

--- a/indicators/ChaikinOsc/ChaikinOsc.cs
+++ b/indicators/ChaikinOsc/ChaikinOsc.cs
@@ -6,15 +6,12 @@ namespace Skender.Stock.Indicators
 {
     public static partial class Indicator
     {
-        // SIMPLE MOVING AVERAGE
+        // CHAIKIN OSCILLATOR
         public static IEnumerable<ChaikinOscResult> GetChaikinOsc(
             IEnumerable<Quote> history,
             int fastPeriod = 3,
             int slowPeriod = 10)
         {
-
-            // clean quotes
-            history = Cleaners.PrepareHistory(history);
 
             // check parameters
             ValidateChaikinOsc(history, fastPeriod, slowPeriod);
@@ -31,8 +28,9 @@ namespace Skender.Stock.Indicators
                 .ToList();
 
             // EMA of ADL
-            IEnumerable<BasicData> adlBasicData = results
-                .Select(x => new BasicData { Date = x.Date, Value = x.Adl });
+            List<BasicData> adlBasicData = results
+                .Select(x => new BasicData { Date = x.Date, Value = x.Adl })
+                .ToList();
 
             List<EmaResult> adlEmaSlow = CalcEma(adlBasicData, slowPeriod).ToList();
             List<EmaResult> adlEmaFast = CalcEma(adlBasicData, fastPeriod).ToList();

--- a/indicators/ChaikinOsc/ChaikinOsc.cs
+++ b/indicators/ChaikinOsc/ChaikinOsc.cs
@@ -23,7 +23,6 @@ namespace Skender.Stock.Indicators
             List<ChaikinOscResult> results = GetAdl(history)
                 .Select(r => new ChaikinOscResult
                 {
-                    Index = r.Index,
                     Date = r.Date,
                     MoneyFlowMultiplier = r.MoneyFlowMultiplier,
                     MoneyFlowVolume = r.MoneyFlowVolume,
@@ -33,7 +32,7 @@ namespace Skender.Stock.Indicators
 
             // EMA of ADL
             IEnumerable<BasicData> adlBasicData = results
-                .Select(x => new BasicData { Index = x.Index, Date = x.Date, Value = x.Adl });
+                .Select(x => new BasicData { Date = x.Date, Value = x.Adl });
 
             List<EmaResult> adlEmaSlow = CalcEma(adlBasicData, slowPeriod).ToList();
             List<EmaResult> adlEmaFast = CalcEma(adlBasicData, fastPeriod).ToList();

--- a/indicators/Chandelier/Chandelier.cs
+++ b/indicators/Chandelier/Chandelier.cs
@@ -13,7 +13,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            List<Quote> historyList = Cleaners.PrepareHistory(history).ToList();
+            List<Quote> historyList = history.Sort();
 
             // validate inputs
             ValidateChandelier(history, lookbackPeriod, multiplier);

--- a/indicators/Chandelier/Chandelier.cs
+++ b/indicators/Chandelier/Chandelier.cs
@@ -26,15 +26,15 @@ namespace Skender.Stock.Indicators
             for (int i = 0; i < historyList.Count; i++)
             {
                 Quote h = historyList[i];
+                int index = i + 1;
 
                 ChandelierResult result = new ChandelierResult
                 {
-                    Index = (int)h.Index,
                     Date = h.Date
                 };
 
                 // add exit values
-                if (h.Index >= lookbackPeriod)
+                if (index >= lookbackPeriod)
                 {
 
                     decimal atr = (decimal)atrResult[i].Atr;
@@ -44,7 +44,7 @@ namespace Skender.Stock.Indicators
                         case ChandelierType.Long:
 
                             decimal maxHigh = 0;
-                            for (int p = (int)h.Index - lookbackPeriod; p < h.Index; p++)
+                            for (int p = index - lookbackPeriod; p < index; p++)
                             {
                                 Quote d = historyList[p];
                                 if (d.High > maxHigh)
@@ -59,7 +59,7 @@ namespace Skender.Stock.Indicators
                         case ChandelierType.Short:
 
                             decimal minLow = decimal.MaxValue;
-                            for (int p = (int)h.Index - lookbackPeriod; p < h.Index; p++)
+                            for (int p = index - lookbackPeriod; p < index; p++)
                             {
                                 Quote d = historyList[p];
                                 if (d.Low < minLow)

--- a/indicators/Cmf/Cmf.cs
+++ b/indicators/Cmf/Cmf.cs
@@ -24,21 +24,21 @@ namespace Skender.Stock.Indicators
             for (int i = 0; i < adlResults.Count; i++)
             {
                 AdlResult r = adlResults[i];
+                var index = i + 1;
 
                 CmfResult result = new CmfResult
                 {
-                    Index = r.Index,
                     Date = r.Date,
                     MoneyFlowMultiplier = r.MoneyFlowMultiplier,
                     MoneyFlowVolume = r.MoneyFlowVolume
                 };
 
-                if (r.Index >= lookbackPeriod)
+                if (index >= lookbackPeriod)
                 {
                     decimal sumMfv = 0;
                     decimal sumVol = 0;
 
-                    for (int p = r.Index - lookbackPeriod; p < r.Index; p++)
+                    for (int p = index - lookbackPeriod; p < index; p++)
                     {
                         Quote h = historyList[p];
                         sumVol += h.Volume;

--- a/indicators/Cmf/Cmf.cs
+++ b/indicators/Cmf/Cmf.cs
@@ -24,7 +24,7 @@ namespace Skender.Stock.Indicators
             for (int i = 0; i < adlResults.Count; i++)
             {
                 AdlResult r = adlResults[i];
-                var index = i + 1;
+                int index = i + 1;
 
                 CmfResult result = new CmfResult
                 {

--- a/indicators/Cmf/Cmf.cs
+++ b/indicators/Cmf/Cmf.cs
@@ -11,7 +11,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            List<Quote> historyList = Cleaners.PrepareHistory(history).ToList();
+            List<Quote> historyList = history.Sort();
 
             // check parameters
             ValidateCmf(history, lookbackPeriod);

--- a/indicators/ConnorsRsi/ConnorsRsi.cs
+++ b/indicators/ConnorsRsi/ConnorsRsi.cs
@@ -24,7 +24,7 @@ namespace Skender.Stock.Indicators
             // RSI of streak
             List<BasicData> bdStreak = results
                 .Where(x => x.Streak != null)
-                .Select(x => new BasicData { Index = null, Date = x.Date, Value = (decimal)x.Streak })
+                .Select(x => new BasicData { Date = x.Date, Value = (decimal)x.Streak })
                 .ToList();
 
             List<RsiResult> rsiStreakResults = CalcRsi(bdStreak, streakPeriod).ToList();
@@ -37,7 +37,7 @@ namespace Skender.Stock.Indicators
 
                 r.RsiStreak = k.Rsi;
 
-                if (r.Index >= startPeriod)
+                if (p + 1 >= startPeriod)
                 {
                     r.ConnorsRsi = (r.RsiClose + r.RsiStreak + r.PercentRank) / 3;
                 }
@@ -60,10 +60,10 @@ namespace Skender.Stock.Indicators
             for (int i = 0; i < bd.Count; i++)
             {
                 BasicData h = bd[i];
+                int index = i + 1;
 
                 ConnorsRsiResult result = new ConnorsRsiResult
                 {
-                    Index = (int)h.Index,
                     Date = h.Date,
                     RsiClose = rsiResults[i].Rsi
                 };
@@ -111,10 +111,10 @@ namespace Skender.Stock.Indicators
 
                 results.Add(result);
 
-                if (h.Index > rankPeriod)
+                if (index > rankPeriod)
                 {
                     int qty = 0;
-                    for (int p = (int)h.Index - rankPeriod - 1; p < h.Index; p++)
+                    for (int p = index - rankPeriod - 1; p < index; p++)
                     {
                         ConnorsRsiResult r = results[p];
                         if (r.PeriodGain < result.PeriodGain)

--- a/indicators/Correlation/Correlation.cs
+++ b/indicators/Correlation/Correlation.cs
@@ -26,6 +26,7 @@ namespace Skender.Stock.Indicators
             {
                 Quote a = historyListA[i];
                 Quote b = historyListB[i];
+                int index = i + 1;
 
                 if (a.Date != b.Date)
                 {
@@ -35,12 +36,11 @@ namespace Skender.Stock.Indicators
 
                 CorrResult r = new CorrResult
                 {
-                    Index = (int)a.Index,
                     Date = a.Date
                 };
 
                 // compute correlation
-                if (i + 1 >= lookbackPeriod)
+                if (index >= lookbackPeriod)
                 {
                     decimal sumPriceA = 0m;
                     decimal sumPriceB = 0m;
@@ -48,7 +48,7 @@ namespace Skender.Stock.Indicators
                     decimal sumPriceB2 = 0m;
                     decimal sumPriceAB = 0m;
 
-                    for (int p = r.Index - lookbackPeriod; p < r.Index; p++)
+                    for (int p = index - lookbackPeriod; p < index; p++)
                     {
                         Quote qa = historyListA[p];
                         Quote qb = historyListB[p];

--- a/indicators/Correlation/Correlation.cs
+++ b/indicators/Correlation/Correlation.cs
@@ -11,8 +11,8 @@ namespace Skender.Stock.Indicators
             IEnumerable<Quote> historyA, IEnumerable<Quote> historyB, int lookbackPeriod)
         {
             // clean quotes
-            List<Quote> historyListA = Cleaners.PrepareHistory(historyA).ToList();
-            List<Quote> historyListB = Cleaners.PrepareHistory(historyB).ToList();
+            List<Quote> historyListA = historyA.Sort();
+            List<Quote> historyListB = historyB.Sort();
 
             // validate parameters
             ValidateCorrelation(historyA, historyB, lookbackPeriod);

--- a/indicators/Donchian/Donchian.cs
+++ b/indicators/Donchian/Donchian.cs
@@ -12,7 +12,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            List<Quote> historyList = Cleaners.PrepareHistory(history).ToList();
+            List<Quote> historyList = history.Sort();
 
             // validate parameters
             ValidateDonchian(history, lookbackPeriod);

--- a/indicators/Donchian/Donchian.cs
+++ b/indicators/Donchian/Donchian.cs
@@ -24,19 +24,19 @@ namespace Skender.Stock.Indicators
             for (int i = 0; i < historyList.Count; i++)
             {
                 Quote h = historyList[i];
+                int index = i + 1;
 
                 DonchianResult result = new DonchianResult
                 {
-                    Index = (int)h.Index,
                     Date = h.Date
                 };
 
-                if (h.Index >= lookbackPeriod)
+                if (index >= lookbackPeriod)
                 {
                     decimal highHigh = 0;
                     decimal lowLow = decimal.MaxValue;
 
-                    for (int p = (int)h.Index - lookbackPeriod; p < h.Index; p++)
+                    for (int p = index - lookbackPeriod; p < index; p++)
                     {
                         Quote d = historyList[p];
 

--- a/indicators/Ema/DoubleEma.cs
+++ b/indicators/Ema/DoubleEma.cs
@@ -22,7 +22,7 @@ namespace Skender.Stock.Indicators
 
             List<BasicData> bd2 = emaN
                 .Where(x => x.Ema != null)
-                .Select(x => new BasicData { Index = null, Date = x.Date, Value = (decimal)x.Ema })
+                .Select(x => new BasicData { Date = x.Date, Value = (decimal)x.Ema })
                 .ToList();  // note: ToList seems to be required when changing data
 
             List<EmaResult> emaN2 = CalcEma(bd2, lookbackPeriod).ToList();
@@ -31,16 +31,16 @@ namespace Skender.Stock.Indicators
             for (int i = 0; i < emaN.Count; i++)
             {
                 EmaResult e1 = emaN[i];
+                int index = i + 1;
 
                 EmaResult result = new EmaResult
                 {
-                    Index = e1.Index,
                     Date = e1.Date
                 };
 
-                if (e1.Index >= 2 * lookbackPeriod - 1)
+                if (index >= 2 * lookbackPeriod - 1)
                 {
-                    EmaResult e2 = emaN2[e1.Index - lookbackPeriod];
+                    EmaResult e2 = emaN2[index - lookbackPeriod];
                     result.Ema = 2 * e1.Ema - e2.Ema;
                 }
 

--- a/indicators/Ema/DoubleEma.cs
+++ b/indicators/Ema/DoubleEma.cs
@@ -11,7 +11,7 @@ namespace Skender.Stock.Indicators
         {
 
             // convert history to basic format
-            IEnumerable<BasicData> bd = Cleaners.ConvertHistoryToBasic(history, "C");
+            List<BasicData> bd = Cleaners.ConvertHistoryToBasic(history, "C");
 
             // validate parameters
             ValidateDema(bd, lookbackPeriod);

--- a/indicators/Ema/Ema.cs
+++ b/indicators/Ema/Ema.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Skender.Stock.Indicators
 {
@@ -11,21 +10,18 @@ namespace Skender.Stock.Indicators
         {
 
             // convert history to basic format
-            IEnumerable<BasicData> bd = Cleaners.ConvertHistoryToBasic(history, "C");
+            List<BasicData> bd = Cleaners.ConvertHistoryToBasic(history, "C");
 
             // calculate
             return CalcEma(bd, lookbackPeriod);
         }
 
 
-        private static IEnumerable<EmaResult> CalcEma(IEnumerable<BasicData> basicData, int lookbackPeriod)
+        private static IEnumerable<EmaResult> CalcEma(List<BasicData> bdList, int lookbackPeriod)
         {
 
-            // clean quotes
-            List<BasicData> bdList = Cleaners.PrepareBasicData(basicData);
-
             // validate parameters
-            ValidateEma(basicData, lookbackPeriod);
+            ValidateEma(bdList, lookbackPeriod);
 
             // initialize
             List<EmaResult> results = new List<EmaResult>();
@@ -68,7 +64,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateEma(IEnumerable<BasicData> history, int lookbackPeriod)
+        private static void ValidateEma(List<BasicData> history, int lookbackPeriod)
         {
 
             // check parameters
@@ -79,7 +75,7 @@ namespace Skender.Stock.Indicators
             }
 
             // check history
-            int qtyHistory = history.Count();
+            int qtyHistory = history.Count;
             int minHistory = Math.Max(2 * lookbackPeriod, lookbackPeriod + 100);
             if (qtyHistory < minHistory)
             {

--- a/indicators/Ema/Ema.cs
+++ b/indicators/Ema/Ema.cs
@@ -22,7 +22,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            basicData = Cleaners.PrepareBasicData(basicData);
+            List<BasicData> bdList = Cleaners.PrepareBasicData(basicData);
 
             // validate parameters
             ValidateEma(basicData, lookbackPeriod);
@@ -32,28 +32,31 @@ namespace Skender.Stock.Indicators
 
             // initialize EMA
             decimal k = 2 / (decimal)(lookbackPeriod + 1);
-            decimal lastEma = basicData
-                .Where(x => x.Index <= lookbackPeriod)
-                .ToList()
-                .Select(x => x.Value)
-                .Average();
+            decimal lastEma = 0;
+
+            for (int i = 0; i < lookbackPeriod; i++)
+            {
+                lastEma += bdList[i].Value;
+            }
+            lastEma /= lookbackPeriod;
 
             // roll through history
-            foreach (BasicData h in basicData)
+            for (int i = 0; i < bdList.Count; i++)
             {
+                BasicData h = bdList[i];
+                int index = i + 1;
 
                 EmaResult result = new EmaResult
                 {
-                    Index = (int)h.Index,
                     Date = h.Date
                 };
 
-                if (h.Index > lookbackPeriod)
+                if (index > lookbackPeriod)
                 {
                     result.Ema = lastEma + k * (h.Value - lastEma);
                     lastEma = (decimal)result.Ema;
                 }
-                else if (h.Index == lookbackPeriod)
+                else if (index == lookbackPeriod)
                 {
                     result.Ema = lastEma;
                 }

--- a/indicators/Ema/TripleEma.cs
+++ b/indicators/Ema/TripleEma.cs
@@ -22,14 +22,14 @@ namespace Skender.Stock.Indicators
 
             List<BasicData> bd2 = emaN1
                 .Where(x => x.Ema != null)
-                .Select(x => new BasicData { Index = null, Date = x.Date, Value = (decimal)x.Ema })
+                .Select(x => new BasicData { Date = x.Date, Value = (decimal)x.Ema })
                 .ToList();
 
             List<EmaResult> emaN2 = CalcEma(bd2, lookbackPeriod).ToList();
 
             List<BasicData> bd3 = emaN2
                 .Where(x => x.Ema != null)
-                .Select(x => new BasicData { Index = null, Date = x.Date, Value = (decimal)x.Ema })
+                .Select(x => new BasicData { Date = x.Date, Value = (decimal)x.Ema })
                 .ToList();
 
             List<EmaResult> emaN3 = CalcEma(bd3, lookbackPeriod).ToList();
@@ -38,17 +38,17 @@ namespace Skender.Stock.Indicators
             for (int i = 0; i < emaN1.Count; i++)
             {
                 EmaResult e1 = emaN1[i];
+                int index = i + 1;
 
                 EmaResult result = new EmaResult
                 {
-                    Index = e1.Index,
                     Date = e1.Date
                 };
 
-                if (e1.Index >= 3 * lookbackPeriod - 2)
+                if (index >= 3 * lookbackPeriod - 2)
                 {
-                    EmaResult e2 = emaN2[e1.Index - lookbackPeriod];
-                    EmaResult e3 = emaN3[e2.Index - lookbackPeriod];
+                    EmaResult e2 = emaN2[index - lookbackPeriod];
+                    EmaResult e3 = emaN3[index - 2 * lookbackPeriod + 1];
 
                     result.Ema = 3 * e1.Ema - 3 * e2.Ema + e3.Ema;
                 }

--- a/indicators/Ema/TripleEma.cs
+++ b/indicators/Ema/TripleEma.cs
@@ -11,7 +11,7 @@ namespace Skender.Stock.Indicators
         {
 
             // convert history to basic format
-            IEnumerable<BasicData> bd = Cleaners.ConvertHistoryToBasic(history, "C");
+            List<BasicData> bd = Cleaners.ConvertHistoryToBasic(history, "C");
 
             // validate parameters
             ValidateTema(bd, lookbackPeriod);

--- a/indicators/HeikinAshi/HeikinAshi.cs
+++ b/indicators/HeikinAshi/HeikinAshi.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            history = Cleaners.PrepareHistory(history);
+            List<Quote> historyList = Cleaners.PrepareHistory(history).ToList();
 
             // check parameters
             ValidateHeikinAshi(history);
@@ -21,8 +21,9 @@ namespace Skender.Stock.Indicators
             decimal? prevOpen = null;
             decimal? prevClose = null;
 
-            foreach (Quote h in history)
+            for (int i = 0; i < historyList.Count; i++)
             {
+                Quote h = historyList[i];
 
                 // close
                 decimal close = (h.Open + h.High + h.Low + h.Close) / 4;
@@ -41,7 +42,6 @@ namespace Skender.Stock.Indicators
 
                 HeikinAshiResult result = new HeikinAshiResult
                 {
-                    Index = (int)h.Index,
                     Date = h.Date,
                     Open = open,
                     High = high,

--- a/indicators/HeikinAshi/HeikinAshi.cs
+++ b/indicators/HeikinAshi/HeikinAshi.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            List<Quote> historyList = Cleaners.PrepareHistory(history).ToList();
+            List<Quote> historyList = history.Sort();
 
             // check parameters
             ValidateHeikinAshi(history);

--- a/indicators/Hma/Hma.cs
+++ b/indicators/Hma/Hma.cs
@@ -11,7 +11,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            List<Quote> historyList = Cleaners.PrepareHistory(history).ToList();
+            List<Quote> historyList = history.Sort();
 
             // check parameters
             ValidateHma(history, lookbackPeriod);

--- a/indicators/Hma/Hma.cs
+++ b/indicators/Hma/Hma.cs
@@ -48,19 +48,17 @@ namespace Skender.Stock.Indicators
             int shiftQty = lookbackPeriod - 1;
 
             List<HmaResult> results = historyList
+                .Take(shiftQty)
                 .Select(x => new HmaResult
                 {
-                    Index = (int)x.Index,
                     Date = x.Date
                 })
-                .Where(x => x.Index <= shiftQty)
                 .ToList();
 
             // calculate final HMA = WMA with period SQRT(n)
             List<HmaResult> hmaResults = GetWma(synthHistory, sqN)
                 .Select(x => new HmaResult
                 {
-                    Index = x.Index + shiftQty,
                     Date = x.Date,
                     Hma = x.Wma
                 })
@@ -68,7 +66,7 @@ namespace Skender.Stock.Indicators
 
             // add WMA to results
             results.AddRange(hmaResults);
-            results = results.OrderBy(x => x.Index).ToList();
+            results = results.OrderBy(x => x.Date).ToList();
 
             return results;
         }

--- a/indicators/Ichimoku/Ichimoku.cs
+++ b/indicators/Ichimoku/Ichimoku.cs
@@ -12,7 +12,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            List<Quote> historyList = Cleaners.PrepareHistory(history).ToList();
+            List<Quote> historyList = history.Sort();
 
             // check parameters
             ValidateIchimoku(history, signalPeriod, shortSpanPeriod, longSpanPeriod);

--- a/indicators/Ichimoku/Ichimoku.cs
+++ b/indicators/Ichimoku/Ichimoku.cs
@@ -24,23 +24,23 @@ namespace Skender.Stock.Indicators
             for (int i = 0; i < historyList.Count; i++)
             {
                 Quote h = historyList[i];
+                int index = i + 1;
 
                 IchimokuResult result = new IchimokuResult
                 {
-                    Index = (int)h.Index,
                     Date = h.Date
                 };
 
                 // tenkan-sen conversion line
-                CalcIchimokuTenkanSen(historyList, result, h, signalPeriod);
+                CalcIchimokuTenkanSen(index, historyList, result, signalPeriod);
 
                 // kijun-sen base line
-                CalcIchimokuKijunSen(historyList, result, h, shortSpanPeriod);
+                CalcIchimokuKijunSen(index, historyList, result, shortSpanPeriod);
 
                 // senkou span A
-                if (h.Index >= 2 * shortSpanPeriod)
+                if (index >= 2 * shortSpanPeriod)
                 {
-                    IchimokuResult skq = results[(int)h.Index - shortSpanPeriod - 1];
+                    IchimokuResult skq = results[index - shortSpanPeriod - 1];
 
                     if (skq != null && skq.TenkanSen != null && skq.KijunSen != null)
                     {
@@ -49,12 +49,12 @@ namespace Skender.Stock.Indicators
                 }
 
                 // senkou span B
-                CalcIchimokuSenkouB(historyList, result, h, shortSpanPeriod, longSpanPeriod);
+                CalcIchimokuSenkouB(index, historyList, result, shortSpanPeriod, longSpanPeriod);
 
                 // chikou line
-                if (h.Index + shortSpanPeriod <= historyList.Count)
+                if (index + shortSpanPeriod <= historyList.Count)
                 {
-                    result.ChikouSpan = historyList[(int)h.Index + shortSpanPeriod - 1].Close;
+                    result.ChikouSpan = historyList[index + shortSpanPeriod - 1].Close;
                 }
                 results.Add(result);
             }
@@ -64,16 +64,14 @@ namespace Skender.Stock.Indicators
 
 
         private static void CalcIchimokuTenkanSen(
-            List<Quote> historyList,
-            IchimokuResult result,
-            Quote h, int signalPeriod)
+            int index, List<Quote> historyList, IchimokuResult result, int signalPeriod)
         {
-            if (h.Index >= signalPeriod)
+            if (index >= signalPeriod)
             {
                 decimal max = 0;
                 decimal min = decimal.MaxValue;
 
-                for (int p = (int)h.Index - signalPeriod; p < h.Index; p++)
+                for (int p = index - signalPeriod; p < index; p++)
                 {
                     Quote d = historyList[p];
 
@@ -94,16 +92,14 @@ namespace Skender.Stock.Indicators
 
 
         private static void CalcIchimokuKijunSen(
-            List<Quote> historyList,
-            IchimokuResult result,
-            Quote h, int shortSpanPeriod)
+            int index, List<Quote> historyList, IchimokuResult result, int shortSpanPeriod)
         {
-            if (h.Index >= shortSpanPeriod)
+            if (index >= shortSpanPeriod)
             {
                 decimal max = 0;
                 decimal min = decimal.MaxValue;
 
-                for (int p = (int)h.Index - shortSpanPeriod; p < h.Index; p++)
+                for (int p = index - shortSpanPeriod; p < index; p++)
                 {
                     Quote d = historyList[p];
 
@@ -124,17 +120,15 @@ namespace Skender.Stock.Indicators
 
 
         private static void CalcIchimokuSenkouB(
-            List<Quote> historyList,
-            IchimokuResult result,
-            Quote h, int shortSpanPeriod, int longSpanPeriod)
+            int index, List<Quote> historyList, IchimokuResult result, int shortSpanPeriod, int longSpanPeriod)
         {
-            if (h.Index >= shortSpanPeriod + longSpanPeriod)
+            if (index >= shortSpanPeriod + longSpanPeriod)
             {
                 decimal max = 0;
                 decimal min = decimal.MaxValue;
 
-                for (int p = (int)h.Index - shortSpanPeriod - longSpanPeriod;
-                    p < h.Index - shortSpanPeriod; p++)
+                for (int p = index - shortSpanPeriod - longSpanPeriod;
+                    p < index - shortSpanPeriod; p++)
                 {
                     Quote d = historyList[p];
 

--- a/indicators/Keltner/Keltner.cs
+++ b/indicators/Keltner/Keltner.cs
@@ -27,14 +27,14 @@ namespace Skender.Stock.Indicators
             for (int i = 0; i < historyList.Count; i++)
             {
                 Quote h = historyList[i];
+                int index = i + 1;
 
                 KeltnerResult result = new KeltnerResult
                 {
-                    Index = (int)h.Index,
                     Date = h.Date
                 };
 
-                if (h.Index >= lookbackPeriod)
+                if (index >= lookbackPeriod)
                 {
                     EmaResult ema = emaResults[i];
                     AtrResult atr = atrResults[i];
@@ -42,7 +42,8 @@ namespace Skender.Stock.Indicators
                     result.UpperBand = ema.Ema + multiplier * atr.Atr;
                     result.LowerBand = ema.Ema - multiplier * atr.Atr;
                     result.Centerline = ema.Ema;
-                    result.Width = (result.Centerline == 0) ? null : (result.UpperBand - result.LowerBand) / result.Centerline;
+                    result.Width = (result.Centerline == 0) ? null
+                        : (result.UpperBand - result.LowerBand) / result.Centerline;
                 }
 
                 results.Add(result);

--- a/indicators/Keltner/Keltner.cs
+++ b/indicators/Keltner/Keltner.cs
@@ -12,7 +12,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            List<Quote> historyList = Cleaners.PrepareHistory(history).ToList();
+            List<Quote> historyList = history.Sort();
 
             // validate parameters
             ValidateKeltner(history, emaPeriod, multiplier, atrPeriod);

--- a/indicators/Macd/Macd.cs
+++ b/indicators/Macd/Macd.cs
@@ -32,7 +32,6 @@ namespace Skender.Stock.Indicators
 
                 MacdResult result = new MacdResult
                 {
-                    Index = (int)h.Index,
                     Date = h.Date
                 };
 
@@ -45,7 +44,6 @@ namespace Skender.Stock.Indicators
                     // temp data for interim EMA of macd
                     BasicData diff = new BasicData
                     {
-                        Index = h.Index - slowPeriod + 1,
                         Date = h.Date,
                         Value = macd
                     };
@@ -59,9 +57,10 @@ namespace Skender.Stock.Indicators
             // add signal and histogram to result
             List<EmaResult> emaSignal = CalcEma(emaDiff, signalPeriod).ToList();
 
-            foreach (MacdResult r in results.Where(x => x.Index >= slowPeriod))
+            for (int d = slowPeriod - 1; d < results.Count; d++)
             {
-                EmaResult ds = emaSignal[r.Index - slowPeriod];
+                MacdResult r = results[d];
+                EmaResult ds = emaSignal[d + 1 - slowPeriod];
 
                 r.Signal = ds.Ema;
                 r.Histogram = r.Macd - r.Signal;

--- a/indicators/Macd/Macd.cs
+++ b/indicators/Macd/Macd.cs
@@ -11,13 +11,12 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            history = Cleaners.PrepareHistory(history);
+            List<Quote> historyList = history.Sort();
 
             // check parameters
             ValidateMacd(history, fastPeriod, slowPeriod, signalPeriod);
 
             // initialize
-            List<Quote> historyList = history.ToList();
             List<EmaResult> emaFast = GetEma(history, fastPeriod).ToList();
             List<EmaResult> emaSlow = GetEma(history, slowPeriod).ToList();
 

--- a/indicators/Mfi/Mfi.cs
+++ b/indicators/Mfi/Mfi.cs
@@ -28,7 +28,6 @@ namespace Skender.Stock.Indicators
 
                 MfiResult result = new MfiResult
                 {
-                    Index = (int)h.Index,
                     Date = h.Date,
                     TruePrice = (h.High + h.Low + h.Close) / 3
                 };
@@ -59,11 +58,12 @@ namespace Skender.Stock.Indicators
             for (int i = lookbackPeriod; i < results.Count; i++)
             {
                 MfiResult r = results[i];
+                int index = i + 1;
 
                 decimal sumPosMFs = 0;
                 decimal sumNegMFs = 0;
 
-                for (int p = r.Index - lookbackPeriod; p < r.Index; p++)
+                for (int p = index - lookbackPeriod; p < index; p++)
                 {
                     MfiResult d = results[p];
 

--- a/indicators/Mfi/Mfi.cs
+++ b/indicators/Mfi/Mfi.cs
@@ -11,7 +11,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            List<Quote> historyList = Cleaners.PrepareHistory(history).ToList();
+            List<Quote> historyList = history.Sort();
 
             // check parameters
             ValidateMfi(history, lookbackPeriod);

--- a/indicators/Obv/Obv.cs
+++ b/indicators/Obv/Obv.cs
@@ -11,7 +11,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            history = Cleaners.PrepareHistory(history);
+            List<Quote> historyList = Cleaners.PrepareHistory(history).ToList();
 
             // check parameters
             ValidateObv(history, smaPeriod);
@@ -22,8 +22,11 @@ namespace Skender.Stock.Indicators
             decimal? prevClose = null;
             decimal obv = 0;
 
-            foreach (Quote h in history)
+            for (int i = 0; i < historyList.Count; i++)
             {
+                Quote h = historyList[i];
+                int index = i + 1;
+
                 if (prevClose == null || h.Close == prevClose)
                 {
                     // no change to OBV
@@ -39,7 +42,6 @@ namespace Skender.Stock.Indicators
 
                 ObvResult result = new ObvResult
                 {
-                    Index = (int)h.Index,
                     Date = h.Date,
                     Obv = obv
                 };
@@ -48,10 +50,10 @@ namespace Skender.Stock.Indicators
                 prevClose = h.Close;
 
                 // optional SMA
-                if (smaPeriod != null && h.Index > smaPeriod)
+                if (smaPeriod != null && index > smaPeriod)
                 {
                     decimal sumSma = 0m;
-                    for (int p = (int)h.Index - (int)smaPeriod; p < h.Index; p++)
+                    for (int p = index - (int)smaPeriod; p < index; p++)
                     {
                         sumSma += results[p].Obv;
                     }

--- a/indicators/Obv/Obv.cs
+++ b/indicators/Obv/Obv.cs
@@ -11,7 +11,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            List<Quote> historyList = Cleaners.PrepareHistory(history).ToList();
+            List<Quote> historyList = history.Sort();
 
             // check parameters
             ValidateObv(history, smaPeriod);

--- a/indicators/ParabolicSar/ParabolicSar.cs
+++ b/indicators/ParabolicSar/ParabolicSar.cs
@@ -35,12 +35,11 @@ namespace Skender.Stock.Indicators
 
                 ParabolicSarResult result = new ParabolicSarResult
                 {
-                    Index = (int)h.Index,
                     Date = h.Date
                 };
 
                 // skip first one
-                if (h.Index == 1)
+                if (i == 0)
                 {
                     results.Add(result);
                     continue;
@@ -138,13 +137,16 @@ namespace Skender.Stock.Indicators
             // remove first trend to reversal, since it is an invalid guess
             ParabolicSarResult firstReversal = results
                 .Where(x => x.IsReversal == true)
-                .OrderBy(x => x.Index)
+                .OrderBy(x => x.Date)
                 .FirstOrDefault();
 
             if (firstReversal != null)
             {
-                foreach (ParabolicSarResult r in results.Where(x => x.Index <= firstReversal.Index))
+                int cutIndex = results.IndexOf(firstReversal);
+
+                for (int d = 0; d <= cutIndex; d++)
                 {
+                    ParabolicSarResult r = results[d];
                     r.Sar = null;
                     r.IsReversal = null;
                 }

--- a/indicators/ParabolicSar/ParabolicSar.cs
+++ b/indicators/ParabolicSar/ParabolicSar.cs
@@ -14,7 +14,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            List<Quote> historyList = Cleaners.PrepareHistory(history).ToList();
+            List<Quote> historyList = history.Sort();
 
             // check parameters
             ValidateParabolicSar(history, accelerationStep, maxAccelerationFactor);

--- a/indicators/Pmo/Pmo.cs
+++ b/indicators/Pmo/Pmo.cs
@@ -31,15 +31,16 @@ namespace Skender.Stock.Indicators
             for (int i = startIndex - 1; i < results.Count; i++)
             {
                 PmoResult pr = results[i];
+                int index = i + 1;
 
-                if (pr.Index > startIndex)
+                if (index > startIndex)
                 {
                     pr.Pmo = (pr.RocEma - lastPmo) * smoothingConstant + lastPmo;
                 }
-                else if (pr.Index == startIndex)
+                else if (index == startIndex)
                 {
                     decimal sumRocEma = 0;
-                    for (int p = pr.Index - smoothingPeriod; p < pr.Index; p++)
+                    for (int p = index - smoothingPeriod; p < index; p++)
                     {
                         PmoResult d = results[p];
                         sumRocEma += (decimal)d.RocEma;
@@ -70,21 +71,21 @@ namespace Skender.Stock.Indicators
             for (int i = 0; i < roc.Count; i++)
             {
                 RocResult r = roc[i];
+                int index = i + 1;
 
                 PmoResult result = new PmoResult
                 {
-                    Index = r.Index,
                     Date = r.Date
                 };
 
-                if (r.Index > startIndex)
+                if (index > startIndex)
                 {
                     result.RocEma = r.Roc * smoothingMultiplier + lastRocEma * (1 - smoothingMultiplier);
                 }
-                else if (r.Index == startIndex)
+                else if (index == startIndex)
                 {
                     decimal sumRoc = 0;
-                    for (int p = r.Index - timePeriod; p < r.Index; p++)
+                    for (int p = index - timePeriod; p < index; p++)
                     {
                         RocResult d = roc[p];
                         sumRoc += (decimal)d.Roc;
@@ -115,15 +116,16 @@ namespace Skender.Stock.Indicators
             for (int i = startIndex - 1; i < results.Count; i++)
             {
                 PmoResult pr = results[i];
+                int index = i + 1;
 
-                if (pr.Index > startIndex)
+                if (index > startIndex)
                 {
                     pr.Signal = (pr.Pmo - lastSignal) * signalConstant + lastSignal;
                 }
-                else if (pr.Index == startIndex)
+                else if (index == startIndex)
                 {
                     decimal sumPmo = 0;
-                    for (int p = pr.Index - signalPeriod; p < pr.Index; p++)
+                    for (int p = index - signalPeriod; p < index; p++)
                     {
                         PmoResult d = results[p];
                         sumPmo += (decimal)d.Pmo;

--- a/indicators/Pmo/Pmo.cs
+++ b/indicators/Pmo/Pmo.cs
@@ -14,9 +14,6 @@ namespace Skender.Stock.Indicators
             int signalPeriod = 10)
         {
 
-            // clean quotes
-            history = Cleaners.PrepareHistory(history);
-
             // check parameters
             ValidatePmo(history, timePeriod, smoothingPeriod, signalPeriod);
 

--- a/indicators/Prs/Prs.cs
+++ b/indicators/Prs/Prs.cs
@@ -26,6 +26,7 @@ namespace Skender.Stock.Indicators
             {
                 Quote bi = historyBaseList[i];
                 Quote ei = historyEvalList[i];
+                int index = i + 1;
 
                 if (ei.Date != bi.Date)
                 {
@@ -35,13 +36,12 @@ namespace Skender.Stock.Indicators
 
                 PrsResult r = new PrsResult
                 {
-                    Index = (int)ei.Index,
                     Date = ei.Date,
                     Prs = ei.Close / bi.Close  // relative strength ratio
                 };
                 results.Add(r);
 
-                if (lookbackPeriod != null && r.Index > lookbackPeriod)
+                if (lookbackPeriod != null && index > lookbackPeriod)
                 {
                     Quote bo = historyBaseList[i - (int)lookbackPeriod];
                     Quote eo = historyEvalList[i - (int)lookbackPeriod];
@@ -56,10 +56,10 @@ namespace Skender.Stock.Indicators
                 }
 
                 // optional moving average of PRS
-                if (smaPeriod != null && r.Index >= smaPeriod)
+                if (smaPeriod != null && index >= smaPeriod)
                 {
                     decimal sumRs = 0m;
-                    for (int p = r.Index - (int)smaPeriod; p < r.Index; p++)
+                    for (int p = index - (int)smaPeriod; p < index; p++)
                     {
                         PrsResult d = results[p];
                         sumRs += (decimal)d.Prs;

--- a/indicators/Prs/Prs.cs
+++ b/indicators/Prs/Prs.cs
@@ -11,8 +11,8 @@ namespace Skender.Stock.Indicators
             IEnumerable<Quote> historyBase, IEnumerable<Quote> historyEval, int? lookbackPeriod = null, int? smaPeriod = null)
         {
             // clean quotes
-            List<Quote> historyBaseList = Cleaners.PrepareHistory(historyBase).ToList();
-            List<Quote> historyEvalList = Cleaners.PrepareHistory(historyEval).ToList();
+            List<Quote> historyBaseList = historyBase.Sort();
+            List<Quote> historyEvalList = historyEval.Sort();
 
             // validate parameters
             ValidatePriceRelative(historyBase, historyEval, lookbackPeriod, smaPeriod);

--- a/indicators/Roc/Roc.cs
+++ b/indicators/Roc/Roc.cs
@@ -12,7 +12,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            List<Quote> historyList = Cleaners.PrepareHistory(history).ToList();
+            List<Quote> historyList = history.Sort();
 
             // check parameters
             ValidateRoc(history, lookbackPeriod, smaPeriod);

--- a/indicators/Roc/Roc.cs
+++ b/indicators/Roc/Roc.cs
@@ -24,26 +24,26 @@ namespace Skender.Stock.Indicators
             for (int i = 0; i < historyList.Count; i++)
             {
                 Quote h = historyList[i];
+                int index = i + 1;
 
                 RocResult result = new RocResult
                 {
-                    Index = (int)h.Index,
                     Date = h.Date
                 };
 
-                if (h.Index > lookbackPeriod)
+                if (index > lookbackPeriod)
                 {
-                    Quote back = historyList[(int)h.Index - lookbackPeriod - 1];
+                    Quote back = historyList[index - lookbackPeriod - 1];
                     result.Roc = 100 * (h.Close - back.Close) / back.Close;
                 }
 
                 results.Add(result);
 
                 // optional SMA
-                if (smaPeriod != null && h.Index >= lookbackPeriod + smaPeriod)
+                if (smaPeriod != null && index >= lookbackPeriod + smaPeriod)
                 {
                     decimal sumSma = 0m;
-                    for (int p = (int)h.Index - (int)smaPeriod; p < h.Index; p++)
+                    for (int p = index - (int)smaPeriod; p < index; p++)
                     {
                         sumSma += (decimal)results[p].Roc;
                     }

--- a/indicators/Rsi/Rsi.cs
+++ b/indicators/Rsi/Rsi.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Skender.Stock.Indicators
 {
@@ -11,21 +10,18 @@ namespace Skender.Stock.Indicators
         {
 
             // convert history to basic format
-            IEnumerable<BasicData> bd = Cleaners.ConvertHistoryToBasic(history, "C");
+            List<BasicData> bd = Cleaners.ConvertHistoryToBasic(history, "C");
 
             // calculate
             return CalcRsi(bd, lookbackPeriod);
         }
 
 
-        private static IEnumerable<RsiResult> CalcRsi(IEnumerable<BasicData> basicData, int lookbackPeriod = 14)
+        private static IEnumerable<RsiResult> CalcRsi(List<BasicData> bdList, int lookbackPeriod = 14)
         {
 
-            // clean data
-            List<BasicData> bdList = Cleaners.PrepareBasicData(basicData);
-
             // check parameters
-            ValidateRsi(basicData, lookbackPeriod);
+            ValidateRsi(bdList, lookbackPeriod);
 
             // initialize
             decimal lastValue = bdList[0].Value;
@@ -88,7 +84,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateRsi(IEnumerable<BasicData> history, int lookbackPeriod)
+        private static void ValidateRsi(List<BasicData> history, int lookbackPeriod)
         {
 
             // check parameters
@@ -99,7 +95,7 @@ namespace Skender.Stock.Indicators
             }
 
             // check history
-            int qtyHistory = history.Count();
+            int qtyHistory = history.Count;
             int minHistory = lookbackPeriod;
             if (qtyHistory < minHistory)
             {

--- a/indicators/Rsi/Rsi.cs
+++ b/indicators/Rsi/Rsi.cs
@@ -22,7 +22,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean data
-            List<BasicData> bdList = Cleaners.PrepareBasicData(basicData).ToList();
+            List<BasicData> bdList = Cleaners.PrepareBasicData(basicData);
 
             // check parameters
             ValidateRsi(basicData, lookbackPeriod);

--- a/indicators/Rsi/Rsi.cs
+++ b/indicators/Rsi/Rsi.cs
@@ -37,10 +37,10 @@ namespace Skender.Stock.Indicators
             for (int i = 0; i < bdList.Count; i++)
             {
                 BasicData h = bdList[i];
+                int index = i + 1;
 
                 RsiResult r = new RsiResult
                 {
-                    Index = (int)h.Index,
                     Date = h.Date,
                     Gain = (h.Value > lastValue) ? h.Value - lastValue : 0,
                     Loss = (h.Value < lastValue) ? lastValue - h.Value : 0
@@ -49,7 +49,7 @@ namespace Skender.Stock.Indicators
                 lastValue = h.Value;
 
                 // calculate RSI
-                if (h.Index > lookbackPeriod + 1)
+                if (index > lookbackPeriod + 1)
                 {
                     avgGain = (avgGain * (lookbackPeriod - 1) + r.Gain) / lookbackPeriod;
                     avgLoss = (avgLoss * (lookbackPeriod - 1) + r.Loss) / lookbackPeriod;
@@ -66,7 +66,7 @@ namespace Skender.Stock.Indicators
                 }
 
                 // initialize average gain
-                else if (h.Index == lookbackPeriod + 1)
+                else if (index == lookbackPeriod + 1)
                 {
                     decimal sumGain = 0;
                     decimal sumLoss = 0;

--- a/indicators/Slope/Slope.cs
+++ b/indicators/Slope/Slope.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         public static IEnumerable<SlopeResult> GetSlope(IEnumerable<Quote> history, int lookbackPeriod)
         {
             // clean quotes
-            List<Quote> historyList = Cleaners.PrepareHistory(history).ToList();
+            List<Quote> historyList = history.Sort();
 
             // validate parameters
             ValidateSlope(history, lookbackPeriod);

--- a/indicators/Slope/Slope.cs
+++ b/indicators/Slope/Slope.cs
@@ -22,17 +22,17 @@ namespace Skender.Stock.Indicators
             for (int i = 0; i < historyList.Count; i++)
             {
                 Quote h = historyList[i];
+                int index = i + 1;
 
                 SlopeResult r = new SlopeResult
                 {
-                    Index = (int)h.Index,
                     Date = h.Date
                 };
 
                 results.Add(r);
 
                 // skip initialization period
-                if (h.Index < lookbackPeriod)
+                if (index < lookbackPeriod)
                 {
                     continue;
                 }
@@ -41,11 +41,11 @@ namespace Skender.Stock.Indicators
                 decimal sumX = 0m;
                 decimal sumY = 0m;
 
-                for (int p = r.Index - lookbackPeriod; p < r.Index; p++)
+                for (int p = index - lookbackPeriod; p < index; p++)
                 {
                     Quote d = historyList[p];
 
-                    sumX += (decimal)d.Index;
+                    sumX += p + 1m;
                     sumY += d.Close;
                 }
 
@@ -57,11 +57,11 @@ namespace Skender.Stock.Indicators
                 decimal sumSqY = 0m;
                 decimal sumSqXY = 0m;
 
-                for (int p = r.Index - lookbackPeriod; p < r.Index; p++)
+                for (int p = index - lookbackPeriod; p < index; p++)
                 {
                     Quote d = historyList[p];
 
-                    decimal devX = ((decimal)d.Index - avgX);
+                    decimal devX = (p + 1m - avgX);
                     decimal devY = (d.Close - avgY);
 
                     sumSqX += devX * devX;
@@ -85,12 +85,13 @@ namespace Skender.Stock.Indicators
             }
 
             // add last Line (y = mx + b)
-            SlopeResult last = results[historyList.Count - 1];
+            int lastIndex = historyList.Count;
+            SlopeResult last = results[lastIndex - 1];
 
-            for (int p = last.Index - lookbackPeriod; p < last.Index; p++)
+            for (int p = lastIndex - lookbackPeriod; p < lastIndex; p++)
             {
                 SlopeResult d = results[p];
-                d.Line = last.Slope * d.Index + last.Intercept;
+                d.Line = last.Slope * (p + 1) + last.Intercept;
             }
 
             return results;

--- a/indicators/Sma/Sma.cs
+++ b/indicators/Sma/Sma.cs
@@ -12,7 +12,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            List<Quote> historyList = Cleaners.PrepareHistory(history).ToList();
+            List<Quote> historyList = history.Sort();
 
             // check parameters
             ValidateSma(history, lookbackPeriod);

--- a/indicators/Sma/Sma.cs
+++ b/indicators/Sma/Sma.cs
@@ -24,17 +24,17 @@ namespace Skender.Stock.Indicators
             for (int i = 0; i < historyList.Count; i++)
             {
                 Quote h = historyList[i];
+                int index = i + 1;
 
                 SmaResult result = new SmaResult
                 {
-                    Index = (int)h.Index,
                     Date = h.Date
                 };
 
-                if (h.Index >= lookbackPeriod)
+                if (index >= lookbackPeriod)
                 {
                     decimal sumSma = 0m;
-                    for (int p = (int)h.Index - lookbackPeriod; p < h.Index; p++)
+                    for (int p = index - lookbackPeriod; p < index; p++)
                     {
                         Quote d = historyList[p];
                         sumSma += d.Close;
@@ -49,7 +49,7 @@ namespace Skender.Stock.Indicators
                         decimal sumMse = 0m;
                         decimal sumMape = 0m;
 
-                        for (int p = (int)h.Index - lookbackPeriod; p < h.Index; p++)
+                        for (int p = index - lookbackPeriod; p < index; p++)
                         {
                             Quote d = historyList[p];
                             sumMad += Math.Abs(d.Close - (decimal)result.Sma);

--- a/indicators/StdDev/StdDev.cs
+++ b/indicators/StdDev/StdDev.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Skender.Stock.Indicators
 {
@@ -12,7 +11,7 @@ namespace Skender.Stock.Indicators
         {
 
             // convert to basic data
-            IEnumerable<BasicData> bd = Cleaners.ConvertHistoryToBasic(history, "C");
+            List<BasicData> bd = Cleaners.ConvertHistoryToBasic(history, "C");
 
             // calculate
             return CalcStdDev(bd, lookbackPeriod, smaPeriod);
@@ -20,13 +19,11 @@ namespace Skender.Stock.Indicators
 
 
         private static IEnumerable<StdDevResult> CalcStdDev(
-            IEnumerable<BasicData> basicData, int lookbackPeriod, int? smaPeriod = null)
+            List<BasicData> bdList, int lookbackPeriod, int? smaPeriod = null)
         {
-            // clean data
-            List<BasicData> bdList = Cleaners.PrepareBasicData(basicData);
 
             // validate inputs
-            ValidateStdDev(basicData, lookbackPeriod, smaPeriod);
+            ValidateStdDev(bdList, lookbackPeriod, smaPeriod);
 
             // initialize results
             List<StdDevResult> results = new List<StdDevResult>();
@@ -81,7 +78,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateStdDev(IEnumerable<BasicData> history, int lookbackPeriod, int? smaPeriod)
+        private static void ValidateStdDev(List<BasicData> history, int lookbackPeriod, int? smaPeriod)
         {
 
             // check parameters
@@ -98,7 +95,7 @@ namespace Skender.Stock.Indicators
             }
 
             // check history
-            int qtyHistory = history.Count();
+            int qtyHistory = history.Count;
             int minHistory = lookbackPeriod;
             if (qtyHistory < minHistory)
             {

--- a/indicators/StdDev/StdDev.cs
+++ b/indicators/StdDev/StdDev.cs
@@ -23,7 +23,7 @@ namespace Skender.Stock.Indicators
             IEnumerable<BasicData> basicData, int lookbackPeriod, int? smaPeriod = null)
         {
             // clean data
-            List<BasicData> basicDataList = Cleaners.PrepareBasicData(basicData).ToList();
+            List<BasicData> bdList = Cleaners.PrepareBasicData(basicData);
 
             // validate inputs
             ValidateStdDev(basicData, lookbackPeriod, smaPeriod);
@@ -32,7 +32,7 @@ namespace Skender.Stock.Indicators
             List<StdDevResult> results = new List<StdDevResult>();
 
             // roll through history and compute lookback standard deviation
-            foreach (BasicData bd in basicDataList)
+            foreach (BasicData bd in bdList)
             {
                 StdDevResult result = new StdDevResult
                 {
@@ -48,7 +48,7 @@ namespace Skender.Stock.Indicators
 
                     for (int p = (int)bd.Index - lookbackPeriod; p < bd.Index; p++)
                     {
-                        BasicData d = basicDataList[p];
+                        BasicData d = bdList[p];
                         periodValues[n] = (double)d.Value;
                         sum += d.Value;
                         n++;

--- a/indicators/StdDev/StdDev.cs
+++ b/indicators/StdDev/StdDev.cs
@@ -32,21 +32,23 @@ namespace Skender.Stock.Indicators
             List<StdDevResult> results = new List<StdDevResult>();
 
             // roll through history and compute lookback standard deviation
-            foreach (BasicData bd in bdList)
+            for (int i = 0; i < bdList.Count; i++)
             {
+                BasicData bd = bdList[i];
+                int index = i + 1;
+
                 StdDevResult result = new StdDevResult
                 {
-                    Index = (int)bd.Index,
                     Date = bd.Date,
                 };
 
-                if (bd.Index >= lookbackPeriod)
+                if (index >= lookbackPeriod)
                 {
                     double[] periodValues = new double[lookbackPeriod];
                     decimal sum = 0m;
                     int n = 0;
 
-                    for (int p = (int)bd.Index - lookbackPeriod; p < bd.Index; p++)
+                    for (int p = index - lookbackPeriod; p < index; p++)
                     {
                         BasicData d = bdList[p];
                         periodValues[n] = (double)d.Value;
@@ -63,10 +65,10 @@ namespace Skender.Stock.Indicators
                 results.Add(result);
 
                 // optional SMA
-                if (smaPeriod != null && bd.Index >= lookbackPeriod + smaPeriod - 1)
+                if (smaPeriod != null && index >= lookbackPeriod + smaPeriod - 1)
                 {
                     decimal sumSma = 0m;
-                    for (int p = (int)bd.Index - (int)smaPeriod; p < bd.Index; p++)
+                    for (int p = index - (int)smaPeriod; p < index; p++)
                     {
                         sumSma += (decimal)results[p].StdDev;
                     }

--- a/indicators/Stoch/Stoch.cs
+++ b/indicators/Stoch/Stoch.cs
@@ -11,7 +11,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            List<Quote> historyList = Cleaners.PrepareHistory(history).ToList();
+            List<Quote> historyList = history.Sort();
 
             // validate parameters
             ValidateStoch(history, lookbackPeriod, signalPeriod, smoothPeriod);

--- a/indicators/Stoch/Stoch.cs
+++ b/indicators/Stoch/Stoch.cs
@@ -23,19 +23,19 @@ namespace Skender.Stock.Indicators
             for (int i = 0; i < historyList.Count; i++)
             {
                 Quote h = historyList[i];
+                int index = i + 1;
 
                 StochResult result = new StochResult
                 {
-                    Index = (int)h.Index,
                     Date = h.Date
                 };
 
-                if (h.Index >= lookbackPeriod)
+                if (index >= lookbackPeriod)
                 {
                     decimal highHigh = 0;
                     decimal lowLow = decimal.MaxValue;
 
-                    for (int p = (int)h.Index - lookbackPeriod; p < h.Index; p++)
+                    for (int p = index - lookbackPeriod; p < index; p++)
                     {
                         Quote d = historyList[p];
 
@@ -71,10 +71,13 @@ namespace Skender.Stock.Indicators
 
 
             // signal and period direction info
-            int stochIndex = lookbackPeriod + smoothPeriod - 1;
+            int stochIndex = lookbackPeriod + smoothPeriod - 2;
 
-            foreach (StochResult r in results.Where(x => x.Index >= stochIndex))
+            for (int i = stochIndex; i < results.Count; i++)
             {
+                StochResult r = results[i];
+                int index = i + 1;
+
                 // add signal
                 int signalIndex = lookbackPeriod + smoothPeriod + signalPeriod - 2;
 
@@ -82,10 +85,10 @@ namespace Skender.Stock.Indicators
                 {
                     r.Signal = r.Oscillator;
                 }
-                else if (r.Index >= signalIndex)
+                else if (index >= signalIndex)
                 {
                     decimal sumOsc = 0m;
-                    for (int p = r.Index - signalPeriod; p < r.Index; p++)
+                    for (int p = index - signalPeriod; p < index; p++)
                     {
                         StochResult d = results[p];
                         sumOsc += (decimal)d.Oscillator;
@@ -99,19 +102,20 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static List<StochResult> SmoothOscillator(List<StochResult> results, int lookbackPeriod, int smoothPeriod)
+        private static List<StochResult> SmoothOscillator(
+            List<StochResult> results, int lookbackPeriod, int smoothPeriod)
         {
 
             // temporarily store interim smoothed oscillator
-            int smoothIndex = lookbackPeriod + smoothPeriod - 1;
+            int smoothIndex = lookbackPeriod + smoothPeriod - 2;
 
-            //foreach (StochResult r in results.Where(x => x.Index >= smoothIndex))
-            for (int i = smoothIndex - 1; i < results.Count; i++)
+            for (int i = smoothIndex; i < results.Count; i++)
             {
                 StochResult r = results[i];
+                int index = i + 1;
 
                 decimal sumOsc = 0m;
-                for (int p = r.Index - smoothPeriod; p < r.Index; p++)
+                for (int p = index - smoothPeriod; p < index; p++)
                 {
                     StochResult d = results[p];
                     sumOsc += (decimal)d.Oscillator;

--- a/indicators/StochRsi/StochRsi.cs
+++ b/indicators/StochRsi/StochRsi.cs
@@ -11,9 +11,6 @@ namespace Skender.Stock.Indicators
             int rsiPeriod, int stochPeriod, int signalPeriod, int smoothPeriod = 1)
         {
 
-            // clean quotes
-            history = Cleaners.PrepareHistory(history);
-
             // validate parameters
             ValidateStochRsi(history, rsiPeriod, stochPeriod, signalPeriod, smoothPeriod);
 

--- a/indicators/StochRsi/StochRsi.cs
+++ b/indicators/StochRsi/StochRsi.cs
@@ -28,7 +28,6 @@ namespace Skender.Stock.Indicators
                 .Where(x => x.Rsi != null)
                 .Select(x => new Quote
                 {
-                    Index = null,
                     Date = x.Date,
                     High = (decimal)x.Rsi,
                     Low = (decimal)x.Rsi,
@@ -43,16 +42,16 @@ namespace Skender.Stock.Indicators
             for (int i = 0; i < rsiResults.Count; i++)
             {
                 RsiResult r = rsiResults[i];
+                int index = i + 1;
 
                 StochRsiResult result = new StochRsiResult
                 {
-                    Index = r.Index,
                     Date = r.Date
                 };
 
-                if (r.Index >= rsiPeriod + stochPeriod)
+                if (index >= rsiPeriod + stochPeriod)
                 {
-                    StochResult sto = stoResults[r.Index - stochPeriod - 1];
+                    StochResult sto = stoResults[index - stochPeriod - 1];
 
                     result.StochRsi = sto.Oscillator;
                     result.Signal = sto.Signal;

--- a/indicators/Trix/Trix.cs
+++ b/indicators/Trix/Trix.cs
@@ -41,19 +41,19 @@ namespace Skender.Stock.Indicators
             for (int i = 0; i < emaN1.Count; i++)
             {
                 EmaResult e1 = emaN1[i];
+                int index = i + 1;
 
                 TrixResult result = new TrixResult
                 {
-                    Index = e1.Index,
                     Date = e1.Date
                 };
 
                 results.Add(result);
 
-                if (e1.Index >= 3 * lookbackPeriod - 2)
+                if (index >= 3 * lookbackPeriod - 2)
                 {
-                    EmaResult e2 = emaN2[e1.Index - lookbackPeriod];
-                    EmaResult e3 = emaN3[e2.Index - lookbackPeriod];
+                    EmaResult e2 = emaN2[index - lookbackPeriod];
+                    EmaResult e3 = emaN3[index - 2 * lookbackPeriod + 1];
 
                     result.Ema3 = e3.Ema;
 
@@ -65,10 +65,10 @@ namespace Skender.Stock.Indicators
                     lastEma = e3.Ema;
 
                     // optional SMA
-                    if (signalPeriod != null && e1.Index >= 3 * lookbackPeriod - 2 + signalPeriod)
+                    if (signalPeriod != null && index >= 3 * lookbackPeriod - 2 + signalPeriod)
                     {
                         decimal sumSma = 0m;
-                        for (int p = e1.Index - (int)signalPeriod; p < e1.Index; p++)
+                        for (int p = index - (int)signalPeriod; p < index; p++)
                         {
                             sumSma += (decimal)results[p].Trix;
                         }

--- a/indicators/Trix/Trix.cs
+++ b/indicators/Trix/Trix.cs
@@ -12,7 +12,7 @@ namespace Skender.Stock.Indicators
         {
 
             // convert history to basic format
-            IEnumerable<BasicData> bd = Cleaners.ConvertHistoryToBasic(history, "C");
+            List<BasicData> bd = Cleaners.ConvertHistoryToBasic(history, "C");
 
             // validate parameters
             ValidateTrix(bd, lookbackPeriod);
@@ -25,14 +25,14 @@ namespace Skender.Stock.Indicators
 
             List<BasicData> bd2 = emaN1
                 .Where(x => x.Ema != null)
-                .Select(x => new BasicData { Index = null, Date = x.Date, Value = (decimal)x.Ema })
+                .Select(x => new BasicData { Date = x.Date, Value = (decimal)x.Ema })
                 .ToList();
 
             List<EmaResult> emaN2 = CalcEma(bd2, lookbackPeriod).ToList();
 
             List<BasicData> bd3 = emaN2
                 .Where(x => x.Ema != null)
-                .Select(x => new BasicData { Index = null, Date = x.Date, Value = (decimal)x.Ema })
+                .Select(x => new BasicData { Date = x.Date, Value = (decimal)x.Ema })
                 .ToList();
 
             List<EmaResult> emaN3 = CalcEma(bd3, lookbackPeriod).ToList();

--- a/indicators/UlcerIndex/Ulcer.cs
+++ b/indicators/UlcerIndex/Ulcer.cs
@@ -23,22 +23,22 @@ namespace Skender.Stock.Indicators
             for (int i = 0; i < historyList.Count; i++)
             {
                 Quote h = historyList[i];
+                int index = i + 1;
 
                 UlcerIndexResult result = new UlcerIndexResult
                 {
-                    Index = (int)h.Index,
                     Date = h.Date
                 };
 
-                if (h.Index >= lookbackPeriod)
+                if (index >= lookbackPeriod)
                 {
                     double sumSquared = 0;
-                    for (int p = (int)h.Index - lookbackPeriod; p < h.Index; p++)
+                    for (int p = index - lookbackPeriod; p < index; p++)
                     {
                         Quote d = historyList[p];
 
                         decimal maxClose = 0;
-                        for (int q = (int)h.Index - lookbackPeriod; q < d.Index; q++)
+                        for (int q = index - lookbackPeriod; q < d.Index; q++)
                         {
                             Quote dd = historyList[q];
                             if (dd.Close > maxClose)

--- a/indicators/UlcerIndex/Ulcer.cs
+++ b/indicators/UlcerIndex/Ulcer.cs
@@ -11,7 +11,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            List<Quote> historyList = Cleaners.PrepareHistory(history).ToList();
+            List<Quote> historyList = history.Sort();
 
             // validate parameters
             ValidateUlcer(history, lookbackPeriod);
@@ -36,9 +36,10 @@ namespace Skender.Stock.Indicators
                     for (int p = index - lookbackPeriod; p < index; p++)
                     {
                         Quote d = historyList[p];
+                        int dIndex = p + 1;
 
                         decimal maxClose = 0;
-                        for (int q = index - lookbackPeriod; q < d.Index; q++)
+                        for (int q = index - lookbackPeriod; q < dIndex; q++)
                         {
                             Quote dd = historyList[q];
                             if (dd.Close > maxClose)

--- a/indicators/Ultimate/Ultimate.cs
+++ b/indicators/Ultimate/Ultimate.cs
@@ -12,7 +12,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            List<Quote> historyList = Cleaners.PrepareHistory(history).ToList();
+            List<Quote> historyList = history.Sort();
 
             // check parameters
             ValidateUltimate(history, shortPeriod, middlePeriod, longPeriod);

--- a/indicators/Ultimate/Ultimate.cs
+++ b/indicators/Ultimate/Ultimate.cs
@@ -25,10 +25,10 @@ namespace Skender.Stock.Indicators
             for (int i = 0; i < historyList.Count; i++)
             {
                 Quote h = historyList[i];
+                int index = i + 1;
 
                 UltimateResult r = new UltimateResult
                 {
-                    Index = (int)h.Index,
                     Date = h.Date
                 };
                 results.Add(r);
@@ -39,7 +39,7 @@ namespace Skender.Stock.Indicators
                     r.Tr = Math.Max(h.High, priorClose) - Math.Min(h.Low, priorClose);
                 }
 
-                if (h.Index >= longPeriod + 1)
+                if (index >= longPeriod + 1)
                 {
                     decimal sumBP1 = 0m;
                     decimal sumBP2 = 0m;
@@ -49,19 +49,20 @@ namespace Skender.Stock.Indicators
                     decimal sumTR2 = 0m;
                     decimal sumTR3 = 0m;
 
-                    for (int p = (int)h.Index - longPeriod; p < h.Index; p++)
+                    for (int p = index - longPeriod; p < index; p++)
                     {
                         UltimateResult pr = results[p];
+                        int pIndex = p + 1;
 
                         // short aggregate
-                        if (pr.Index > h.Index - shortPeriod)
+                        if (pIndex > index - shortPeriod)
                         {
                             sumBP1 += (decimal)pr.Bp;
                             sumTR1 += (decimal)pr.Tr;
                         }
 
                         // middle aggregate
-                        if (pr.Index > h.Index - middlePeriod)
+                        if (pIndex > index - middlePeriod)
                         {
                             sumBP2 += (decimal)pr.Bp;
                             sumTR2 += (decimal)pr.Tr;

--- a/indicators/VolSma/VolSma.cs
+++ b/indicators/VolSma/VolSma.cs
@@ -14,7 +14,6 @@ namespace Skender.Stock.Indicators
             List<VolSmaResult> results = Cleaners.PrepareHistory(history)
                 .Select(x => new VolSmaResult
                 {
-                    Index = (int)x.Index,
                     Date = x.Date,
                     Volume = x.Volume
                 })
@@ -27,9 +26,10 @@ namespace Skender.Stock.Indicators
             for (int i = lookbackPeriod - 1; i < results.Count; i++)
             {
                 VolSmaResult h = results[i];
+                int index = i + 1;
 
                 decimal sumVolSma = 0m;
-                for (int p = h.Index - lookbackPeriod; p < h.Index; p++)
+                for (int p = index - lookbackPeriod; p < index; p++)
                 {
                     VolSmaResult q = results[p];
                     sumVolSma += q.Volume;

--- a/indicators/VolSma/VolSma.cs
+++ b/indicators/VolSma/VolSma.cs
@@ -11,7 +11,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes and initialize results
-            List<VolSmaResult> results = Cleaners.PrepareHistory(history)
+            List<VolSmaResult> results = history.Sort()
                 .Select(x => new VolSmaResult
                 {
                     Date = x.Date,

--- a/indicators/WilliamsR/WilliamsR.cs
+++ b/indicators/WilliamsR/WilliamsR.cs
@@ -10,9 +10,6 @@ namespace Skender.Stock.Indicators
         public static IEnumerable<WilliamsResult> GetWilliamsR(IEnumerable<Quote> history, int lookbackPeriod = 14)
         {
 
-            // clean quotes
-            history = Cleaners.PrepareHistory(history);
-
             // validate parameters
             ValidateWilliam(history, lookbackPeriod);
 

--- a/indicators/WilliamsR/WilliamsR.cs
+++ b/indicators/WilliamsR/WilliamsR.cs
@@ -20,7 +20,6 @@ namespace Skender.Stock.Indicators
             return GetStoch(history, lookbackPeriod, 1, 1) // fast variant
                 .Select(s => new WilliamsResult
                 {
-                    Index = s.Index,
                     Date = s.Date,
                     WilliamsR = s.Oscillator - 100
                 })

--- a/indicators/Wma/Wma.cs
+++ b/indicators/Wma/Wma.cs
@@ -11,7 +11,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            List<Quote> historyList = Cleaners.PrepareHistory(history).ToList();
+            List<Quote> historyList = history.Sort();
 
             // check parameters
             ValidateWma(history, lookbackPeriod);

--- a/indicators/Wma/Wma.cs
+++ b/indicators/Wma/Wma.cs
@@ -24,20 +24,20 @@ namespace Skender.Stock.Indicators
             for (int i = 0; i < historyList.Count; i++)
             {
                 Quote h = historyList[i];
+                int index = i + 1;
 
                 WmaResult result = new WmaResult
                 {
-                    Index = (int)h.Index,
                     Date = h.Date
                 };
 
-                if (h.Index >= lookbackPeriod)
+                if (index >= lookbackPeriod)
                 {
                     decimal wma = 0;
-                    for (int p = (int)h.Index - lookbackPeriod; p < h.Index; p++)
+                    for (int p = index - lookbackPeriod; p < index; p++)
                     {
                         Quote d = historyList[p];
-                        wma += d.Close * (lookbackPeriod - (decimal)(h.Index - d.Index)) / divisor;
+                        wma += d.Close * (lookbackPeriod - (decimal)(index - p - 1)) / divisor;
                     }
 
                     result.Wma = wma;

--- a/indicators/ZigZag/ZigZag.cs
+++ b/indicators/ZigZag/ZigZag.cs
@@ -21,25 +21,25 @@ namespace Skender.Stock.Indicators
             List<ZigZagResult> results = new List<ZigZagResult>();
             decimal changeThreshold = percentChange / 100m;
             Quote firstQuote = historyList[0];
-            ZigZagEval eval = GetZigZagEval(type, firstQuote);
+            ZigZagEval eval = GetZigZagEval(type, 1, firstQuote);
 
             ZigZagPoint lastPoint = new ZigZagPoint
             {
-                Index = 1,
+                Index = eval.Index,
                 Value = firstQuote.Close,
                 PointType = "U"
             };
 
             ZigZagPoint lastHighPoint = new ZigZagPoint
             {
-                Index = 1,
+                Index = eval.Index,
                 Value = eval.High,
                 PointType = "H"
             };
 
             ZigZagPoint lastLowPoint = new ZigZagPoint
             {
-                Index = 1,
+                Index = eval.Index,
                 Value = eval.Low,
                 PointType = "L"
             };
@@ -50,8 +50,9 @@ namespace Skender.Stock.Indicators
             for (int i = 0; i < historyList.Count; i++)
             {
                 Quote h = historyList[i];
+                int index = i + 1;
 
-                eval = GetZigZagEval(type, h);
+                eval = GetZigZagEval(type, index, h);
                 decimal changeUp = (eval.High - lastLowPoint.Value) / lastLowPoint.Value;
                 decimal changeDn = (lastHighPoint.Value - eval.Low) / lastHighPoint.Value;
 
@@ -102,7 +103,6 @@ namespace Skender.Stock.Indicators
             // initialize 
             bool trendUp = (lastPoint.PointType == "L");
             decimal change = 0;
-            ZigZagEval eval = new ZigZagEval();
 
             ZigZagPoint extremePoint = new ZigZagPoint
             {
@@ -115,7 +115,9 @@ namespace Skender.Stock.Indicators
             for (int i = lastPoint.Index; i < historyList.Count; i++)
             {
                 Quote h = historyList[i];
-                eval = GetZigZagEval(type, h);
+                int index = i + 1;
+
+                ZigZagEval eval = GetZigZagEval(type, index, h);
 
                 // reset extreme point
                 switch (trendUp)
@@ -249,9 +251,12 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static ZigZagEval GetZigZagEval(ZigZagType type, Quote q)
+        private static ZigZagEval GetZigZagEval(ZigZagType type, int index, Quote q)
         {
-            ZigZagEval eval = new ZigZagEval();
+            ZigZagEval eval = new ZigZagEval()
+            {
+                Index = index
+            };
 
             // consider `type`
             switch (type)

--- a/indicators/ZigZag/ZigZag.cs
+++ b/indicators/ZigZag/ZigZag.cs
@@ -12,7 +12,7 @@ namespace Skender.Stock.Indicators
         {
 
             // clean quotes
-            List<Quote> historyList = Cleaners.PrepareHistory(history).ToList();
+            List<Quote> historyList = history.Sort();
 
             // check parameters
             ValidateZigZag(history, percentChange);
@@ -25,21 +25,21 @@ namespace Skender.Stock.Indicators
 
             ZigZagPoint lastPoint = new ZigZagPoint
             {
-                Index = eval.Index,
+                Index = 1,
                 Value = firstQuote.Close,
                 PointType = "U"
             };
 
             ZigZagPoint lastHighPoint = new ZigZagPoint
             {
-                Index = eval.Index,
+                Index = 1,
                 Value = eval.High,
                 PointType = "H"
             };
 
             ZigZagPoint lastLowPoint = new ZigZagPoint
             {
-                Index = eval.Index,
+                Index = 1,
                 Value = eval.Low,
                 PointType = "L"
             };
@@ -102,6 +102,7 @@ namespace Skender.Stock.Indicators
             // initialize 
             bool trendUp = (lastPoint.PointType == "L");
             decimal change = 0;
+            ZigZagEval eval = new ZigZagEval();
 
             ZigZagPoint extremePoint = new ZigZagPoint
             {
@@ -114,7 +115,7 @@ namespace Skender.Stock.Indicators
             for (int i = lastPoint.Index; i < historyList.Count; i++)
             {
                 Quote h = historyList[i];
-                ZigZagEval eval = GetZigZagEval(type, h);
+                eval = GetZigZagEval(type, h);
 
                 // reset extreme point
                 switch (trendUp)
@@ -250,10 +251,7 @@ namespace Skender.Stock.Indicators
 
         private static ZigZagEval GetZigZagEval(ZigZagType type, Quote q)
         {
-            ZigZagEval eval = new ZigZagEval()
-            {
-                Index = (int)q.Index
-            };
+            ZigZagEval eval = new ZigZagEval();
 
             // consider `type`
             switch (type)

--- a/indicators/_Common/Cleaners.cs
+++ b/indicators/_Common/Cleaners.cs
@@ -11,7 +11,7 @@ namespace Skender.Stock.Indicators
     {
         private static readonly CultureInfo nativeCulture = Thread.CurrentThread.CurrentUICulture;
 
-        public static List<Quote> PrepareHistory(IEnumerable<Quote> history)
+        public static List<Quote> ValidateHistory(IEnumerable<Quote> history)
         {
             // we cannot rely on date consistency when looking back, so we add an index and sort
 

--- a/indicators/_Common/Cleaners.cs
+++ b/indicators/_Common/Cleaners.cs
@@ -104,7 +104,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        internal static IEnumerable<BasicData> ConvertHistoryToBasic(IEnumerable<Quote> history, string element = "C")
+        internal static List<BasicData> ConvertHistoryToBasic(IEnumerable<Quote> history, string element = "C")
         {
             // elements represents the targeted OHLCV parts, so use "O" to return <Open> as base data, etc.
 

--- a/indicators/_Common/Models.cs
+++ b/indicators/_Common/Models.cs
@@ -5,7 +5,6 @@ namespace Skender.Stock.Indicators
     [Serializable]
     public class Quote
     {
-        internal int? Index { get; set; }
         public DateTime Date { get; set; }
         public decimal Open { get; set; }
         public decimal High { get; set; }
@@ -23,7 +22,6 @@ namespace Skender.Stock.Indicators
     [Serializable]
     internal class BasicData
     {
-        internal int? Index { get; set; }
         internal DateTime Date { get; set; }
         internal decimal Value { get; set; }
     }

--- a/indicators/_Common/Models.cs
+++ b/indicators/_Common/Models.cs
@@ -17,7 +17,6 @@ namespace Skender.Stock.Indicators
     [Serializable]
     public class ResultBase
     {
-        internal int Index { get; set; }
         public DateTime Date { get; set; }
     }
 

--- a/tests/external/Test.PublicClass.cs
+++ b/tests/external/Test.PublicClass.cs
@@ -28,7 +28,7 @@ namespace External.Tests
         public void CleanHistory()
         {
             IEnumerable<Quote> history = History.GetHistory();
-            history = Cleaners.PrepareHistory(history);
+            history = Cleaners.ValidateHistory(history);
 
             Indicator.GetSma(history, 5);
         }
@@ -37,7 +37,7 @@ namespace External.Tests
         public void ReadQuoteClass()
         {
             IEnumerable<Quote> history = History.GetHistory();
-            List<Quote> h = Cleaners.PrepareHistory(history);
+            List<Quote> h = Cleaners.ValidateHistory(history);
 
             Quote f = h.FirstOrDefault();
             Console.WriteLine("Date:{0},Close:{1}", f.Date, f.Close);
@@ -60,7 +60,7 @@ namespace External.Tests
         public void DerivedQuoteClassLinq()
         {
             IEnumerable<Quote> history = History.GetHistory();
-            history = Cleaners.PrepareHistory(history);
+            history = Cleaners.ValidateHistory(history);
 
             // can use a derive Quote class using Linq
 

--- a/tests/indicators/Test.Adl.cs
+++ b/tests/indicators/Test.Adl.cs
@@ -14,22 +14,22 @@ namespace Internal.Tests
         public void GetAdlTest()
         {
 
-            IEnumerable<AdlResult> results = Indicator.GetAdl(history);
+            List<AdlResult> results = Indicator.GetAdl(history).ToList();
 
             // assertions
 
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(502, results.Where(x => x.Sma == null).Count());
 
             // sample values
-            AdlResult r1 = results.Where(x => x.Index == 502).FirstOrDefault();
+            AdlResult r1 = results[501];
             Assert.AreEqual(0.8052m, Math.Round(r1.MoneyFlowMultiplier, 4));
             Assert.AreEqual(118396116.25m, Math.Round(r1.MoneyFlowVolume, 2));
             Assert.AreEqual(3439986548.42m, Math.Round(r1.Adl, 2));
             Assert.AreEqual(null, r1.Sma);
 
-            AdlResult r2 = results.Where(x => x.Index == 250).FirstOrDefault();
+            AdlResult r2 = results[249];
             Assert.AreEqual(0.7778m, Math.Round(r2.MoneyFlowMultiplier, 4));
             Assert.AreEqual(36433792.89m, Math.Round(r2.MoneyFlowVolume, 2));
             Assert.AreEqual(3266400865.74m, Math.Round(r2.Adl, 2));
@@ -40,16 +40,16 @@ namespace Internal.Tests
         public void GetAdlWithSmaTest()
         {
 
-            IEnumerable<AdlResult> results = Indicator.GetAdl(history, 20);
-            Assert.AreEqual(483, results.Where(x => x.Sma != null).Count());
+            List<AdlResult> results = Indicator.GetAdl(history, 20).ToList();
 
             // assertions
 
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
+            Assert.AreEqual(483, results.Where(x => x.Sma != null).Count());
 
             // sample value
-            AdlResult r = results.Where(x => x.Index == 502).FirstOrDefault();
+            AdlResult r = results[501];
             Assert.AreEqual(0.8052m, Math.Round(r.MoneyFlowMultiplier, 4));
             Assert.AreEqual(118396116.25m, Math.Round(r.MoneyFlowVolume, 2));
             Assert.AreEqual(3439986548.42m, Math.Round(r.Adl, 2));

--- a/tests/indicators/Test.Adl.cs
+++ b/tests/indicators/Test.Adl.cs
@@ -70,7 +70,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetAdl(history.Where(x => x.Index < 2));
+            IEnumerable<Quote> h = History.GetHistory(1);
+            Indicator.GetAdl(h);
         }
 
     }

--- a/tests/indicators/Test.Adx.cs
+++ b/tests/indicators/Test.Adx.cs
@@ -59,7 +59,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetAdx(history.Where(x => x.Index < 160), 30);
+            IEnumerable<Quote> h = History.GetHistory(159);
+            Indicator.GetAdx(h, 30);
         }
 
     }

--- a/tests/indicators/Test.Adx.cs
+++ b/tests/indicators/Test.Adx.cs
@@ -14,32 +14,32 @@ namespace Internal.Tests
         public void GetAdxTest()
         {
             int lookbackPeriod = 14;
-            IEnumerable<AdxResult> results = Indicator.GetAdx(history, lookbackPeriod);
+            List<AdxResult> results = Indicator.GetAdx(history, lookbackPeriod).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(475, results.Where(x => x.Adx != null).Count());
 
             // sample values
-            AdxResult r1 = results.Where(x => x.Index == 502).FirstOrDefault();
+            AdxResult r1 = results[501];
             Assert.AreEqual(17.7565m, Math.Round((decimal)r1.Pdi, 4));
             Assert.AreEqual(31.1510m, Math.Round((decimal)r1.Mdi, 4));
             Assert.AreEqual(34.2987m, Math.Round((decimal)r1.Adx, 4));
 
-            AdxResult r2 = results.Where(x => x.Index == 249).FirstOrDefault();
+            AdxResult r2 = results[248];
             Assert.AreEqual(32.3167m, Math.Round((decimal)r2.Pdi, 4));
             Assert.AreEqual(18.2471m, Math.Round((decimal)r2.Mdi, 4));
             Assert.AreEqual(30.5903m, Math.Round((decimal)r2.Adx, 4));
 
-            AdxResult r3 = results.Where(x => x.Index == 20).FirstOrDefault();
+            AdxResult r3 = results[19];
             Assert.AreEqual(21.0361m, Math.Round((decimal)r3.Pdi, 4));
             Assert.AreEqual(25.0124m, Math.Round((decimal)r3.Mdi, 4));
             Assert.AreEqual(null, r3.Adx);
 
-            AdxResult r4 = results.Where(x => x.Index == 30).FirstOrDefault();
+            AdxResult r4 = results[29];
             Assert.AreEqual(37.9719m, Math.Round((decimal)r4.Pdi, 4));
             Assert.AreEqual(14.1658m, Math.Round((decimal)r4.Mdi, 4));
             Assert.AreEqual(19.7949m, Math.Round((decimal)r4.Adx, 4));

--- a/tests/indicators/Test.Aroon.cs
+++ b/tests/indicators/Test.Aroon.cs
@@ -14,39 +14,39 @@ namespace Internal.Tests
         public void GetAroonTest()
         {
             int lookbackPeriod = 25;
-            IEnumerable<AroonResult> results = Indicator.GetAroon(history, lookbackPeriod);
+            List<AroonResult> results = Indicator.GetAroon(history, lookbackPeriod).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(477, results.Where(x => x.AroonUp != null).Count());
             Assert.AreEqual(477, results.Where(x => x.AroonDown != null).Count());
             Assert.AreEqual(477, results.Where(x => x.Oscillator != null).Count());
 
             // sample values
-            AroonResult r1 = results.Where(x => x.Index == 502).FirstOrDefault();
+            AroonResult r1 = results[501];
             Assert.AreEqual(28m, r1.AroonUp);
             Assert.AreEqual(88m, r1.AroonDown);
             Assert.AreEqual(-60m, r1.Oscillator);
 
-            AroonResult r2 = results.Where(x => x.Index == 459).FirstOrDefault();
+            AroonResult r2 = results[458];
             Assert.AreEqual(0m, r2.AroonUp);
             Assert.AreEqual(100m, r2.AroonDown);
             Assert.AreEqual(-100m, r2.Oscillator);
 
-            AroonResult r3 = results.Where(x => x.Index == 299).FirstOrDefault();
+            AroonResult r3 = results[298];
             Assert.AreEqual(0m, r3.AroonUp);
             Assert.AreEqual(20m, r3.AroonDown);
             Assert.AreEqual(-20m, r3.Oscillator);
 
-            AroonResult r4 = results.Where(x => x.Index == 294).FirstOrDefault();
+            AroonResult r4 = results[293];
             Assert.AreEqual(0m, r4.AroonUp);
             Assert.AreEqual(40m, r4.AroonDown);
             Assert.AreEqual(-40m, r4.Oscillator);
 
-            AroonResult r5 = results.Where(x => x.Index == 211).FirstOrDefault();
+            AroonResult r5 = results[210];
             Assert.AreEqual(100m, r5.AroonUp);
             Assert.AreEqual(0m, r5.AroonDown);
             Assert.AreEqual(100m, r5.Oscillator);

--- a/tests/indicators/Test.Aroon.cs
+++ b/tests/indicators/Test.Aroon.cs
@@ -66,7 +66,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetAroon(history.Where(x => x.Index < 30), 30);
+            IEnumerable<Quote> h = History.GetHistory(29);
+            Indicator.GetAroon(h, 30);
         }
 
     }

--- a/tests/indicators/Test.Atr.cs
+++ b/tests/indicators/Test.Atr.cs
@@ -44,7 +44,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetAtr(history.Where(x => x.Index < 31), 30);
+            IEnumerable<Quote> h = History.GetHistory(30);
+            Indicator.GetAtr(h, 30);
         }
 
     }

--- a/tests/indicators/Test.Atr.cs
+++ b/tests/indicators/Test.Atr.cs
@@ -14,17 +14,17 @@ namespace Internal.Tests
         public void GetAtrTest()
         {
             int lookbackPeriod = 14;
-            IEnumerable<AtrResult> results = Indicator.GetAtr(history, lookbackPeriod);
+            List<AtrResult> results = Indicator.GetAtr(history, lookbackPeriod).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(502 - lookbackPeriod + 1, results.Where(x => x.Atr != null).Count());
 
             // sample value
-            AtrResult r = results.Where(x => x.Index == 502).FirstOrDefault();
+            AtrResult r = results[501];
             Assert.AreEqual(2.67m, Math.Round((decimal)r.Tr, 4));
             Assert.AreEqual(6.1497m, Math.Round((decimal)r.Atr, 4));
             Assert.AreEqual(2.5072m, Math.Round((decimal)r.Atrp, 4));

--- a/tests/indicators/Test.Beta.cs
+++ b/tests/indicators/Test.Beta.cs
@@ -14,17 +14,17 @@ namespace Internal.Tests
         public void GetBetaTest()
         {
             int lookbackPeriod = 20;
-            IEnumerable<BetaResult> results = Indicator.GetBeta(history, historyOther, lookbackPeriod);
+            List<BetaResult> results = Indicator.GetBeta(history, historyOther, lookbackPeriod).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(502 - lookbackPeriod + 1, results.Where(x => x.Beta != null).Count());
 
             // sample value
-            BetaResult r = results.Where(x => x.Index == 502).FirstOrDefault();
+            BetaResult r = results[501];
             Assert.AreEqual(1.6759m, Math.Round((decimal)r.Beta, 4));
         }
 
@@ -34,17 +34,17 @@ namespace Internal.Tests
         {
             // Beta should be 1 if evaluating against self
             int lookbackPeriod = 20;
-            IEnumerable<BetaResult> results = Indicator.GetBeta(history, history, lookbackPeriod);
+            List<BetaResult> results = Indicator.GetBeta(history, history, lookbackPeriod).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(502 - lookbackPeriod + 1, results.Where(x => x.Beta != null).Count());
 
             // sample value
-            BetaResult r = results.Where(x => x.Index == 502).FirstOrDefault();
+            BetaResult r = results[501];
             Assert.AreEqual(1, Math.Round((decimal)r.Beta, 4));
         }
 

--- a/tests/indicators/Test.Beta.cs
+++ b/tests/indicators/Test.Beta.cs
@@ -62,14 +62,17 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetBeta(history.Where(x => x.Index < 30), historyOther.Where(x => x.Index < 30), 30);
+            IEnumerable<Quote> h1 = History.GetHistory(29);
+            IEnumerable<Quote> h2 = History.GetHistoryOther(29);
+            Indicator.GetBeta(h1, h2, 30);
         }
 
         [TestMethod()]
         [ExpectedException(typeof(BadHistoryException), "Not enought Eval history.")]
         public void InsufficientEvalHistory()
         {
-            Indicator.GetBeta(history, historyOther.Where(x => x.Index <= 300), 30);
+            IEnumerable<Quote> h = History.GetHistoryOther(300);
+            Indicator.GetBeta(history, h, 30);
         }
 
     }

--- a/tests/indicators/Test.BollingerBands.cs
+++ b/tests/indicators/Test.BollingerBands.cs
@@ -72,7 +72,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetBollingerBands(history.Where(x => x.Index < 30), 30, 2);
+            IEnumerable<Quote> h = History.GetHistory(29);
+            Indicator.GetBollingerBands(h, 30, 2);
         }
 
     }

--- a/tests/indicators/Test.BollingerBands.cs
+++ b/tests/indicators/Test.BollingerBands.cs
@@ -16,14 +16,15 @@ namespace Internal.Tests
             int lookbackPeriod = 20;
             int standardDeviations = 2;
 
-            IEnumerable<BollingerBandsResult> results =
-                Indicator.GetBollingerBands(history, lookbackPeriod, standardDeviations);
+            List<BollingerBandsResult> results =
+                Indicator.GetBollingerBands(history, lookbackPeriod, standardDeviations)
+                .ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(483, results.Where(x => x.Sma != null).Count());
             Assert.AreEqual(483, results.Where(x => x.UpperBand != null).Count());
             Assert.AreEqual(483, results.Where(x => x.LowerBand != null).Count());
@@ -33,7 +34,7 @@ namespace Internal.Tests
 
 
             // sample values
-            BollingerBandsResult r1 = results.Where(x => x.Index == 502).FirstOrDefault();
+            BollingerBandsResult r1 = results[501];
             Assert.AreEqual(251.8600m, Math.Round((decimal)r1.Sma, 4));
             Assert.AreEqual(273.7004m, Math.Round((decimal)r1.UpperBand, 4));
             Assert.AreEqual(230.0196m, Math.Round((decimal)r1.LowerBand, 4));
@@ -41,7 +42,7 @@ namespace Internal.Tests
             Assert.AreEqual(-0.602552m, Math.Round((decimal)r1.ZScore, 6));
             Assert.AreEqual(0.173433m, Math.Round((decimal)r1.Width, 6));
 
-            BollingerBandsResult r2 = results.Where(x => x.Index == 250).FirstOrDefault();
+            BollingerBandsResult r2 = results[249];
             Assert.AreEqual(255.5500m, Math.Round((decimal)r2.Sma, 4));
             Assert.AreEqual(259.5642m, Math.Round((decimal)r2.UpperBand, 4));
             Assert.AreEqual(251.5358m, Math.Round((decimal)r2.LowerBand, 4));

--- a/tests/indicators/Test.Cci.cs
+++ b/tests/indicators/Test.Cci.cs
@@ -15,17 +15,17 @@ namespace Internal.Tests
         {
             int lookbackPeriod = 20;
 
-            IEnumerable<CciResult> results = Indicator.GetCci(history, lookbackPeriod);
+            List<CciResult> results = Indicator.GetCci(history, lookbackPeriod).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(502 - lookbackPeriod + 1, results.Where(x => x.Cci != null).Count());
 
             // sample value
-            CciResult r = results.Where(x => x.Index == 502).FirstOrDefault();
+            CciResult r = results[501];
             Assert.AreEqual(-52.9946m, Math.Round((decimal)r.Cci, 4));
         }
 

--- a/tests/indicators/Test.Cci.cs
+++ b/tests/indicators/Test.Cci.cs
@@ -43,7 +43,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetCci(history.Where(x => x.Index < 31), 30);
+            IEnumerable<Quote> h = History.GetHistory(30);
+            Indicator.GetCci(h, 30);
         }
 
     }

--- a/tests/indicators/Test.ChaikinOsc.cs
+++ b/tests/indicators/Test.ChaikinOsc.cs
@@ -53,14 +53,16 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history for S+100.")]
         public void InsufficientHistory100()
         {
-            Indicator.GetChaikinOsc(history.Where(x => x.Index < 110), 3, 10);
+            IEnumerable<Quote> h = History.GetHistory(109);
+            Indicator.GetChaikinOsc(h, 3, 10);
         }
 
         [TestMethod()]
         [ExpectedException(typeof(BadHistoryException), "Insufficient history for 2×S.")]
         public void InsufficientHistory250()
         {
-            Indicator.GetChaikinOsc(history.Where(x => x.Index < 500), 3, 250);
+            IEnumerable<Quote> h = History.GetHistory(499);
+            Indicator.GetChaikinOsc(h, 3, 250);
         }
 
     }

--- a/tests/indicators/Test.ChaikinOsc.cs
+++ b/tests/indicators/Test.ChaikinOsc.cs
@@ -15,17 +15,17 @@ namespace Internal.Tests
         {
             int fastPeriod = 3;
             int slowPeriod = 10;
-            IEnumerable<ChaikinOscResult> results = Indicator.GetChaikinOsc(history, fastPeriod, slowPeriod);
+            List<ChaikinOscResult> results = Indicator.GetChaikinOsc(history, fastPeriod, slowPeriod).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(502 - slowPeriod + 1, results.Where(x => x.Oscillator != null).Count());
 
             // sample value
-            ChaikinOscResult r = results.Where(x => x.Index == 502).FirstOrDefault();
+            ChaikinOscResult r = results[501];
             Assert.AreEqual(3439986548.42m, Math.Round(r.Adl, 2));
             Assert.AreEqual(0.8052m, Math.Round(r.MoneyFlowMultiplier, 4));
             Assert.AreEqual(118396116.25m, Math.Round(r.MoneyFlowVolume, 2));

--- a/tests/indicators/Test.Chandelier.cs
+++ b/tests/indicators/Test.Chandelier.cs
@@ -14,26 +14,30 @@ namespace Internal.Tests
         public void GetChandleierTest()
         {
             int lookbackPeriod = 22;
-            IEnumerable<ChandelierResult> longResult = Indicator.GetChandelier(history, lookbackPeriod, 3.0m);
+            List<ChandelierResult> longResult =
+                Indicator.GetChandelier(history, lookbackPeriod, 3.0m)
+                .ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, longResult.Count());
+            Assert.AreEqual(502, longResult.Count);
             Assert.AreEqual(502 - lookbackPeriod + 1, longResult.Where(x => x.ChandelierExit != null).Count());
 
             // sample values (long)
-            ChandelierResult a = longResult.Where(x => x.Index == 502).FirstOrDefault();
+            ChandelierResult a = longResult[501];
             Assert.AreEqual(256.5860m, Math.Round((decimal)a.ChandelierExit, 4));
 
-            ChandelierResult b = longResult.Where(x => x.Index == 493).FirstOrDefault();
+            ChandelierResult b = longResult[492];
             Assert.AreEqual(259.0480m, Math.Round((decimal)b.ChandelierExit, 4));
 
             // short
-            IEnumerable<ChandelierResult> shortResult = Indicator.GetChandelier(history, lookbackPeriod, 3.0m, ChandelierType.Short);
+            List<ChandelierResult> shortResult =
+                Indicator.GetChandelier(history, lookbackPeriod, 3.0m, ChandelierType.Short)
+                .ToList();
 
-            ChandelierResult c = shortResult.Where(x => x.Index == 502).FirstOrDefault();
+            ChandelierResult c = shortResult[501];
             Assert.AreEqual(246.4240m, Math.Round((decimal)c.ChandelierExit, 4));
         }
 

--- a/tests/indicators/Test.Chandelier.cs
+++ b/tests/indicators/Test.Chandelier.cs
@@ -62,7 +62,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetChandelier(history.Where(x => x.Index <= 30), 30);
+            IEnumerable<Quote> h = History.GetHistory(30);
+            Indicator.GetChandelier(h, 30);
         }
 
     }

--- a/tests/indicators/Test.Cmf.cs
+++ b/tests/indicators/Test.Cmf.cs
@@ -53,7 +53,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetCmf(history.Where(x => x.Index <= 20), 20);
+            IEnumerable<Quote> h = History.GetHistory(20);
+            Indicator.GetCmf(h, 20);
         }
     }
 }

--- a/tests/indicators/Test.Cmf.cs
+++ b/tests/indicators/Test.Cmf.cs
@@ -14,30 +14,26 @@ namespace Internal.Tests
         public void GetCmfTest()
         {
             int lookbackPeriod = 20;
-            IEnumerable<CmfResult> results = Indicator.GetCmf(history, lookbackPeriod);
+            List<CmfResult> results = Indicator.GetCmf(history, lookbackPeriod).ToList();
 
-            foreach (CmfResult r in results)
-            {
-                Console.WriteLine("{0},{1:F4},{2:F2},{3:F6}", r.Index, r.MoneyFlowMultiplier, r.MoneyFlowVolume, r.Cmf);
-            }
             // assertions
 
             // proper quantities
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(483, results.Where(x => x.Cmf != null).Count());
 
             // sample values
-            CmfResult r1 = results.Where(x => x.Index == 502).FirstOrDefault();
+            CmfResult r1 = results[501];
             Assert.AreEqual(0.8052m, Math.Round(r1.MoneyFlowMultiplier, 4));
             Assert.AreEqual(118396116.25m, Math.Round(r1.MoneyFlowVolume, 2));
             Assert.AreEqual(-0.123754m, Math.Round((decimal)r1.Cmf, 6));
 
-            CmfResult r2 = results.Where(x => x.Index == 250).FirstOrDefault();
+            CmfResult r2 = results[249];
             Assert.AreEqual(0.7778m, Math.Round(r2.MoneyFlowMultiplier, 4));
             Assert.AreEqual(36433792.89m, Math.Round(r2.MoneyFlowVolume, 2));
             Assert.AreEqual(-0.040226m, Math.Round((decimal)r2.Cmf, 6));
 
-            CmfResult r3 = results.Where(x => x.Index == 50).FirstOrDefault();
+            CmfResult r3 = results[49];
             Assert.AreEqual(0.5468m, Math.Round(r3.MoneyFlowMultiplier, 4));
             Assert.AreEqual(55609259m, Math.Round(r3.MoneyFlowVolume, 2));
             Assert.AreEqual(0.350596m, Math.Round((decimal)r3.Cmf, 6));

--- a/tests/indicators/Test.ConnorsRsi.cs
+++ b/tests/indicators/Test.ConnorsRsi.cs
@@ -72,7 +72,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetConnorsRsi(history.Where(x => x.Index < 102), 3, 2, 100);
+            IEnumerable<Quote> h = History.GetHistory(101);
+            Indicator.GetConnorsRsi(h, 3, 2, 100);
         }
 
     }

--- a/tests/indicators/Test.ConnorsRsi.cs
+++ b/tests/indicators/Test.ConnorsRsi.cs
@@ -18,25 +18,25 @@ namespace Internal.Tests
             int rankPeriod = 100;
             int startPeriod = Math.Max(rsiPeriod, Math.Max(streakPeriod, rankPeriod)) + 2;
 
-            IEnumerable<ConnorsRsiResult> results1 = Indicator.GetConnorsRsi(history, rsiPeriod, streakPeriod, rankPeriod);
+            List<ConnorsRsiResult> results1 = Indicator.GetConnorsRsi(history, rsiPeriod, streakPeriod, rankPeriod).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results1.Count());
+            Assert.AreEqual(502, results1.Count);
             Assert.AreEqual(502 - startPeriod + 1, results1.Where(x => x.ConnorsRsi != null).Count());
 
             // sample value
-            ConnorsRsiResult r1 = results1.Where(x => x.Index == 502).FirstOrDefault();
+            ConnorsRsiResult r1 = results1[501];
             Assert.AreEqual(68.8087m, Math.Round((decimal)r1.RsiClose, 4));
             Assert.AreEqual(67.4899m, Math.Round((decimal)r1.RsiStreak, 4));
             Assert.AreEqual(88.0000m, Math.Round((decimal)r1.PercentRank, 4));
             Assert.AreEqual(74.7662m, Math.Round((decimal)r1.ConnorsRsi, 4));
 
             // different parameters
-            IEnumerable<ConnorsRsiResult> results2 = Indicator.GetConnorsRsi(history, 14, 20, 10);
-            ConnorsRsiResult r2 = results2.Where(x => x.Index == 502).FirstOrDefault();
+            List<ConnorsRsiResult> results2 = Indicator.GetConnorsRsi(history, 14, 20, 10).ToList();
+            ConnorsRsiResult r2 = results2[501];
             Assert.AreEqual(42.0773m, Math.Round((decimal)r2.RsiClose, 4));
             Assert.AreEqual(52.7386m, Math.Round((decimal)r2.RsiStreak, 4));
             Assert.AreEqual(90.0000m, Math.Round((decimal)r2.PercentRank, 4));

--- a/tests/indicators/Test.Correlation.cs
+++ b/tests/indicators/Test.Correlation.cs
@@ -44,14 +44,17 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetCorrelation(history.Where(x => x.Index < 30), historyOther.Where(x => x.Index < 30), 30);
+            IEnumerable<Quote> h1 = History.GetHistory(29);
+            IEnumerable<Quote> h2 = History.GetHistoryOther(29);
+            Indicator.GetCorrelation(h1, h2, 30);
         }
 
         [TestMethod()]
         [ExpectedException(typeof(BadHistoryException), "Not enought Eval history.")]
         public void InsufficientEvalHistory()
         {
-            Indicator.GetCorrelation(history, historyOther.Where(x => x.Index <= 300), 30);
+            IEnumerable<Quote> h = History.GetHistory(300);
+            Indicator.GetCorrelation(history, h, 30);
         }
 
         [TestMethod()]

--- a/tests/indicators/Test.Correlation.cs
+++ b/tests/indicators/Test.Correlation.cs
@@ -14,17 +14,19 @@ namespace Internal.Tests
         public void GetCorrelationTest()
         {
             int lookbackPeriod = 20;
-            IEnumerable<CorrResult> results = Indicator.GetCorrelation(history, historyOther, lookbackPeriod);
+            List<CorrResult> results =
+                Indicator.GetCorrelation(history, historyOther, lookbackPeriod)
+                .ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(502 - lookbackPeriod + 1, results.Where(x => x.Correlation != null).Count());
 
             // sample value
-            CorrResult r = results.Where(x => x.Index == 502).FirstOrDefault();
+            CorrResult r = results[501];
             Assert.AreEqual(0.8460m, Math.Round((decimal)r.Correlation, 4));
             Assert.AreEqual(0.7157m, Math.Round((decimal)r.RSquared, 4));
         }

--- a/tests/indicators/Test.Donchian.cs
+++ b/tests/indicators/Test.Donchian.cs
@@ -14,26 +14,26 @@ namespace Internal.Tests
         public void GetDonchianTest()
         {
             int lookbackPeriod = 20;
-            IEnumerable<DonchianResult> results = Indicator.GetDonchian(history, lookbackPeriod);
+            List<DonchianResult> results = Indicator.GetDonchian(history, lookbackPeriod).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(502 - lookbackPeriod + 1, results.Where(x => x.Centerline != null).Count());
             Assert.AreEqual(502 - lookbackPeriod + 1, results.Where(x => x.UpperBand != null).Count());
             Assert.AreEqual(502 - lookbackPeriod + 1, results.Where(x => x.LowerBand != null).Count());
             Assert.AreEqual(502 - lookbackPeriod + 1, results.Where(x => x.Width != null).Count());
 
             // sample value
-            DonchianResult r1 = results.Where(x => x.Index == 502).FirstOrDefault();
+            DonchianResult r1 = results[501];
             Assert.AreEqual(251.5050m, Math.Round((decimal)r1.Centerline, 4));
             Assert.AreEqual(273.5900m, Math.Round((decimal)r1.UpperBand, 4));
             Assert.AreEqual(229.4200m, Math.Round((decimal)r1.LowerBand, 4));
             Assert.AreEqual(0.175623m, Math.Round((decimal)r1.Width, 6));
 
-            DonchianResult r2 = results.Where(x => x.Index == 486).FirstOrDefault();
+            DonchianResult r2 = results[485];
             Assert.AreEqual(265.2300m, Math.Round((decimal)r2.Centerline, 4));
             Assert.AreEqual(274.3900m, Math.Round((decimal)r2.UpperBand, 4));
             Assert.AreEqual(256.0700m, Math.Round((decimal)r2.LowerBand, 4));

--- a/tests/indicators/Test.Donchian.cs
+++ b/tests/indicators/Test.Donchian.cs
@@ -54,7 +54,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetDonchian(history.Where(x => x.Index < 30), 30);
+            IEnumerable<Quote> h = History.GetHistory(29);
+            Indicator.GetDonchian(h, 30);
         }
 
     }

--- a/tests/indicators/Test.DoubleEma.cs
+++ b/tests/indicators/Test.DoubleEma.cs
@@ -14,23 +14,23 @@ namespace Internal.Tests
         public void GetDoubleEmaTest()
         {
             int lookbackPeriod = 20;
-            IEnumerable<EmaResult> results = Indicator.GetDoubleEma(history, lookbackPeriod);
+            List<EmaResult> results = Indicator.GetDoubleEma(history, lookbackPeriod).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(464, results.Where(x => x.Ema != null).Count());
 
             // sample values
-            EmaResult r1 = results.Where(x => x.Index == 502).FirstOrDefault();
+            EmaResult r1 = results[501];
             Assert.AreEqual(241.1677m, Math.Round((decimal)r1.Ema, 4));
 
-            EmaResult r2 = results.Where(x => x.Index == 250).FirstOrDefault();
+            EmaResult r2 = results[249];
             Assert.AreEqual(258.4452m, Math.Round((decimal)r2.Ema, 4));
 
-            EmaResult r3 = results.Where(x => x.Index == 52).FirstOrDefault();
+            EmaResult r3 = results[51];
             Assert.AreEqual(226.0011m, Math.Round((decimal)r3.Ema, 4));
         }
 

--- a/tests/indicators/Test.DoubleEma.cs
+++ b/tests/indicators/Test.DoubleEma.cs
@@ -48,7 +48,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history for 2*N+100.")]
         public void InsufficientHistoryA()
         {
-            Indicator.GetDoubleEma(history.Where(x => x.Index < 160), 30);
+            IEnumerable<Quote> h = History.GetHistory(159);
+            Indicator.GetDoubleEma(h, 30);
         }
 
         [TestMethod()]

--- a/tests/indicators/Test.Ema.cs
+++ b/tests/indicators/Test.Ema.cs
@@ -14,23 +14,23 @@ namespace Internal.Tests
         public void GetEmaTest()
         {
             int lookbackPeriod = 20;
-            IEnumerable<EmaResult> results = Indicator.GetEma(history, lookbackPeriod);
+            List<EmaResult> results = Indicator.GetEma(history, lookbackPeriod).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(483, results.Where(x => x.Ema != null).Count());
 
             // sample values
-            EmaResult r1 = results.Where(x => x.Index == 502).FirstOrDefault();
+            EmaResult r1 = results[501];
             Assert.AreEqual(249.3519m, Math.Round((decimal)r1.Ema, 4));
 
-            EmaResult r2 = results.Where(x => x.Index == 250).FirstOrDefault();
+            EmaResult r2 = results[249];
             Assert.AreEqual(255.3873m, Math.Round((decimal)r2.Ema, 4));
 
-            EmaResult r3 = results.Where(x => x.Index == 30).FirstOrDefault();
+            EmaResult r3 = results[29];
             Assert.AreEqual(216.6228m, Math.Round((decimal)r3.Ema, 4));
         }
 

--- a/tests/indicators/Test.Ema.cs
+++ b/tests/indicators/Test.Ema.cs
@@ -48,14 +48,16 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history for N+100.")]
         public void InsufficientHistoryA()
         {
-            Indicator.GetEma(history.Where(x => x.Index < 130), 30);
+            IEnumerable<Quote> h = History.GetHistory(129);
+            Indicator.GetEma(h, 30);
         }
 
         [TestMethod()]
         [ExpectedException(typeof(BadHistoryException), "Insufficient history for 2×N.")]
         public void InsufficientHistoryB()
         {
-            Indicator.GetEma(history.Where(x => x.Index < 500), 250);
+            IEnumerable<Quote> h = History.GetHistory(499);
+            Indicator.GetEma(h, 250);
         }
 
     }

--- a/tests/indicators/Test.HeikinAshi.cs
+++ b/tests/indicators/Test.HeikinAshi.cs
@@ -14,15 +14,15 @@ namespace Internal.Tests
         public void GetHeikinAshiTest()
         {
 
-            IEnumerable<HeikinAshiResult> results = Indicator.GetHeikinAshi(history);
+            List<HeikinAshiResult> results = Indicator.GetHeikinAshi(history).ToList();
 
             // assertions
 
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
 
             // sample value
-            HeikinAshiResult r = results.Where(x => x.Index == 502).FirstOrDefault();
+            HeikinAshiResult r = results[501];
             Assert.AreEqual(241.3018m, Math.Round(r.Open, 4));
             Assert.AreEqual(245.54m, Math.Round(r.High, 4));
             Assert.AreEqual(241.3018m, Math.Round(r.Low, 4));

--- a/tests/indicators/Test.HeikinAshi.cs
+++ b/tests/indicators/Test.HeikinAshi.cs
@@ -36,7 +36,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetHeikinAshi(history.Where(x => x.Index < 2));
+            IEnumerable<Quote> h = History.GetHistory(1);
+            Indicator.GetHeikinAshi(h);
         }
 
     }

--- a/tests/indicators/Test.Hma.cs
+++ b/tests/indicators/Test.Hma.cs
@@ -45,7 +45,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetHma(history.Where(x => x.Index < 10), 10);
+            IEnumerable<Quote> h = History.GetHistory(9);
+            Indicator.GetHma(h, 10);
         }
     }
 }

--- a/tests/indicators/Test.Hma.cs
+++ b/tests/indicators/Test.Hma.cs
@@ -14,25 +14,20 @@ namespace Internal.Tests
         public void GetHmaTest()
         {
             int lookbackPeriod = 20;
-            IEnumerable<HmaResult> results = Indicator.GetHma(history, lookbackPeriod);
-
-            foreach (HmaResult r in results)
-            {
-                Console.WriteLine("{0},{1:d},{2:N4}", r.Index, r.Date, r.Hma);  // debugging only
-            }
+            List<HmaResult> results = Indicator.GetHma(history, lookbackPeriod).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(480, results.Where(x => x.Hma != null).Count());
 
             // sample values
-            HmaResult r1 = results.Where(x => x.Index == 150).FirstOrDefault();
+            HmaResult r1 = results[149];
             Assert.AreEqual(236.0835m, Math.Round((decimal)r1.Hma, 4));
 
-            HmaResult r2 = results.Where(x => x.Index == 502).FirstOrDefault();
+            HmaResult r2 = results[501];
             Assert.AreEqual(235.6972m, Math.Round((decimal)r2.Hma, 4));
         }
 

--- a/tests/indicators/Test.Ichimoku.cs
+++ b/tests/indicators/Test.Ichimoku.cs
@@ -76,7 +76,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetIchimoku(history.Where(x => x.Index < 52), 9, 26, 52);
+            IEnumerable<Quote> h = History.GetHistory(51);
+            Indicator.GetIchimoku(h, 9, 26, 52);
         }
     }
 }

--- a/tests/indicators/Test.Ichimoku.cs
+++ b/tests/indicators/Test.Ichimoku.cs
@@ -17,14 +17,15 @@ namespace Internal.Tests
             int shortSpanPeriod = 26;
             int longSpanPeriod = 52;
 
-            IEnumerable<IchimokuResult> results = Indicator.GetIchimoku(
-                history, signalPeriod, shortSpanPeriod, longSpanPeriod);
+            List<IchimokuResult> results = Indicator.GetIchimoku(
+                history, signalPeriod, shortSpanPeriod, longSpanPeriod)
+                .ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(494, results.Where(x => x.TenkanSen != null).Count());
             Assert.AreEqual(477, results.Where(x => x.KijunSen != null).Count());
             Assert.AreEqual(451, results.Where(x => x.SenkouSpanA != null).Count());
@@ -32,14 +33,14 @@ namespace Internal.Tests
             Assert.AreEqual(476, results.Where(x => x.ChikouSpan != null).Count());
 
             // sample values
-            IchimokuResult r1 = results.Where(x => x.Index == 476).FirstOrDefault();
+            IchimokuResult r1 = results[475];
             Assert.AreEqual(265.575m, r1.TenkanSen);
             Assert.AreEqual(263.965m, r1.KijunSen);
             Assert.AreEqual(274.9475m, r1.SenkouSpanA);
             Assert.AreEqual(274.95m, r1.SenkouSpanB);
             Assert.AreEqual(245.28m, r1.ChikouSpan);
 
-            IchimokuResult r2 = results.Where(x => x.Index == 502).FirstOrDefault();
+            IchimokuResult r2 = results[501];
             Assert.AreEqual(241.26m, r2.TenkanSen);
             Assert.AreEqual(251.505m, r2.KijunSen);
             Assert.AreEqual(264.77m, r2.SenkouSpanA);

--- a/tests/indicators/Test.Keltner.cs
+++ b/tests/indicators/Test.Keltner.cs
@@ -17,26 +17,29 @@ namespace Internal.Tests
             int multiplier = 2;
             int atrPeriod = 10;
             int lookbackPeriod = Math.Max(emaPeriod, atrPeriod);
-            IEnumerable<KeltnerResult> results = Indicator.GetKeltner(history, emaPeriod, multiplier, atrPeriod);
+
+            List<KeltnerResult> results =
+                Indicator.GetKeltner(history, emaPeriod, multiplier, atrPeriod)
+                .ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(502 - lookbackPeriod + 1, results.Where(x => x.Centerline != null).Count());
             Assert.AreEqual(502 - lookbackPeriod + 1, results.Where(x => x.UpperBand != null).Count());
             Assert.AreEqual(502 - lookbackPeriod + 1, results.Where(x => x.LowerBand != null).Count());
             Assert.AreEqual(502 - lookbackPeriod + 1, results.Where(x => x.Width != null).Count());
 
             // sample value
-            KeltnerResult r1 = results.Where(x => x.Index == 502).FirstOrDefault();
+            KeltnerResult r1 = results[501];
             Assert.AreEqual(262.1873m, Math.Round((decimal)r1.UpperBand, 4));
             Assert.AreEqual(249.3519m, Math.Round((decimal)r1.Centerline, 4));
             Assert.AreEqual(236.5165m, Math.Round((decimal)r1.LowerBand, 4));
             Assert.AreEqual(0.102950m, Math.Round((decimal)r1.Width, 6));
 
-            KeltnerResult r2 = results.Where(x => x.Index == 486).FirstOrDefault();
+            KeltnerResult r2 = results[485];
             Assert.AreEqual(275.4260m, Math.Round((decimal)r2.UpperBand, 4));
             Assert.AreEqual(265.4599m, Math.Round((decimal)r2.Centerline, 4));
             Assert.AreEqual(255.4938m, Math.Round((decimal)r2.LowerBand, 4));

--- a/tests/indicators/Test.Keltner.cs
+++ b/tests/indicators/Test.Keltner.cs
@@ -74,14 +74,16 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history 100.")]
         public void InsufficientHistory100()
         {
-            Indicator.GetKeltner(history.Where(x => x.Index < 120), 20, 2, 10);
+            IEnumerable<Quote> h = History.GetHistory(119);
+            Indicator.GetKeltner(h, 20, 2, 10);
         }
 
         [TestMethod()]
         [ExpectedException(typeof(BadHistoryException), "Insufficient history 250.")]
         public void InsufficientHistory250()
         {
-            Indicator.GetKeltner(history.Where(x => x.Index < 500), 20, 2, 250);
+            IEnumerable<Quote> h = History.GetHistory(499);
+            Indicator.GetKeltner(h, 20, 2, 250);
         }
 
     }

--- a/tests/indicators/Test.Macd.cs
+++ b/tests/indicators/Test.Macd.cs
@@ -82,7 +82,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetMacd(history.Where(x => x.Index < 61), 12, 26, 9);
+            IEnumerable<Quote> h = History.GetHistory(60);
+            Indicator.GetMacd(h, 12, 26, 9);
         }
 
     }

--- a/tests/indicators/Test.Macd.cs
+++ b/tests/indicators/Test.Macd.cs
@@ -17,29 +17,31 @@ namespace Internal.Tests
             int slowPeriod = 26;
             int signalPeriod = 9;
 
-            IEnumerable<MacdResult> results = Indicator.GetMacd(history, fastPeriod, slowPeriod, signalPeriod);
+            List<MacdResult> results =
+                Indicator.GetMacd(history, fastPeriod, slowPeriod, signalPeriod)
+                .ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(477, results.Where(x => x.Macd != null).Count());
             Assert.AreEqual(469, results.Where(x => x.Signal != null).Count());
             Assert.AreEqual(469, results.Where(x => x.Histogram != null).Count());
 
             // sample values
-            MacdResult r1 = results.Where(x => x.Index == 502).FirstOrDefault();
+            MacdResult r1 = results[501];
             Assert.AreEqual(-6.2198m, Math.Round((decimal)r1.Macd, 4));
             Assert.AreEqual(-5.8569m, Math.Round((decimal)r1.Signal, 4));
             Assert.AreEqual(-0.3629m, Math.Round((decimal)r1.Histogram, 4));
 
-            MacdResult r2 = results.Where(x => x.Index == 50).FirstOrDefault();
+            MacdResult r2 = results[49];
             Assert.AreEqual(1.7203m, Math.Round((decimal)r2.Macd, 4));
             Assert.AreEqual(1.9675m, Math.Round((decimal)r2.Signal, 4));
             Assert.AreEqual(-0.2472m, Math.Round((decimal)r2.Histogram, 4));
 
-            MacdResult r3 = results.Where(x => x.Index == 250).FirstOrDefault();
+            MacdResult r3 = results[249];
             Assert.AreEqual(2.2353m, Math.Round((decimal)r3.Macd, 4));
             Assert.AreEqual(2.3141m, Math.Round((decimal)r3.Signal, 4));
             Assert.AreEqual(-0.0789m, Math.Round((decimal)r3.Histogram, 4));

--- a/tests/indicators/Test.Mfi.cs
+++ b/tests/indicators/Test.Mfi.cs
@@ -66,7 +66,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history for N+1.")]
         public void InsufficientHistoryA()
         {
-            Indicator.GetMfi(history.Where(x => x.Index < 15), 14);
+            IEnumerable<Quote> h = History.GetHistory(14);
+            Indicator.GetMfi(h, 14);
         }
 
     }

--- a/tests/indicators/Test.Mfi.cs
+++ b/tests/indicators/Test.Mfi.cs
@@ -14,20 +14,20 @@ namespace Internal.Tests
         public void GetMfiTest()
         {
             int lookbackPeriod = 14;
-            IEnumerable<MfiResult> results = Indicator.GetMfi(history, lookbackPeriod);
+            List<MfiResult> results = Indicator.GetMfi(history, lookbackPeriod).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(502 - lookbackPeriod, results.Where(x => x.Mfi != null).Count());
 
             // sample values
-            MfiResult r1 = results.Where(x => x.Index == 502).FirstOrDefault();
+            MfiResult r1 = results[501];
             Assert.AreEqual(39.9494m, Math.Round((decimal)r1.Mfi, 4));
 
-            MfiResult r2 = results.Where(x => x.Index == 440).FirstOrDefault();
+            MfiResult r2 = results[439];
             Assert.AreEqual(69.0622m, Math.Round((decimal)r2.Mfi, 4));
         }
 
@@ -35,20 +35,20 @@ namespace Internal.Tests
         public void GetMfiSmallPeriodTest()
         {
             int lookbackPeriod = 4;
-            IEnumerable<MfiResult> results = Indicator.GetMfi(history, lookbackPeriod);
+            List<MfiResult> results = Indicator.GetMfi(history, lookbackPeriod).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(502 - lookbackPeriod, results.Where(x => x.Mfi != null).Count());
 
             // sample values
-            MfiResult r1 = results.Where(x => x.Index == 32).FirstOrDefault();
+            MfiResult r1 = results[31];
             Assert.AreEqual(100m, Math.Round((decimal)r1.Mfi, 4));
 
-            MfiResult r2 = results.Where(x => x.Index == 44).FirstOrDefault();
+            MfiResult r2 = results[43];
             Assert.AreEqual(0m, Math.Round((decimal)r2.Mfi, 4));
         }
 

--- a/tests/indicators/Test.Obv.cs
+++ b/tests/indicators/Test.Obv.cs
@@ -64,7 +64,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetObv(history.Where(x => x.Index < 2));
+            IEnumerable<Quote> h = History.GetHistory(1);
+            Indicator.GetObv(h);
         }
 
     }

--- a/tests/indicators/Test.Obv.cs
+++ b/tests/indicators/Test.Obv.cs
@@ -14,20 +14,20 @@ namespace Internal.Tests
         public void GetObvTest()
         {
 
-            IEnumerable<ObvResult> results = Indicator.GetObv(history);
+            List<ObvResult> results = Indicator.GetObv(history).ToList();
 
             // assertions
 
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(502, results.Where(x => x.Sma == null).Count());
 
             // sample values
-            ObvResult r1 = results.Where(x => x.Index == 250).FirstOrDefault();
+            ObvResult r1 = results[249];
             Assert.AreEqual(1780918888m, r1.Obv);
             Assert.AreEqual(null, r1.Sma);
 
-            ObvResult r2 = results.Where(x => x.Index == 502).FirstOrDefault();
+            ObvResult r2 = results[501];
             Assert.AreEqual(539843504, r2.Obv);
             Assert.AreEqual(null, r2.Sma);
         }
@@ -36,16 +36,16 @@ namespace Internal.Tests
         public void GetObvWithSmaTest()
         {
 
-            IEnumerable<ObvResult> results = Indicator.GetObv(history, 20);
+            List<ObvResult> results = Indicator.GetObv(history, 20).ToList();
 
             // assertions
 
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(482, results.Where(x => x.Sma != null).Count());
 
             // sample values
-            ObvResult r1 = results.Where(x => x.Index == 502).FirstOrDefault();
+            ObvResult r1 = results[501];
             Assert.AreEqual(539843504, r1.Obv);
             Assert.AreEqual(1016208844.40m, r1.Sma);
         }

--- a/tests/indicators/Test.ParabolicSar.cs
+++ b/tests/indicators/Test.ParabolicSar.cs
@@ -69,7 +69,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetParabolicSar(history.Where(x => x.Index < 2), (decimal)0.02, (decimal)0.2);
+            IEnumerable<Quote> h = History.GetHistory(1);
+            Indicator.GetParabolicSar(h, (decimal)0.02, (decimal)0.2);
         }
 
     }

--- a/tests/indicators/Test.ParabolicSar.cs
+++ b/tests/indicators/Test.ParabolicSar.cs
@@ -16,25 +16,27 @@ namespace Internal.Tests
             decimal acclerationStep = (decimal)0.02;
             decimal maxAccelerationFactor = (decimal)0.2;
 
-            IEnumerable<ParabolicSarResult> results = Indicator.GetParabolicSar(history, acclerationStep, maxAccelerationFactor);
+            List<ParabolicSarResult> results =
+                Indicator.GetParabolicSar(history, acclerationStep, maxAccelerationFactor)
+                .ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(488, results.Where(x => x.Sar != null).Count());
 
             // sample values
-            ParabolicSarResult r1 = results.Where(x => x.Index == 15).FirstOrDefault();
+            ParabolicSarResult r1 = results[14];
             Assert.AreEqual(212.83m, Math.Round((decimal)r1.Sar, 4));
             Assert.AreEqual(true, r1.IsReversal);
 
-            ParabolicSarResult r2 = results.Where(x => x.Index == 17).FirstOrDefault();
+            ParabolicSarResult r2 = results[16];
             Assert.AreEqual(212.9924m, Math.Round((decimal)r2.Sar, 4));
             Assert.AreEqual(false, r2.IsReversal);
 
-            ParabolicSarResult r3 = results.Where(x => x.Index == 502).FirstOrDefault();
+            ParabolicSarResult r3 = results[501];
             Assert.AreEqual(229.7662m, Math.Round((decimal)r3.Sar, 4));
             Assert.AreEqual(false, r3.IsReversal);
         }

--- a/tests/indicators/Test.Pmo.cs
+++ b/tests/indicators/Test.Pmo.cs
@@ -13,22 +13,22 @@ namespace Internal.Tests
         [TestMethod()]
         public void GetPmoTest()
         {
-            IEnumerable<PmoResult> results = Indicator.GetPmo(history, 35, 20, 10);
+            List<PmoResult> results = Indicator.GetPmo(history, 35, 20, 10).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(448, results.Where(x => x.Pmo != null).Count());
             Assert.AreEqual(439, results.Where(x => x.Signal != null).Count());
 
             // sample values
-            PmoResult r1 = results.Where(x => x.Index == 93).FirstOrDefault();
+            PmoResult r1 = results[92];
             Assert.AreEqual(0.6159m, Math.Round((decimal)r1.Pmo, 4));
             Assert.AreEqual(0.5582m, Math.Round((decimal)r1.Signal, 4));
 
-            PmoResult r2 = results.Where(x => x.Index == 502).FirstOrDefault();
+            PmoResult r2 = results[501];
             Assert.AreEqual(-2.7016m, Math.Round((decimal)r2.Pmo, 4));
             Assert.AreEqual(-2.3117m, Math.Round((decimal)r2.Signal, 4));
         }

--- a/tests/indicators/Test.Pmo.cs
+++ b/tests/indicators/Test.Pmo.cs
@@ -62,7 +62,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetPmo(history.Where(x => x.Index < 55), 35, 20, 10);
+            IEnumerable<Quote> h = History.GetHistory(54);
+            Indicator.GetPmo(h, 35, 20, 10);
         }
     }
 }

--- a/tests/indicators/Test.Prs.cs
+++ b/tests/indicators/Test.Prs.cs
@@ -66,14 +66,16 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetPrs(history, historyOther.Where(x => x.Index < 14), 14);
+            IEnumerable<Quote> h = History.GetHistoryOther(13);
+            Indicator.GetPrs(history, h, 14);
         }
 
         [TestMethod()]
         [ExpectedException(typeof(BadHistoryException), "Not enought Eval history.")]
         public void InsufficientEvalHistory()
         {
-            Indicator.GetPrs(history, historyOther.Where(x => x.Index <= 300), 14);
+            IEnumerable<Quote> h = History.GetHistoryOther(300);
+            Indicator.GetPrs(history, h, 14);
         }
 
         [TestMethod()]

--- a/tests/indicators/Test.Prs.cs
+++ b/tests/indicators/Test.Prs.cs
@@ -15,28 +15,31 @@ namespace Internal.Tests
         {
             int lookbackPeriod = 30;
             int smaPeriod = 10;
-            IEnumerable<PrsResult> results = Indicator.GetPrs(history, historyOther, lookbackPeriod, smaPeriod);
+
+            List<PrsResult> results =
+                Indicator.GetPrs(history, historyOther, lookbackPeriod, smaPeriod)
+                .ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(502, results.Count(x => x.Prs != null));
             Assert.AreEqual(493, results.Where(x => x.Sma != null).Count());
 
             // sample values
-            PrsResult r1 = results.Where(x => x.Index == 502).FirstOrDefault();
+            PrsResult r1 = results[501];
             Assert.AreEqual(1.356817m, Math.Round((decimal)r1.Prs, 6));
             Assert.AreEqual(1.343445m, Math.Round((decimal)r1.Sma, 6));
             Assert.AreEqual(0.037082m, Math.Round((decimal)r1.PrsPercent, 6));
 
-            PrsResult r2 = results.Where(x => x.Index == 250).FirstOrDefault();
+            PrsResult r2 = results[249];
             Assert.AreEqual(1.222373m, Math.Round((decimal)r2.Prs, 6));
             Assert.AreEqual(1.275808m, Math.Round((decimal)r2.Sma, 6));
             Assert.AreEqual(-0.023089m, Math.Round((decimal)r2.PrsPercent, 6));
 
-            PrsResult r3 = results.Where(x => x.Index == 9).FirstOrDefault();
+            PrsResult r3 = results[8];
             Assert.AreEqual(1.108340m, Math.Round((decimal)r3.Prs, 6));
             Assert.AreEqual(null, r3.Sma);
             Assert.AreEqual(null, r3.PrsPercent);

--- a/tests/indicators/Test.Roc.cs
+++ b/tests/indicators/Test.Roc.cs
@@ -81,7 +81,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetRoc(history.Where(x => x.Index <= 10), 10);
+            IEnumerable<Quote> h = History.GetHistory(10);
+            Indicator.GetRoc(h, 10);
         }
     }
 }

--- a/tests/indicators/Test.Roc.cs
+++ b/tests/indicators/Test.Roc.cs
@@ -14,22 +14,22 @@ namespace Internal.Tests
         public void GetRocTest()
         {
             int lookbackPeriod = 20;
-            IEnumerable<RocResult> results = Indicator.GetRoc(history, lookbackPeriod);
+            List<RocResult> results = Indicator.GetRoc(history, lookbackPeriod).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(482, results.Where(x => x.Roc != null).Count());
             Assert.AreEqual(false, results.Any(x => x.Sma != null));
 
             // sample values
-            RocResult r1 = results.Where(x => x.Index == 502).FirstOrDefault();
+            RocResult r1 = results[501];
             Assert.AreEqual(-8.2482m, Math.Round((decimal)r1.Roc, 4));
             Assert.AreEqual(null, r1.Sma);
 
-            RocResult r2 = results.Where(x => x.Index == 250).FirstOrDefault();
+            RocResult r2 = results[249];
             Assert.AreEqual(2.4827m, Math.Round((decimal)r2.Roc, 4));
             Assert.AreEqual(null, r2.Sma);
         }
@@ -39,22 +39,22 @@ namespace Internal.Tests
         {
             int lookbackPeriod = 20;
             int smaPeriod = 5;
-            IEnumerable<RocResult> results = Indicator.GetRoc(history, lookbackPeriod, smaPeriod);
+            List<RocResult> results = Indicator.GetRoc(history, lookbackPeriod, smaPeriod).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(502 - lookbackPeriod, results.Where(x => x.Roc != null).Count());
             Assert.AreEqual(478, results.Where(x => x.Sma != null).Count());
 
             // sample values
-            RocResult r1 = results.Where(x => x.Index == 502).FirstOrDefault();
+            RocResult r1 = results[501];
             Assert.AreEqual(-8.2482m, Math.Round((decimal)r1.Roc, 4));
             Assert.AreEqual(-8.4828m, Math.Round((decimal)r1.Sma, 4));
 
-            RocResult r2 = results.Where(x => x.Index == 30).FirstOrDefault();
+            RocResult r2 = results[29];
             Assert.AreEqual(3.2936m, Math.Round((decimal)r2.Roc, 4));
             Assert.AreEqual(2.1558m, Math.Round((decimal)r2.Sma, 4));
         }

--- a/tests/indicators/Test.Rsi.cs
+++ b/tests/indicators/Test.Rsi.cs
@@ -14,17 +14,17 @@ namespace Internal.Tests
         public void GetRsiTest()
         {
             int lookbackPeriod = 14;
-            IEnumerable<RsiResult> results = Indicator.GetRsi(history, lookbackPeriod);
+            List<RsiResult> results = Indicator.GetRsi(history, lookbackPeriod).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(488, results.Where(x => x.Rsi != null).Count());
 
             // sample value
-            RsiResult r = results.Where(x => x.Index == 502).FirstOrDefault();
+            RsiResult r = results[501];
             Assert.AreEqual(42.0773m, Math.Round((decimal)r.Rsi, 4));
         }
 
@@ -32,20 +32,20 @@ namespace Internal.Tests
         public void GetRsiSmallPeriodTest()
         {
             int lookbackPeriod = 1;
-            IEnumerable<RsiResult> results = Indicator.GetRsi(history, lookbackPeriod);
+            List<RsiResult> results = Indicator.GetRsi(history, lookbackPeriod).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(501, results.Where(x => x.Rsi != null).Count());
 
             // sample values
-            RsiResult r1 = results.Where(x => x.Index == 29).FirstOrDefault();
+            RsiResult r1 = results[28];
             Assert.AreEqual(100m, Math.Round((decimal)r1.Rsi, 4));
 
-            RsiResult r2 = results.Where(x => x.Index == 53).FirstOrDefault();
+            RsiResult r2 = results[52];
             Assert.AreEqual(0m, Math.Round((decimal)r2.Rsi, 4));
         }
 

--- a/tests/indicators/Test.Rsi.cs
+++ b/tests/indicators/Test.Rsi.cs
@@ -63,7 +63,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetRsi(history.Where(x => x.Index < 30), 30);
+            IEnumerable<Quote> h = History.GetHistory(29);
+            Indicator.GetRsi(h, 30);
         }
 
     }

--- a/tests/indicators/Test.Slope.cs
+++ b/tests/indicators/Test.Slope.cs
@@ -14,33 +14,33 @@ namespace Internal.Tests
         public void GetSlopeTest()
         {
             int lookbackPeriod = 20;
-            IEnumerable<SlopeResult> results = Indicator.GetSlope(history, lookbackPeriod);
+            List<SlopeResult> results = Indicator.GetSlope(history, lookbackPeriod).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(502 - lookbackPeriod + 1, results.Where(x => x.Slope != null).Count());
             Assert.AreEqual(502 - lookbackPeriod + 1, results.Where(x => x.StdDev != null).Count());
             Assert.AreEqual(lookbackPeriod, results.Where(x => x.Line != null).Count());
 
             // sample values
-            SlopeResult r1 = results.Where(x => x.Index == 502).FirstOrDefault();
+            SlopeResult r1 = results[501];
             Assert.AreEqual(-1.689143m, Math.Round((decimal)r1.Slope, 6));
             Assert.AreEqual(1083.7629m, Math.Round((decimal)r1.Intercept, 4));
             Assert.AreEqual(0.7955m, Math.Round((decimal)r1.RSquared, 4));
             Assert.AreEqual(10.9202m, Math.Round((decimal)r1.StdDev, 4));
             Assert.AreEqual(235.8131m, Math.Round((decimal)r1.Line, 4));
 
-            SlopeResult r2 = results.Where(x => x.Index == 483).FirstOrDefault();
+            SlopeResult r2 = results[482];
             Assert.AreEqual(-0.337015m, Math.Round((decimal)r2.Slope, 6));
             Assert.AreEqual(425.1111m, Math.Round((decimal)r2.Intercept, 4));
             Assert.AreEqual(0.1730m, Math.Round((decimal)r2.RSquared, 4));
             Assert.AreEqual(4.6719m, Math.Round((decimal)r2.StdDev, 4));
             Assert.AreEqual(267.9069m, Math.Round((decimal)r2.Line, 4));
 
-            SlopeResult r3 = results.Where(x => x.Index == 250).FirstOrDefault();
+            SlopeResult r3 = results[249];
             Assert.AreEqual(0.312406m, Math.Round((decimal)r3.Slope, 6));
             Assert.AreEqual(180.4164m, Math.Round((decimal)r3.Intercept, 4));
             Assert.AreEqual(0.8056m, Math.Round((decimal)r3.RSquared, 4));

--- a/tests/indicators/Test.Slope.cs
+++ b/tests/indicators/Test.Slope.cs
@@ -61,7 +61,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetSlope(history.Where(x => x.Index < 30), 30);
+            IEnumerable<Quote> h = History.GetHistory(29);
+            Indicator.GetSlope(h, 30);
         }
     }
 }

--- a/tests/indicators/Test.Sma.cs
+++ b/tests/indicators/Test.Sma.cs
@@ -14,17 +14,17 @@ namespace Internal.Tests
         public void GetSmaTest()
         {
             int lookbackPeriod = 20;
-            IEnumerable<SmaResult> results = Indicator.GetSma(history, lookbackPeriod, true);
+            List<SmaResult> results = Indicator.GetSma(history, lookbackPeriod, true).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(502 - lookbackPeriod + 1, results.Where(x => x.Sma != null).Count());
 
             // sample value
-            SmaResult r = results.Where(x => x.Index == 502).FirstOrDefault();
+            SmaResult r = results[501];
             Assert.AreEqual(251.86m, r.Sma);
             Assert.AreEqual(9.45m, r.Mad);
             Assert.AreEqual(119.2510m, Math.Round((decimal)r.Mse, 4));

--- a/tests/indicators/Test.Sma.cs
+++ b/tests/indicators/Test.Sma.cs
@@ -45,7 +45,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetSma(history.Where(x => x.Index < 10), 10);
+            IEnumerable<Quote> h = History.GetHistory(9);
+            Indicator.GetSma(h, 10);
         }
     }
 }

--- a/tests/indicators/Test.StdDev.cs
+++ b/tests/indicators/Test.StdDev.cs
@@ -14,24 +14,24 @@ namespace Internal.Tests
         public void GetStdDevTest()
         {
             int lookbackPeriod = 10;
-            IEnumerable<StdDevResult> results = Indicator.GetStdDev(history, lookbackPeriod);
+            List<StdDevResult> results = Indicator.GetStdDev(history, lookbackPeriod).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(493, results.Where(x => x.StdDev != null).Count());
             Assert.AreEqual(493, results.Where(x => x.ZScore != null).Count());
             Assert.AreEqual(false, results.Any(x => x.Sma != null));
 
             // sample values
-            StdDevResult r1 = results.Where(x => x.Index == 502).FirstOrDefault();
+            StdDevResult r1 = results[501];
             Assert.AreEqual(5.4738m, Math.Round((decimal)r1.StdDev, 4));
             Assert.AreEqual(0.524312m, Math.Round((decimal)r1.ZScore, 6));
             Assert.AreEqual(null, r1.Sma);
 
-            StdDevResult r2 = results.Where(x => x.Index == 250).FirstOrDefault();
+            StdDevResult r2 = results[249];
             Assert.AreEqual(0.9827m, Math.Round((decimal)r2.StdDev, 4));
             Assert.AreEqual(0.783563m, Math.Round((decimal)r2.ZScore, 6));
             Assert.AreEqual(null, r2.Sma);
@@ -42,24 +42,24 @@ namespace Internal.Tests
         {
             int lookbackPeriod = 10;
             int smaPeriod = 5;
-            IEnumerable<StdDevResult> results = Indicator.GetStdDev(history, lookbackPeriod, smaPeriod);
+            List<StdDevResult> results = Indicator.GetStdDev(history, lookbackPeriod, smaPeriod).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(493, results.Where(x => x.StdDev != null).Count());
             Assert.AreEqual(493, results.Where(x => x.ZScore != null).Count());
             Assert.AreEqual(489, results.Where(x => x.Sma != null).Count());
 
             // sample values
-            StdDevResult r1 = results.Where(x => x.Index == 502).FirstOrDefault();
+            StdDevResult r1 = results[501];
             Assert.AreEqual(5.4738m, Math.Round((decimal)r1.StdDev, 4));
             Assert.AreEqual(0.524312m, Math.Round((decimal)r1.ZScore, 6));
             Assert.AreEqual(7.6886m, Math.Round((decimal)r1.Sma, 4));
 
-            StdDevResult r2 = results.Where(x => x.Index == 20).FirstOrDefault();
+            StdDevResult r2 = results[19];
             Assert.AreEqual(1.1642m, Math.Round((decimal)r2.StdDev, 4));
             Assert.AreEqual(-0.065282m, Math.Round((decimal)r2.ZScore, 6));
             Assert.AreEqual(1.1422m, Math.Round((decimal)r2.Sma, 4));

--- a/tests/indicators/Test.StdDev.cs
+++ b/tests/indicators/Test.StdDev.cs
@@ -86,7 +86,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetStdDev(history.Where(x => x.Index < 30), 30);
+            IEnumerable<Quote> h = History.GetHistory(29);
+            Indicator.GetStdDev(h, 30);
         }
 
     }

--- a/tests/indicators/Test.Stoch.cs
+++ b/tests/indicators/Test.Stoch.cs
@@ -17,19 +17,20 @@ namespace Internal.Tests
             int signalPeriod = 3;
             int smoothPeriod = 3;
 
-            IEnumerable<StochResult> results = Indicator.GetStoch(
-                history, lookbackPeriod, signalPeriod, smoothPeriod);
+            List<StochResult> results =
+                Indicator.GetStoch(history, lookbackPeriod, signalPeriod, smoothPeriod)
+                .ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(487, results.Where(x => x.Oscillator != null).Count());
             Assert.AreEqual(485, results.Where(x => x.Signal != null).Count());
 
             // sample value
-            StochResult r = results.Where(x => x.Index == 502).FirstOrDefault();
+            StochResult r = results[501];
             Assert.AreEqual(43.1353m, Math.Round((decimal)r.Oscillator, 4));
             Assert.AreEqual(35.5674m, Math.Round((decimal)r.Signal, 4));
         }
@@ -41,14 +42,15 @@ namespace Internal.Tests
             int signalPeriod = 1;
             int smoothPeriod = 3;
 
-            IEnumerable<StochResult> results = Indicator.GetStoch(
-                history, lookbackPeriod, signalPeriod, smoothPeriod);
+            List<StochResult> results =
+                Indicator.GetStoch(history, lookbackPeriod, signalPeriod, smoothPeriod)
+                .ToList();
 
             // signal equals oscillator
-            StochResult r1 = results.Where(x => x.Index == 502).FirstOrDefault();
+            StochResult r1 = results[501];
             Assert.AreEqual(r1.Oscillator, r1.Signal);
 
-            StochResult r2 = results.Where(x => x.Index == 488).FirstOrDefault();
+            StochResult r2 = results[487];
             Assert.AreEqual(r2.Oscillator, r2.Signal);
         }
 
@@ -59,15 +61,16 @@ namespace Internal.Tests
             int signalPeriod = 10;
             int smoothPeriod = 1;
 
-            IEnumerable<StochResult> results = Indicator.GetStoch(
-                history, lookbackPeriod, signalPeriod, smoothPeriod);
+            List<StochResult> results =
+                Indicator.GetStoch(history, lookbackPeriod, signalPeriod, smoothPeriod)
+                .ToList();
 
             // sample values
-            StochResult r1 = results.Where(x => x.Index == 502).FirstOrDefault();
+            StochResult r1 = results[501];
             Assert.AreEqual(91.6233m, Math.Round((decimal)r1.Oscillator, 4));
             Assert.AreEqual(36.0608m, Math.Round((decimal)r1.Signal, 4));
 
-            StochResult r2 = results.Where(x => x.Index == 488).FirstOrDefault();
+            StochResult r2 = results[487];
             Assert.AreEqual(25.0353m, Math.Round((decimal)r2.Oscillator, 4));
             Assert.AreEqual(60.5706m, Math.Round((decimal)r2.Signal, 4));
         }
@@ -79,14 +82,15 @@ namespace Internal.Tests
             int signalPeriod = 10;
             int smoothPeriod = 1;
 
-            IEnumerable<StochResult> results = Indicator.GetStoch(
-                history, lookbackPeriod, signalPeriod, smoothPeriod);
+            List<StochResult> results =
+                Indicator.GetStoch(history, lookbackPeriod, signalPeriod, smoothPeriod)
+                .ToList();
 
             // sample values
-            StochResult r1 = results.Where(x => x.Index == 71).FirstOrDefault();
+            StochResult r1 = results[70];
             Assert.AreEqual(0m, Math.Round((decimal)r1.Oscillator, 4));
 
-            StochResult r2 = results.Where(x => x.Index == 72).FirstOrDefault();
+            StochResult r2 = results[71];
             Assert.AreEqual(100m, Math.Round((decimal)r2.Oscillator, 4));
         }
 

--- a/tests/indicators/Test.Stoch.cs
+++ b/tests/indicators/Test.Stoch.cs
@@ -122,7 +122,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetStoch(history.Where(x => x.Index < 33), 30, 3, 3);
+            IEnumerable<Quote> h = History.GetHistory(32);
+            Indicator.GetStoch(h, 30, 3, 3);
         }
 
     }

--- a/tests/indicators/Test.StochRsi.cs
+++ b/tests/indicators/Test.StochRsi.cs
@@ -96,7 +96,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetStochRsi(history.Where(x => x.Index < 60), 30, 30, 5, 5);
+            IEnumerable<Quote> h = History.GetHistory(59);
+            Indicator.GetStochRsi(h, 30, 30, 5, 5);
         }
 
     }

--- a/tests/indicators/Test.StochRsi.cs
+++ b/tests/indicators/Test.StochRsi.cs
@@ -18,18 +18,19 @@ namespace Internal.Tests
             int signalPeriod = 3;
             int smoothPeriod = 1;
 
-            IEnumerable<StochRsiResult> results = Indicator.GetStochRsi(
-                history, rsiPeriod, stochPeriod, signalPeriod, smoothPeriod);
+            List<StochRsiResult> results =
+                Indicator.GetStochRsi(history, rsiPeriod, stochPeriod, signalPeriod, smoothPeriod)
+                .ToList();
 
             // assertions
 
             // proper quantities
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(502 - rsiPeriod - stochPeriod - smoothPeriod + 2, results.Where(x => x.StochRsi != null).Count());
             Assert.AreEqual(502 - rsiPeriod - stochPeriod - signalPeriod - smoothPeriod + 3, results.Where(x => x.Signal != null).Count());
 
             // sample value
-            StochRsiResult r = results.Where(x => x.Index == 502).FirstOrDefault();
+            StochRsiResult r = results[501];
             Assert.AreEqual(97.5244m, Math.Round((decimal)r.StochRsi, 4));
             Assert.AreEqual(89.8385m, Math.Round((decimal)r.Signal, 4));
         }
@@ -43,18 +44,19 @@ namespace Internal.Tests
             int signalPeriod = 3;
             int smoothPeriod = 3;
 
-            IEnumerable<StochRsiResult> results = Indicator.GetStochRsi(
-                history, rsiPeriod, stochPeriod, signalPeriod, smoothPeriod);
+            List<StochRsiResult> results =
+                Indicator.GetStochRsi(history, rsiPeriod, stochPeriod, signalPeriod, smoothPeriod)
+                .ToList();
 
             // assertions
 
             // proper quantities
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(502 - rsiPeriod - stochPeriod - smoothPeriod + 2, results.Where(x => x.StochRsi != null).Count());
             Assert.AreEqual(502 - rsiPeriod - stochPeriod - signalPeriod - smoothPeriod + 3, results.Where(x => x.Signal != null).Count());
 
             // sample value
-            StochRsiResult r = results.Where(x => x.Index == 502).FirstOrDefault();
+            StochRsiResult r = results[501];
             Assert.AreEqual(89.8385m, Math.Round((decimal)r.StochRsi, 4));
             Assert.AreEqual(73.4176m, Math.Round((decimal)r.Signal, 4));
         }

--- a/tests/indicators/Test.TripleEma.cs
+++ b/tests/indicators/Test.TripleEma.cs
@@ -14,23 +14,23 @@ namespace Internal.Tests
         public void GetTripleEmaTest()
         {
             int lookbackPeriod = 20;
-            IEnumerable<EmaResult> results = Indicator.GetTripleEma(history, lookbackPeriod);
+            List<EmaResult> results = Indicator.GetTripleEma(history, lookbackPeriod).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(445, results.Where(x => x.Ema != null).Count());
 
             // sample values
-            EmaResult r1 = results.Where(x => x.Index == 502).FirstOrDefault();
+            EmaResult r1 = results[501];
             Assert.AreEqual(238.7690m, Math.Round((decimal)r1.Ema, 4));
 
-            EmaResult r2 = results.Where(x => x.Index == 250).FirstOrDefault();
+            EmaResult r2 = results[249];
             Assert.AreEqual(258.6208m, Math.Round((decimal)r2.Ema, 4));
 
-            EmaResult r3 = results.Where(x => x.Index == 68).FirstOrDefault();
+            EmaResult r3 = results[67];
             Assert.AreEqual(222.9105m, Math.Round((decimal)r3.Ema, 4));
         }
 

--- a/tests/indicators/Test.TripleEma.cs
+++ b/tests/indicators/Test.TripleEma.cs
@@ -48,7 +48,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history for 3*N+100.")]
         public void InsufficientHistoryA()
         {
-            Indicator.GetTripleEma(history.Where(x => x.Index < 190), 30);
+            IEnumerable<Quote> h = History.GetHistory(189);
+            Indicator.GetTripleEma(h, 30);
         }
 
         [TestMethod()]

--- a/tests/indicators/Test.Trix.cs
+++ b/tests/indicators/Test.Trix.cs
@@ -13,29 +13,29 @@ namespace Internal.Tests
         [TestMethod()]
         public void GetTrixTest()
         {
-            IEnumerable<TrixResult> results = Indicator.GetTrix(history, 20, 5);
+            List<TrixResult> results = Indicator.GetTrix(history, 20, 5).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(445, results.Where(x => x.Ema3 != null).Count());
             Assert.AreEqual(444, results.Where(x => x.Trix != null).Count());
             Assert.AreEqual(440, results.Where(x => x.Signal != null).Count());
 
             // sample values
-            TrixResult r1 = results.Where(x => x.Index == 502).FirstOrDefault();
+            TrixResult r1 = results[501];
             Assert.AreEqual(263.3216m, Math.Round((decimal)r1.Ema3, 4));
             Assert.AreEqual(-0.230742m, Math.Round((decimal)r1.Trix, 6));
             Assert.AreEqual(-0.204536m, Math.Round((decimal)r1.Signal, 6));
 
-            TrixResult r2 = results.Where(x => x.Index == 250).FirstOrDefault();
+            TrixResult r2 = results[249];
             Assert.AreEqual(249.4469m, Math.Round((decimal)r2.Ema3, 4));
             Assert.AreEqual(0.121781m, Math.Round((decimal)r2.Trix, 6));
             Assert.AreEqual(0.119769m, Math.Round((decimal)r2.Signal, 6));
 
-            TrixResult r3 = results.Where(x => x.Index == 68).FirstOrDefault();
+            TrixResult r3 = results[67];
             Assert.AreEqual(221.6320m, Math.Round((decimal)r3.Ema3, 4));
             Assert.AreEqual(0.055596m, Math.Round((decimal)r3.Trix, 6));
             Assert.AreEqual(0.063512m, Math.Round((decimal)r3.Signal, 6));

--- a/tests/indicators/Test.Trix.cs
+++ b/tests/indicators/Test.Trix.cs
@@ -55,7 +55,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history for 3*N+100.")]
         public void InsufficientHistoryA()
         {
-            Indicator.GetTrix(history.Where(x => x.Index < 190), 30);
+            IEnumerable<Quote> h = History.GetHistory(189);
+            Indicator.GetTrix(h, 30);
         }
 
         [TestMethod()]

--- a/tests/indicators/Test.UlcerIndex.cs
+++ b/tests/indicators/Test.UlcerIndex.cs
@@ -42,7 +42,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetUlcerIndex(history.Where(x => x.Index < 30), 30);
+            IEnumerable<Quote> h = History.GetHistory(29);
+            Indicator.GetUlcerIndex(h, 30);
         }
 
     }

--- a/tests/indicators/Test.UlcerIndex.cs
+++ b/tests/indicators/Test.UlcerIndex.cs
@@ -14,7 +14,6 @@ namespace Internal.Tests
         public void GetUlcerIndexTest()
         {
             int lookbackPeriod = 14;
-
             List<UlcerIndexResult> results = Indicator.GetUlcerIndex(history, lookbackPeriod).ToList();
 
             // assertions

--- a/tests/indicators/Test.UlcerIndex.cs
+++ b/tests/indicators/Test.UlcerIndex.cs
@@ -15,17 +15,17 @@ namespace Internal.Tests
         {
             int lookbackPeriod = 14;
 
-            IEnumerable<UlcerIndexResult> results = Indicator.GetUlcerIndex(history, lookbackPeriod);
+            List<UlcerIndexResult> results = Indicator.GetUlcerIndex(history, lookbackPeriod).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(502 - lookbackPeriod + 1, results.Where(x => x.UI != null).Count());
 
             // sample value
-            UlcerIndexResult r = results.Where(x => x.Index == 502).FirstOrDefault();
+            UlcerIndexResult r = results[501];
             Assert.AreEqual(5.7255m, Math.Round((decimal)r.UI, 4));
         }
 

--- a/tests/indicators/Test.Ultimate.cs
+++ b/tests/indicators/Test.Ultimate.cs
@@ -13,23 +13,23 @@ namespace Internal.Tests
         [TestMethod()]
         public void GetUltimateTest()
         {
-            IEnumerable<UltimateResult> results = Indicator.GetUltimate(history, 7, 14, 28);
+            List<UltimateResult> results = Indicator.GetUltimate(history, 7, 14, 28).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(474, results.Where(x => x.Ultimate != null).Count());
 
             // sample values
-            UltimateResult r1 = results.Where(x => x.Index == 502).FirstOrDefault();
+            UltimateResult r1 = results[501];
             Assert.AreEqual(49.5257m, Math.Round((decimal)r1.Ultimate, 4));
 
-            UltimateResult r2 = results.Where(x => x.Index == 250).FirstOrDefault();
+            UltimateResult r2 = results[249];
             Assert.AreEqual(45.3121m, Math.Round((decimal)r2.Ultimate, 4));
 
-            UltimateResult r3 = results.Where(x => x.Index == 75).FirstOrDefault();
+            UltimateResult r3 = results[74];
             Assert.AreEqual(51.7770m, Math.Round((decimal)r3.Ultimate, 4));
 
         }

--- a/tests/indicators/Test.Ultimate.cs
+++ b/tests/indicators/Test.Ultimate.cs
@@ -62,7 +62,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetUltimate(history.Where(x => x.Index <= 28), 7, 14, 28);
+            IEnumerable<Quote> h = History.GetHistory(28);
+            Indicator.GetUltimate(h, 7, 14, 28);
         }
     }
 }

--- a/tests/indicators/Test.VolSma.cs
+++ b/tests/indicators/Test.VolSma.cs
@@ -50,7 +50,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetVolSma(history.Where(x => x.Index < 10), 10);
+            IEnumerable<Quote> h = History.GetHistory(9);
+            Indicator.GetVolSma(h, 10);
         }
     }
 }

--- a/tests/indicators/Test.VolSma.cs
+++ b/tests/indicators/Test.VolSma.cs
@@ -14,23 +14,23 @@ namespace Internal.Tests
         public void GetVolSmaTest()
         {
             int lookbackPeriod = 20;
-            IEnumerable<VolSmaResult> results = Indicator.GetVolSma(history, lookbackPeriod);
+            List<VolSmaResult> results = Indicator.GetVolSma(history, lookbackPeriod).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(483, results.Where(x => x.VolSma != null).Count());
 
             // sample values
-            VolSmaResult r1 = results.Where(x => x.Index == 25).FirstOrDefault();
+            VolSmaResult r1 = results[24];
             Assert.AreEqual(77293768.2m, r1.VolSma);
 
-            VolSmaResult r2 = results.Where(x => x.Index == 291).FirstOrDefault();
+            VolSmaResult r2 = results[290];
             Assert.AreEqual(157958070.8m, r2.VolSma);
 
-            VolSmaResult r3 = results.Where(x => x.Index == 502).FirstOrDefault();
+            VolSmaResult r3 = results[501];
             Assert.AreEqual(DateTime.ParseExact("12/31/2018", "MM/dd/yyyy", englishCulture), r3.Date);
             Assert.AreEqual(147031456m, r3.Volume);
             Assert.AreEqual(163695200m, r3.VolSma);

--- a/tests/indicators/Test.WilliamsR.cs
+++ b/tests/indicators/Test.WilliamsR.cs
@@ -14,20 +14,20 @@ namespace Internal.Tests
         public void GetWilliamsRTest()
         {
             int lookbackPeriod = 14;
-            IEnumerable<WilliamsResult> results = Indicator.GetWilliamsR(history, lookbackPeriod);
+            List<WilliamsResult> results = Indicator.GetWilliamsR(history, lookbackPeriod).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(502 - lookbackPeriod + 1, results.Where(x => x.WilliamsR != null).Count());
 
             // sample values
-            WilliamsResult r1 = results.Where(x => x.Index == 502).FirstOrDefault();
+            WilliamsResult r1 = results[501];
             Assert.AreEqual(-52.0121m, Math.Round((decimal)r1.WilliamsR, 4));
 
-            WilliamsResult r2 = results.Where(x => x.Index == 344).FirstOrDefault();
+            WilliamsResult r2 = results[343];
             Assert.AreEqual(-19.8211m, Math.Round((decimal)r2.WilliamsR, 4));
         }
 

--- a/tests/indicators/Test.WilliamsR.cs
+++ b/tests/indicators/Test.WilliamsR.cs
@@ -45,7 +45,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetWilliamsR(history.Where(x => x.Index < 30), 30);
+            IEnumerable<Quote> h = History.GetHistory(29);
+            Indicator.GetWilliamsR(h, 30);
         }
 
     }

--- a/tests/indicators/Test.Wma.cs
+++ b/tests/indicators/Test.Wma.cs
@@ -14,20 +14,20 @@ namespace Internal.Tests
         public void GetWmaTest()
         {
             int lookbackPeriod = 20;
-            IEnumerable<WmaResult> results = Indicator.GetWma(history, lookbackPeriod);
+            List<WmaResult> results = Indicator.GetWma(history, lookbackPeriod).ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(502 - lookbackPeriod + 1, results.Where(x => x.Wma != null).Count());
 
             // sample values
-            WmaResult r1 = results.Where(x => x.Index == 502).FirstOrDefault();
+            WmaResult r1 = results[501];
             Assert.AreEqual(246.5110m, Math.Round((decimal)r1.Wma, 4));
 
-            WmaResult r2 = results.Where(x => x.Index == 150).FirstOrDefault();
+            WmaResult r2 = results[149];
             Assert.AreEqual(235.5253m, Math.Round((decimal)r2.Wma, 4));
         }
 

--- a/tests/indicators/Test.Wma.cs
+++ b/tests/indicators/Test.Wma.cs
@@ -45,7 +45,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetWma(history.Where(x => x.Index < 10), 10);
+            IEnumerable<Quote> h = History.GetHistory(9);
+            Indicator.GetWma(h, 10);
         }
     }
 }

--- a/tests/indicators/Test.ZigZag.cs
+++ b/tests/indicators/Test.ZigZag.cs
@@ -136,7 +136,8 @@ namespace Internal.Tests
         [ExpectedException(typeof(BadHistoryException), "Insufficient history.")]
         public void InsufficientHistory()
         {
-            Indicator.GetZigZag(history.Where(x => x.Index < 2));
+            IEnumerable<Quote> h = History.GetHistory(1);
+            Indicator.GetZigZag(h);
         }
     }
 }

--- a/tests/indicators/Test.ZigZag.cs
+++ b/tests/indicators/Test.ZigZag.cs
@@ -14,50 +14,52 @@ namespace Internal.Tests
         public void GetZigZagClose()
         {
             decimal percentChange = 3;
-            IEnumerable<ZigZagResult> results = Indicator.GetZigZag(history, ZigZagType.Close, percentChange);
+            List<ZigZagResult> results =
+                Indicator.GetZigZag(history, ZigZagType.Close, percentChange)
+                .ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(234, results.Where(x => x.ZigZag != null).Count());
             Assert.AreEqual(234, results.Where(x => x.RetraceHigh != null).Count());
             Assert.AreEqual(221, results.Where(x => x.RetraceLow != null).Count());
             Assert.AreEqual(14, results.Where(x => x.PointType != null).Count());
 
             // sample values
-            ZigZagResult r0 = results.Where(x => x.Index == 250).FirstOrDefault();
+            ZigZagResult r0 = results[249];
             Assert.AreEqual(null, r0.ZigZag);
             Assert.AreEqual(null, r0.RetraceHigh);
             Assert.AreEqual(null, r0.RetraceLow);
             Assert.AreEqual(null, r0.PointType);
 
-            ZigZagResult r1 = results.Where(x => x.Index == 278).FirstOrDefault();
+            ZigZagResult r1 = results[277];
             Assert.AreEqual(248.13m, r1.ZigZag);
             Assert.AreEqual(272.248m, r1.RetraceHigh);
             Assert.AreEqual(248.13m, r1.RetraceLow);
             Assert.AreEqual("L", r1.PointType);
 
-            ZigZagResult r2 = results.Where(x => x.Index == 484).FirstOrDefault();
+            ZigZagResult r2 = results[483];
             Assert.AreEqual(272.52m, r2.ZigZag);
             Assert.AreEqual(272.52m, r2.RetraceHigh);
             Assert.AreEqual(248.799m, r2.RetraceLow);
             Assert.AreEqual("H", r2.PointType);
 
-            ZigZagResult r3 = results.Where(x => x.Index == 440).FirstOrDefault();
+            ZigZagResult r3 = results[439];
             Assert.AreEqual(276.0133m, Math.Round((decimal)r3.ZigZag, 4));
             Assert.AreEqual(280.9158m, Math.Round((decimal)r3.RetraceHigh, 4));
             Assert.AreEqual(264.5769m, Math.Round((decimal)r3.RetraceLow, 4));
             Assert.AreEqual(null, r3.PointType);
 
-            ZigZagResult r4 = results.Where(x => x.Index == 501).FirstOrDefault();
+            ZigZagResult r4 = results[500];
             Assert.AreEqual(241.4575m, Math.Round((decimal)r4.ZigZag, 4));
             Assert.AreEqual(246.7933m, Math.Round((decimal)r4.RetraceHigh, 4));
             Assert.AreEqual(null, r4.RetraceLow);
             Assert.AreEqual(null, r4.PointType);
 
-            ZigZagResult r5 = results.Where(x => x.Index == 502).FirstOrDefault();
+            ZigZagResult r5 = results[501];
             Assert.AreEqual(245.28m, r5.ZigZag);
             Assert.AreEqual(245.28m, r5.RetraceHigh);
             Assert.AreEqual(null, r5.RetraceLow);
@@ -68,50 +70,52 @@ namespace Internal.Tests
         public void GetZigZagHighLow()
         {
             decimal percentChange = 3;
-            IEnumerable<ZigZagResult> results = Indicator.GetZigZag(history, ZigZagType.HighLow, percentChange);
+            List<ZigZagResult> results =
+                Indicator.GetZigZag(history, ZigZagType.HighLow, percentChange)
+                .ToList();
 
             // assertions
 
             // proper quantities
             // should always be the same number of results as there is history
-            Assert.AreEqual(502, results.Count());
+            Assert.AreEqual(502, results.Count);
             Assert.AreEqual(463, results.Where(x => x.ZigZag != null).Count());
             Assert.AreEqual(462, results.Where(x => x.RetraceHigh != null).Count());
             Assert.AreEqual(445, results.Where(x => x.RetraceLow != null).Count());
             Assert.AreEqual(31, results.Where(x => x.PointType != null).Count());
 
             // sample values
-            ZigZagResult r0 = results.Where(x => x.Index == 39).FirstOrDefault();
+            ZigZagResult r0 = results[38];
             Assert.AreEqual(null, r0.ZigZag);
             Assert.AreEqual(null, r0.RetraceHigh);
             Assert.AreEqual(null, r0.RetraceLow);
             Assert.AreEqual(null, r0.PointType);
 
-            ZigZagResult r1 = results.Where(x => x.Index == 278).FirstOrDefault();
+            ZigZagResult r1 = results[277];
             Assert.AreEqual(252.9550m, r1.ZigZag);
             Assert.AreEqual(262.8054m, Math.Round((decimal)r1.RetraceHigh, 4));
             Assert.AreEqual(245.4467m, Math.Round((decimal)r1.RetraceLow, 4));
             Assert.AreEqual(null, r1.PointType);
 
-            ZigZagResult r2 = results.Where(x => x.Index == 317).FirstOrDefault();
+            ZigZagResult r2 = results[316];
             Assert.AreEqual(249.48m, r2.ZigZag);
             Assert.AreEqual(258.34m, r2.RetraceHigh);
             Assert.AreEqual(249.48m, r2.RetraceLow);
             Assert.AreEqual("L", r2.PointType);
 
-            ZigZagResult r3 = results.Where(x => x.Index == 457).FirstOrDefault();
+            ZigZagResult r3 = results[456];
             Assert.AreEqual(261.3325m, Math.Round((decimal)r3.ZigZag, 4));
             Assert.AreEqual(274.3419m, Math.Round((decimal)r3.RetraceHigh, 4));
             Assert.AreEqual(256.1050m, Math.Round((decimal)r3.RetraceLow, 4));
             Assert.AreEqual(null, r3.PointType);
 
-            ZigZagResult r4 = results.Where(x => x.Index == 501).FirstOrDefault();
+            ZigZagResult r4 = results[500];
             Assert.AreEqual(246.73m, Math.Round((decimal)r4.ZigZag, 4));
             Assert.AreEqual(246.73m, r4.RetraceHigh);
             Assert.AreEqual(238.3867m, Math.Round((decimal)r4.RetraceLow, 4));
             Assert.AreEqual("H", r4.PointType);
 
-            ZigZagResult r5 = results.Where(x => x.Index == 502).FirstOrDefault();
+            ZigZagResult r5 = results[501];
             Assert.AreEqual(242.87m, r5.ZigZag);
             Assert.AreEqual(null, r5.RetraceHigh);
             Assert.AreEqual(242.87m, r5.RetraceLow);

--- a/tests/indicators/common/Test.Cleaner.cs
+++ b/tests/indicators/common/Test.Cleaner.cs
@@ -11,12 +11,12 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void PrepareHistoryTest()
+        public void ValidateHistoryTest()
         {
             IEnumerable<Quote> history = History.GetHistory();
 
             // clean
-            List<Quote> h = Cleaners.PrepareHistory(history);
+            List<Quote> h = Cleaners.ValidateHistory(history);
 
             // assertions
 
@@ -34,11 +34,11 @@ namespace Internal.Tests
 
 
         [TestMethod()]
-        public void PrepareLongHistoryTest()
+        public void ValidateLongHistoryTest()
         {
             IEnumerable<Quote> historyLong = History.GetHistoryLong();
 
-            List<Quote> h = Cleaners.PrepareHistory(historyLong);
+            List<Quote> h = Cleaners.ValidateHistory(historyLong);
 
             // assertions
 
@@ -57,7 +57,7 @@ namespace Internal.Tests
             // if history post-cleaning, is cut down in size it should not corrupt the results
 
             IEnumerable<Quote> history = History.GetHistory(200);
-            List<Quote> h = Cleaners.PrepareHistory(history);
+            List<Quote> h = Cleaners.ValidateHistory(history);
 
             // assertions
 
@@ -156,7 +156,7 @@ namespace Internal.Tests
         public void NoHistory()
         {
             List<Quote> badHistory = new List<Quote>();
-            Cleaners.PrepareHistory(badHistory);
+            Cleaners.ValidateHistory(badHistory);
         }
 
         [TestMethod()]
@@ -172,7 +172,7 @@ namespace Internal.Tests
             new Quote { Date = DateTime.ParseExact("2017-01-06", "yyyy-MM-dd", englishCulture), Open=228.97m, High=231.92m, Low=228.00m, Close=231.28m, Volume = 3979484 }
             };
 
-            Cleaners.PrepareHistory(badHistory);
+            Cleaners.ValidateHistory(badHistory);
         }
 
 

--- a/tests/performance/GlobalSuppressions.cs
+++ b/tests/performance/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "These cannot be static for performance tests.")]

--- a/tests/performance/Perf.Functions.cs
+++ b/tests/performance/Perf.Functions.cs
@@ -44,9 +44,9 @@ namespace Tests.Performance
         }
 
         [Benchmark]
-        public static object PrepareHistory()
+        public static object ValidateHistory()
         {
-            return Cleaners.PrepareHistory(h);
+            return Cleaners.ValidateHistory(h);
         }
 
         [Benchmark]

--- a/tests/performance/Perf.Functions.cs
+++ b/tests/performance/Perf.Functions.cs
@@ -38,19 +38,19 @@ namespace Tests.Performance
         private static readonly IEnumerable<Quote> h = History.GetHistory();
 
         [Benchmark]
-        public static object SortHistory()
+        public object SortHistory()
         {
             return h.Sort();
         }
 
         [Benchmark]
-        public static object ValidateHistory()
+        public object ValidateHistory()
         {
             return Cleaners.ValidateHistory(h);
         }
 
         [Benchmark]
-        public static object ConvertToBasicData()
+        public object ConvertToBasicData()
         {
             return Cleaners.ConvertHistoryToBasic(h);
         }

--- a/tests/performance/Perf.Functions.cs
+++ b/tests/performance/Perf.Functions.cs
@@ -36,18 +36,23 @@ namespace Tests.Performance
     public class MarkCleaners
     {
         private static readonly IEnumerable<Quote> h = History.GetHistory();
-        private static readonly IEnumerable<BasicData> b = Cleaners.ConvertHistoryToBasic(h);
 
         [Benchmark]
-        public object PrepareHistory()
+        public static object SortHistory()
+        {
+            return h.Sort();
+        }
+
+        [Benchmark]
+        public static object PrepareHistory()
         {
             return Cleaners.PrepareHistory(h);
         }
 
         [Benchmark]
-        public object PrepareBasicData()
+        public static object ConvertToBasicData()
         {
-            return Cleaners.PrepareBasicData(b);
+            return Cleaners.ConvertHistoryToBasic(h);
         }
 
     }

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -1,9 +1,9 @@
-# Performance benchmarks for v1.1.0
+# Performance benchmarks for v1.1.7
 
 These are the execution times for the current indicators using two years of historical daily stock quotes (502 periods) with default or typical parameters.
 
 ``` bash
-BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.572 (2004/?/20H1)
+BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
 Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
 .NET Core SDK=5.0.100
   [Host]     : .NET Core 5.0.0 (CoreCLR 5.0.20.51904, CoreFX 5.0.20.51904), X64 RyuJIT
@@ -14,60 +14,61 @@ Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical co
 
 |             Method |        Mean |     Error |    StdDev |      Median |
 |------------------- |------------:|----------:|----------:|------------:|
-|             GetAdl |   166.29 μs |  3.317 μs |  9.356 μs |   163.07 μs |
-|      GetAdlWithSma |   428.63 μs |  3.787 μs |  3.163 μs |   427.75 μs |
-|             GetAdx |   845.12 μs | 10.864 μs | 12.933 μs |   843.00 μs |
-|           GetAroon |   337.13 μs |  3.841 μs |  3.405 μs |   337.53 μs |
-|             GetAtr |   184.31 μs |  3.653 μs |  5.239 μs |   183.19 μs |
-|            GetBeta | 1,049.45 μs | 12.113 μs |  9.457 μs | 1,050.90 μs |
-|  GetBollingerBands |   442.86 μs |  5.722 μs |  4.468 μs |   442.49 μs |
-|             GetCci |   910.38 μs | 22.144 μs | 64.946 μs |   879.66 μs |
-|      GetChaikinOsc |   377.55 μs |  1.668 μs |  1.478 μs |   376.92 μs |
-|      GetChandelier |   363.40 μs |  3.433 μs |  3.043 μs |   362.35 μs |
-|             GetCmf |   662.24 μs |  2.385 μs |  1.991 μs |   661.99 μs |
-|      GetConnorsRsi | 1,279.67 μs |  3.615 μs |  3.019 μs | 1,279.85 μs |
-|     GetCorrelation |   817.38 μs |  7.546 μs |  6.301 μs |   814.70 μs |
-|        GetDonchian |   302.10 μs |  1.735 μs |  1.354 μs |   301.92 μs |
-|       GetDoubleEma |   253.41 μs |  3.928 μs |  3.482 μs |   252.23 μs |
-|             GetEma |   139.20 μs |  0.670 μs |  0.559 μs |   139.08 μs |
-|      GetHeikinAshi |   183.00 μs |  0.617 μs |  0.515 μs |   183.01 μs |
-|             GetHma | 1,426.38 μs |  6.791 μs |  6.020 μs | 1,423.66 μs |
-|        GetIchimoku |   877.50 μs |  4.985 μs |  4.419 μs |   876.12 μs |
-|         GetKeltner |   526.29 μs |  1.989 μs |  1.553 μs |   526.26 μs |
-|            GetMacd |   418.10 μs |  3.455 μs |  2.697 μs |   417.17 μs |
-|             GetMfi |   498.57 μs |  7.252 μs |  9.429 μs |   496.00 μs |
-|             GetObv |    66.55 μs |  0.549 μs |  0.514 μs |    66.41 μs |
-|      GetObvWithSma |   192.81 μs |  7.121 μs | 20.771 μs |   187.22 μs |
-|    GetParabolicSar |   141.38 μs |  2.811 μs |  4.697 μs |   141.78 μs |
-|             GetPmo |   398.54 μs |  7.699 μs | 11.041 μs |   395.49 μs |
-|             GetPrs |   201.48 μs |  4.013 μs |  8.466 μs |   201.01 μs |
-|      GetPrsWithSma |   273.75 μs |  5.403 μs |  8.571 μs |   271.70 μs |
-|             GetRoc |   143.71 μs |  2.868 μs |  8.044 μs |   142.89 μs |
-|      GetRocWithSma |   401.29 μs |  5.310 μs |  4.967 μs |   399.92 μs |
-|             GetRsi |   482.43 μs |  6.164 μs |  5.766 μs |   481.19 μs |
-|           GetSlope |   997.45 μs | 19.623 μs | 40.525 μs | 1,001.09 μs |
-|             GetSma |   164.34 μs |  3.247 μs |  7.127 μs |   163.61 μs |
-|     GetSmaExtended | 1,136.51 μs | 22.495 μs | 22.093 μs | 1,131.39 μs |
-|          GetStdDev |   482.58 μs |  8.562 μs |  8.793 μs |   482.03 μs |
-|   GetStdDevWithSma |   594.46 μs | 11.689 μs | 10.933 μs |   594.59 μs |
-|           GetStoch |   493.60 μs |  7.157 μs |  6.695 μs |   495.79 μs |
-|        GetStochRsi |   741.82 μs |  9.198 μs | 21.859 μs |   737.06 μs |
-|       GetTripleEma |   364.59 μs |  1.909 μs |  1.692 μs |   364.03 μs |
-|            GetTrix |   435.09 μs |  1.952 μs |  1.731 μs |   434.60 μs |
-|     GetTrixWithSma |   491.33 μs |  2.010 μs |  1.678 μs |   491.30 μs |
-|      GetUlcerIndex | 1,380.28 μs |  6.563 μs |  5.481 μs | 1,378.85 μs |
-|        GetUltimate |   600.91 μs |  4.134 μs |  3.452 μs |   602.13 μs |
-|          GetVolSma |   121.56 μs |  0.691 μs |  0.613 μs |   121.65 μs |
-|       GetWilliamsR |   292.65 μs |  1.621 μs |  1.517 μs |   292.32 μs |
-|             GetWma |   756.90 μs |  2.817 μs |  2.353 μs |   757.01 μs |
-|          GetZigZag |   232.81 μs |  3.206 μs |  2.503 μs |   232.23 μs |
+|             GetAdl |   137.24 μs |  1.534 μs |  1.281 μs |   137.30 μs |
+|      GetAdlWithSma |   376.36 μs |  5.379 μs |  4.768 μs |   374.32 μs |
+|             GetAdx |   745.02 μs | 10.035 μs |  8.896 μs |   743.31 μs |
+|           GetAroon |   293.20 μs |  3.375 μs |  2.992 μs |   292.89 μs |
+|             GetAtr |   156.83 μs |  1.939 μs |  1.813 μs |   156.16 μs |
+|            GetBeta |   936.10 μs | 18.649 μs | 47.468 μs |   917.91 μs |
+|  GetBollingerBands |   421.22 μs |  2.632 μs |  2.198 μs |   420.23 μs |
+|             GetCci |   938.87 μs | 18.736 μs | 38.692 μs |   947.69 μs |
+|      GetChaikinOsc |   261.66 μs |  2.004 μs |  1.777 μs |   260.88 μs |
+|      GetChandelier |   347.84 μs |  4.633 μs |  5.149 μs |   344.90 μs |
+|             GetCmf |   650.66 μs | 11.334 μs | 10.048 μs |   645.57 μs |
+|      GetConnorsRsi | 1,239.76 μs | 19.696 μs | 22.682 μs | 1,226.99 μs |
+|     GetCorrelation |   798.39 μs |  8.640 μs |  7.659 μs |   795.42 μs |
+|        GetDonchian |   311.99 μs |  3.047 μs |  2.702 μs |   311.41 μs |
+|       GetDoubleEma |   187.94 μs |  3.722 μs |  7.519 μs |   183.50 μs |
+|             GetEma |    99.38 μs |  0.982 μs |  0.919 μs |    98.93 μs |
+|      GetHeikinAshi |   168.49 μs |  0.527 μs |  0.467 μs |   168.40 μs |
+|             GetHma | 1,376.12 μs | 14.132 μs | 13.219 μs | 1,371.61 μs |
+|        GetIchimoku |   791.79 μs | 10.578 μs |  9.895 μs |   786.88 μs |
+|         GetKeltner |   464.88 μs |  3.340 μs |  3.124 μs |   463.44 μs |
+|            GetMacd |   301.04 μs |  1.449 μs |  1.284 μs |   300.77 μs |
+|             GetMfi |   483.38 μs |  5.222 μs |  4.884 μs |   482.29 μs |
+|             GetObv |    57.22 μs |  0.360 μs |  0.301 μs |    57.12 μs |
+|      GetObvWithSma |   140.01 μs |  2.717 μs |  3.627 μs |   141.21 μs |
+|    GetParabolicSar |    92.30 μs |  0.940 μs |  0.785 μs |    92.00 μs |
+|             GetPmo |   256.93 μs |  1.358 μs |  1.271 μs |   256.58 μs |
+|             GetPrs |   124.44 μs |  1.214 μs |  1.136 μs |   124.66 μs |
+|      GetPrsWithSma |   182.98 μs |  3.401 μs |  3.340 μs |   181.38 μs |
+|             GetRoc |    90.65 μs |  1.727 μs |  1.848 μs |    89.81 μs |
+|      GetRocWithSma |   303.77 μs |  2.919 μs |  2.730 μs |   302.55 μs |
+|             GetRsi |   342.30 μs |  3.700 μs |  3.461 μs |   341.25 μs |
+|           GetSlope |   853.82 μs |  8.382 μs |  7.840 μs |   848.86 μs |
+|             GetSma |   103.24 μs |  0.947 μs |  0.839 μs |   102.81 μs |
+|     GetSmaExtended |   823.31 μs |  9.011 μs |  8.429 μs |   818.74 μs |
+|          GetStdDev |   286.72 μs |  1.441 μs |  1.203 μs |   286.63 μs |
+|   GetStdDevWithSma |   374.83 μs |  3.881 μs |  3.440 μs |   374.10 μs |
+|           GetStoch |   341.61 μs |  3.872 μs |  3.622 μs |   339.28 μs |
+|        GetStochRsi |   649.50 μs |  2.592 μs |  2.297 μs |   649.88 μs |
+|       GetTripleEma |   264.51 μs |  1.983 μs |  1.758 μs |   263.68 μs |
+|            GetTrix |   325.91 μs |  1.490 μs |  1.244 μs |   325.41 μs |
+|     GetTrixWithSma |   386.88 μs |  3.600 μs |  3.367 μs |   387.34 μs |
+|      GetUlcerIndex | 1,362.65 μs | 21.196 μs | 17.700 μs | 1,353.32 μs |
+|        GetUltimate |   583.55 μs |  2.676 μs |  2.089 μs |   583.80 μs |
+|          GetVolSma |   116.47 μs |  1.187 μs |  1.110 μs |   116.11 μs |
+|       GetWilliamsR |   257.74 μs |  0.407 μs |  0.340 μs |   257.77 μs |
+|             GetWma |   742.48 μs |  8.612 μs |  8.056 μs |   737.53 μs |
+|          GetZigZag |   138.55 μs |  0.722 μs |  0.603 μs |   138.42 μs |
 
 ## internal cleaners
 
-|           Method |     Mean |    Error |   StdDev |
-|----------------- |---------:|---------:|---------:|
-|   PrepareHistory | 42.15 μs | 0.483 μs | 0.452 μs |
-| PrepareBasicData | 30.35 μs | 0.221 μs | 0.196 μs |
+|             Method |     Mean |    Error |   StdDev |   Median |
+|------------------- |---------:|---------:|---------:|---------:|
+|        SortHistory | 37.42 μs | 0.702 μs | 0.751 μs | 37.33 μs |
+|    ValidateHistory | 37.37 μs | 0.361 μs | 0.337 μs | 37.42 μs |
+| ConvertToBasicData | 44.66 μs | 1.066 μs | 3.025 μs | 43.16 μs |
 
 ## internal math functions
 


### PR DESCRIPTION
Removing internal redundant indexing as part of ongoing continuous improvement, per [AB#763](https://dev.azure.com/skender/5123ca47-74f2-4d67-a5d4-c4d90b8d670a/_workitems/edit/763).  The internal Index has been problematic in its current implementation for some unexpected use cases.  This resolves issues #180 and #170.

To do:
- [x] remove index from indicator classes
- [x] remove Index from `Quote` class
- [x] replace the use of Cleaner in indicators with simpler Resorter
- [x] keep `PrepareHistory` for optional advanced cleaning (to make it optional), also to avoid breaking change
