### PR TITLE
bug fix: bollinger band div by zero

### DIFF
--- a/indicators/BollingerBands/BollingerBands.cs
+++ b/indicators/BollingerBands/BollingerBands.cs
@@ -52,7 +52,9 @@ namespace Skender.Stock.Indicators
                     r.UpperBand = periodAvg + standardDeviations * stdDev;
                     r.LowerBand = periodAvg - standardDeviations * stdDev;
 
-                    r.PercentB = (h.Close - r.LowerBand) / (r.UpperBand - r.LowerBand);
+                    r.PercentB = (r.UpperBand == r.LowerBand) ? null 
+                        : h.Close - r.LowerBand) / (r.UpperBand - r.LowerBand);
+                    
                     r.ZScore = (stdDev == 0) ? null : (h.Close - r.Sma) / stdDev;
                     r.Width = (r.Sma == 0) ? null : (r.UpperBand - r.LowerBand) / r.Sma;
                 }

--- a/indicators/BollingerBands/BollingerBands.cs
+++ b/indicators/BollingerBands/BollingerBands.cs
@@ -53,7 +53,7 @@ namespace Skender.Stock.Indicators
                     r.LowerBand = periodAvg - standardDeviations * stdDev;
 
                     r.PercentB = (r.UpperBand == r.LowerBand) ? null 
-                        : h.Close - r.LowerBand) / (r.UpperBand - r.LowerBand);
+                        : (h.Close - r.LowerBand) / (r.UpperBand - r.LowerBand);
                     
                     r.ZScore = (stdDev == 0) ? null : (h.Close - r.Sma) / stdDev;
                     r.Width = (r.Sma == 0) ? null : (r.UpperBand - r.LowerBand) / r.Sma;

--- a/indicators/BollingerBands/BollingerBands.cs
+++ b/indicators/BollingerBands/BollingerBands.cs
@@ -52,9 +52,9 @@ namespace Skender.Stock.Indicators
                     r.UpperBand = periodAvg + standardDeviations * stdDev;
                     r.LowerBand = periodAvg - standardDeviations * stdDev;
 
-                    r.PercentB = (r.UpperBand == r.LowerBand) ? null 
+                    r.PercentB = (r.UpperBand == r.LowerBand) ? null
                         : (h.Close - r.LowerBand) / (r.UpperBand - r.LowerBand);
-                    
+
                     r.ZScore = (stdDev == 0) ? null : (h.Close - r.Sma) / stdDev;
                     r.Width = (r.Sma == 0) ? null : (r.UpperBand - r.LowerBand) / r.Sma;
                 }


### PR DESCRIPTION
Fixes #183.  This divide by zero error can occur in rare circumstances when the price does not change over the lookback period.