### PR TITLE
add IQuote generic interface

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -5,9 +5,9 @@
 - [Prerequisite data](#prerequisite-data)
 - [Example usage](#example-usage)
 - [About historical quotes](#quote)
-- [Using custom Quote classes](#using-custom-quote-classes)
+- [Using custom quote classes](#using-custom-quote-classes)
 - [Validating historical quotes](#validating-historical-quotes)
-- [Using derived Results classes](#using-derived-results-classes)
+- [Using derived results classes](#using-derived-results-classes)
 - [Generating indicator of indicators](#generating-indicator-of-indicators)
 - [Contributing guidelines](CONTRIBUTING.md)
 
@@ -46,7 +46,7 @@ Console.WriteLine("SMA on {0} was ${1}", result.Date, result.Sma);
 SMA on 12/31/2018 was $251.86
 ```
 
-See [using custom Quote classes](#using-custom-quote-classes) if you prefer to use your own quote class.
+See [using custom quote classes](#using-custom-quote-classes) if you prefer to use your own quote class.
 
 See [individual indicator pages](INDICATORS.md) for specific guidance.
 
@@ -75,7 +75,7 @@ Note that some indicators, especially those that are derived from [Exponential M
 
 For example, if you are using daily data and want one year of precise EMA(250) data, you need to provide 3 years of total historical quotes (1 extra year for the lookback period and 1 extra year for convergence); thereafter, you would discard or not use the first two years of results.
 
-## Using custom Quote classes
+## Using custom quote classes
 
 If you would like to use your own custom `MyCustomQuote` _quote_ class, to avoid needing to transpose into the library `Quote` class, you only need to add the `IQuote` interface.
 
@@ -105,7 +105,7 @@ IEnumerable<MyCustomQuote> myHistory = GetHistoryFromFeed("MSFT");
 IEnumerable<SmaResult> results = Indicator.GetSma(myHistory,20);
 ```
 
-### Using custom Quote property names
+### Using custom quote property names
 
 If you have a model that has different properties names, but the same meaning, you only need to map them.
 Suppose your class has a property called `CloseDate` instead of `Date`, it could be represented like this:
@@ -143,7 +143,7 @@ IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 List<Quote> validatedHistory = Cleaners.ValidateHistory(history);
 ```
 
-## Using derived Results classes
+## Using derived results classes
 
 The indicator result (e.g. `EmaResult`) classes can be extended in your code.  Here's an example of how you'd set that up:
 
@@ -186,7 +186,7 @@ public void MyClass(){
 If you prefer nested classes, here's an alternative method for customizing your results:
 
 ```csharp
-// your custom derived class
+// your custom nested class
 public class MyEma
 {
   public int MyId { get; set; }

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -1,4 +1,5 @@
 ﻿<!-- markdownlint-disable MD026 -->
+
 # Guide and Pro tips
 
 - [Prerequisite data](#prerequisite-data)
@@ -90,7 +91,7 @@ public class MyCustomQuote : IQuote
     public decimal Volume { get; set; }
 
     // custom properties
-    public int myOtherProperty { get; set; }
+    public int MyOtherProperty { get; set; }
 }
 ```
 
@@ -103,6 +104,34 @@ IEnumerable<MyCustomQuote> myHistory = GetHistoryFromFeed("MSFT");
 // example: get 20-period simple moving average
 IEnumerable<SmaResult> results = Indicator.GetSma(myHistory,20);
 ```
+
+
+
+`IQuote` interface just requires you to implement property getters, so if you have a model that has properties with a different name but the same meaning, you have just to implement a wrapper on them.
+Suppose your class has a property called `CloseDate` instead of `Date`, it could be represented like this:
+
+```csharp
+public class MyCustomQuote : IQuote
+{
+    // required base properties
+    DateTime IQuote.Date => CloseDate;
+    public decimal Open { get; set; }
+    public decimal High { get; set; }
+    public decimal Low { get; set; }
+    public decimal Close { get; set; }
+    public decimal Volume { get; set; }
+
+    // custom properties
+    public int MyOtherProperty { get; set; }
+    public DateTime CloseDate { get; set; }
+}
+```
+
+Note the use of explicit interface (property declaration is `IQuote.Date`), this is because having two properties that expose the same information can be confusing, this way Date property is only accessible when working with the IQuote type, while if you are working with a `MyCustomQuote` the Date property will be hidden, avoiding confusion.
+
+For more information on explicit interfaces, refer to the [c# documentation](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/interfaces/explicit-interface-implementation).
+
+
 
 ## Validating history
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -106,7 +106,7 @@ IEnumerable<SmaResult> results = Indicator.GetSma(myHistory,20);
 
 ## Validating history
 
-Historical quotes are automatically re-sorted [ascending by date] on every call to the library.  This is needed to ensure that it is sequenced properly.  If you want a more advanced check of your `IEnumerable<IQuote> history` (historical quotes) you can _optionally_ validate it with the `ValidateHistory` helper function.  It will check for duplicate dates and other bad data.  This comes at a small performance cost, so we did not automatically add these advanced validations in the indicator methods.  Of course, you can and should do your own validation of `history` prior to using it in this library.  Bad historical quotes data can produce unexpected results.
+Historical quotes are automatically re-sorted [ascending by date] on every call to the library.  This is needed to ensure that it is sequenced properly.  If you want a more advanced check of your `IEnumerable<TQuote> history` (historical quotes) you can _optionally_ validate it with the `ValidateHistory` helper function.  It will check for duplicate dates and other bad data.  This comes at a small performance cost, so we did not automatically add these advanced validations in the indicator methods.  Of course, you can and should do your own validation of `history` prior to using it in this library.  Bad historical quotes data can produce unexpected results.
 
 ```csharp
 // fetch historical quotes from your favorite feed, in Quote format

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -4,6 +4,7 @@
 - [Prerequisite data](#prerequisite-data)
 - [Example usage](#example-usage)
 - [About historical quotes](#quote)
+- [Using generic Quote classes](#using-generic-quote-classes)
 - [Validating history](#validating-history)
 - [Using derived classes](#using-derived-classes)
 - [Generating indicator of indicators](#generating-indicator-of-indicators)
@@ -14,7 +15,7 @@
 Most indicators require that you provide historical quote data and additional configuration parameters.
 
 You can get historical quotes from your favorite stock data provider.
-Historical data is an `IEnumerable` of the `Quote` class ([see below](#quote)).
+Historical data is an `IEnumerable` of the `Quote` class ([see below](#quote)); however, it can also be supplied as a [generic quote type](#using-generic-quote-classes) if you prefer to use your own quote model.
 
 For additional configuration parameters, default values are provided when there is an industry standard.
 You can, of course, override these and provide your own values.
@@ -44,6 +45,8 @@ Console.WriteLine("SMA on {0} was ${1}", result.Date, result.Sma);
 SMA on 12/31/2018 was $251.86
 ```
 
+See [using generic Quote classes](#using-generic-quote-classes) if you prefer to use your custom quote class.
+
 See [individual indicator pages](INDICATORS.md) for specific guidance.
 
 ## Quote
@@ -71,9 +74,39 @@ Note that some indicators, especially those that are derived from [Exponential M
 
 For example, if you are using daily data and want one year of precise EMA(250) data, you need to provide 3 years of total historical quotes (1 extra year for the lookback period and 1 extra year for convergence); thereafter, you would discard or not use the first two years of results.
 
+## Using generic Quote classes
+
+If you would like to use your own custom `MyCustomQuote` _quote_ class, to avoid needing to transpose into the library `Quote` class, you only need to add the `IQuote` interface.
+
+```csharp
+public class MyCustomQuote : IQuote
+{
+    // required base properties
+    public DateTime Date { get; set; }
+    public decimal Open { get; set; }
+    public decimal High { get; set; }
+    public decimal Low { get; set; }
+    public decimal Close { get; set; }
+    public decimal Volume { get; set; }
+
+    // custom properties
+    public int myOtherProperty { get; set; }
+}
+```
+
+```csharp
+using Skender.Stock.Indicators;
+
+// fetch historical quotes from your favorite feed
+IEnumerable<MyCustomQuote> myHistory = GetHistoryFromFeed("MSFT");
+
+// example: get 20-period simple moving average
+IEnumerable<SmaResult> results = Indicator.GetSma(myHistory,20);
+```
+
 ## Validating history
 
-Historical quotes are automatically re-sorted [ascending by date] on every call to the library.  This is needed to ensure that it is sequenced properly.  If you want a more advanced check of your `IEnumerable<Quote> history` (historical quotes) you can validate it with the `ValidateHistory` helper function.  It will check for duplicate dates and other bad data.  This comes at a small performance cost, so we did not automatically add these advanced validations in the indicator methods.  Of course, you can and should do your own validation of `history` prior to using it in this library.  Bad historical quotes data can produce unexpected results.
+Historical quotes are automatically re-sorted [ascending by date] on every call to the library.  This is needed to ensure that it is sequenced properly.  If you want a more advanced check of your `IEnumerable<IQuote> history` (historical quotes) you can _optionally_ validate it with the `ValidateHistory` helper function.  It will check for duplicate dates and other bad data.  This comes at a small performance cost, so we did not automatically add these advanced validations in the indicator methods.  Of course, you can and should do your own validation of `history` prior to using it in this library.  Bad historical quotes data can produce unexpected results.
 
 ```csharp
 // fetch historical quotes from your favorite feed, in Quote format

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -5,9 +5,9 @@
 - [Prerequisite data](#prerequisite-data)
 - [Example usage](#example-usage)
 - [About historical quotes](#quote)
-- [Using generic Quote classes](#using-generic-quote-classes)
-- [Validating history](#validating-history)
-- [Using derived classes](#using-derived-classes)
+- [Using custom Quote classes](#using-custom-quote-classes)
+- [Validating historical quotes](#validating-historical-quotes)
+- [Using derived Results classes](#using-derived-results-classes)
 - [Generating indicator of indicators](#generating-indicator-of-indicators)
 - [Contributing guidelines](CONTRIBUTING.md)
 
@@ -16,7 +16,7 @@
 Most indicators require that you provide historical quote data and additional configuration parameters.
 
 You can get historical quotes from your favorite stock data provider.
-Historical data is an `IEnumerable` of the `Quote` class ([see below](#quote)); however, it can also be supplied as a [generic quote type](#using-generic-quote-classes) if you prefer to use your own quote model.
+Historical data is an `IEnumerable` of the `Quote` class ([see below](#quote)); however, it can also be supplied as a generic [custom quote type](#using-custom-quote-classes) if you prefer to use your own quote model.
 
 For additional configuration parameters, default values are provided when there is an industry standard.
 You can, of course, override these and provide your own values.
@@ -46,7 +46,7 @@ Console.WriteLine("SMA on {0} was ${1}", result.Date, result.Sma);
 SMA on 12/31/2018 was $251.86
 ```
 
-See [using generic Quote classes](#using-generic-quote-classes) if you prefer to use your custom quote class.
+See [using custom Quote classes](#using-custom-quote-classes) if you prefer to use your own quote class.
 
 See [individual indicator pages](INDICATORS.md) for specific guidance.
 
@@ -75,7 +75,7 @@ Note that some indicators, especially those that are derived from [Exponential M
 
 For example, if you are using daily data and want one year of precise EMA(250) data, you need to provide 3 years of total historical quotes (1 extra year for the lookback period and 1 extra year for convergence); thereafter, you would discard or not use the first two years of results.
 
-## Using generic Quote classes
+## Using custom Quote classes
 
 If you would like to use your own custom `MyCustomQuote` _quote_ class, to avoid needing to transpose into the library `Quote` class, you only need to add the `IQuote` interface.
 
@@ -105,9 +105,9 @@ IEnumerable<MyCustomQuote> myHistory = GetHistoryFromFeed("MSFT");
 IEnumerable<SmaResult> results = Indicator.GetSma(myHistory,20);
 ```
 
+### Using custom Quote property names
 
-
-`IQuote` interface just requires you to implement property getters, so if you have a model that has properties with a different name but the same meaning, you have just to implement a wrapper on them.
+If you have a model that has different properties names, but the same meaning, you only need to map them.
 Suppose your class has a property called `CloseDate` instead of `Date`, it could be represented like this:
 
 ```csharp
@@ -127,13 +127,11 @@ public class MyCustomQuote : IQuote
 }
 ```
 
-Note the use of explicit interface (property declaration is `IQuote.Date`), this is because having two properties that expose the same information can be confusing, this way Date property is only accessible when working with the IQuote type, while if you are working with a `MyCustomQuote` the Date property will be hidden, avoiding confusion.
+Note the use of explicit interface (property declaration is `IQuote.Date`), this is because having two properties that expose the same information can be confusing, this way `Date` property is only accessible when working with the `IQuote` type, while if you are working with a `MyCustomQuote` the `Date` property will be hidden, avoiding confusion.
 
-For more information on explicit interfaces, refer to the [c# documentation](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/interfaces/explicit-interface-implementation).
+For more information on explicit interfaces, refer to the [C# Programming Guide](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/interfaces/explicit-interface-implementation).
 
-
-
-## Validating history
+## Validating historical quotes
 
 Historical quotes are automatically re-sorted [ascending by date] on every call to the library.  This is needed to ensure that it is sequenced properly.  If you want a more advanced check of your `IEnumerable<TQuote> history` (historical quotes) you can _optionally_ validate it with the `ValidateHistory` helper function.  It will check for duplicate dates and other bad data.  This comes at a small performance cost, so we did not automatically add these advanced validations in the indicator methods.  Of course, you can and should do your own validation of `history` prior to using it in this library.  Bad historical quotes data can produce unexpected results.
 
@@ -145,9 +143,9 @@ IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 List<Quote> validatedHistory = Cleaners.ValidateHistory(history);
 ```
 
-## Using derived classes
+## Using derived Results classes
 
-The `Quote` and indicator result (e.g. `EmaResult`) classes can be extended in your code.  Here's an example of how you'd set that up:
+The indicator result (e.g. `EmaResult`) classes can be extended in your code.  Here's an example of how you'd set that up:
 
 ```csharp
 // your custom derived class
@@ -180,6 +178,44 @@ public void MyClass(){
   // use your custom quote data
   Console.WriteLine("On {0}, EMA was {1} for my EMA ID {2}.",
                      r.Date, r.Ema, r.MyId);
+}
+```
+
+### Using nested Results classes
+
+If you prefer nested classes, here's an alternative method for customizing your results:
+
+```csharp
+// your custom derived class
+public class MyEma
+{
+  public int MyId { get; set; }
+  public EmaResult Result { get; set; }
+}
+
+public void MyClass(){
+
+  // fetch historical quotes from your favorite feed, in Quote format
+  IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
+
+  // compute indicator
+  INumerable<EmaResult> emaResults = Indicator.GetEma(history,14);
+
+  // convert to my Ema class list [using LINQ]
+  List<MyEma> myEmaResults = emaResults
+    .Select(x => new MyEma
+      {
+        MyId = 123,
+        Result = x
+      })
+    .ToList();
+
+  // randomly selecting first record from the collection here for the example
+  MyEma r = myEmaResults.FirstOrDefault();
+
+  // use your custom quote data
+  Console.WriteLine("On {0}, EMA was {1} for my EMA ID {2}.",
+                     r.Result.Date, r.Result.Ema, r.MyId);
 }
 ```
 

--- a/indicators/Adl/Adl.cs
+++ b/indicators/Adl/Adl.cs
@@ -7,11 +7,11 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // ACCUMULATION / DISTRIBUTION LINE
-        public static IEnumerable<AdlResult> GetAdl(IEnumerable<Quote> history, int? smaPeriod = null)
+        public static IEnumerable<AdlResult> GetAdl<TQuote>(IEnumerable<TQuote> history, int? smaPeriod = null) where TQuote : IQuote
         {
 
             // clean quotes
-            List<Quote> historyList = history.Sort();
+            List<TQuote> historyList = history.Sort();
 
             // check parameters
             ValidateAdl(history, smaPeriod);
@@ -23,7 +23,7 @@ namespace Skender.Stock.Indicators
             // get money flow multiplier
             for (int i = 0; i < historyList.Count; i++)
             {
-                Quote h = historyList[i];
+                TQuote h = historyList[i];
                 int index = i + 1;
 
                 decimal mfm = (h.High == h.Low) ? 0 : ((h.Close - h.Low) - (h.High - h.Close)) / (h.High - h.Low);
@@ -58,7 +58,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateAdl(IEnumerable<Quote> history, int? smaPeriod)
+        private static void ValidateAdl<TQuote>(IEnumerable<TQuote> history, int? smaPeriod) where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/Adl/README.md
+++ b/indicators/Adl/README.md
@@ -16,7 +16,7 @@ IEnumerable<AdlResult> results = Indicator.GetAdl(history,smaPeriod);
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least two historical quotes; however, since this is a trendline, more is recommended.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least two historical quotes; however, since this is a trendline, more is recommended.
 | `smaPeriod` | int | Optional.  Number of periods (`N`) in the moving average of ADL.  Must be greater than 0, if specified.
 
 ## Response

--- a/indicators/Adx/Adx.cs
+++ b/indicators/Adx/Adx.cs
@@ -7,7 +7,10 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // AVERAGE DIRECTIONAL INDEX
-        public static IEnumerable<AdxResult> GetAdx<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod = 14) where TQuote : IQuote
+        public static IEnumerable<AdxResult> GetAdx<TQuote>(
+            IEnumerable<TQuote> history,
+            int lookbackPeriod = 14)
+            where TQuote : IQuote
         {
 
             // clean quotes

--- a/indicators/Adx/Adx.cs
+++ b/indicators/Adx/Adx.cs
@@ -7,11 +7,11 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // AVERAGE DIRECTIONAL INDEX
-        public static IEnumerable<AdxResult> GetAdx(IEnumerable<Quote> history, int lookbackPeriod = 14)
+        public static IEnumerable<AdxResult> GetAdx<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod = 14) where TQuote : IQuote
         {
 
             // clean quotes
-            List<Quote> historyList = history.Sort();
+            List<TQuote> historyList = history.Sort();
 
             // verify parameters
             ValidateAdx(history, lookbackPeriod);
@@ -35,7 +35,7 @@ namespace Skender.Stock.Indicators
             // roll through history
             for (int i = 0; i < historyList.Count; i++)
             {
-                Quote h = historyList[i];
+                TQuote h = historyList[i];
                 int index = i + 1;
 
                 AdxResult result = new AdxResult
@@ -139,7 +139,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateAdx(IEnumerable<Quote> history, int lookbackPeriod)
+        private static void ValidateAdx<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod) where TQuote : IQuote
         {
             // check parameters
             if (lookbackPeriod <= 1)

--- a/indicators/Adx/README.md
+++ b/indicators/Adx/README.md
@@ -13,7 +13,7 @@ IEnumerable<AdxResult> results = Indicator.GetAdx(history, lookbackPeriod);
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `2×N+100` periods of `history` to allow for smoothing convergence.  We generally recommend you use at least 250 data points prior to the intended usage date for maximum precision.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `2×N+100` periods of `history` to allow for smoothing convergence.  We generally recommend you use at least 250 data points prior to the intended usage date for maximum precision.
 | `lookbackPeriod` | int | Number of periods (`N`) to consider.  Must be greater than 1.  Default is 14.
 
 ## Response

--- a/indicators/Aroon/Aroon.cs
+++ b/indicators/Aroon/Aroon.cs
@@ -7,11 +7,11 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // AROON OSCILLATOR
-        public static IEnumerable<AroonResult> GetAroon(IEnumerable<Quote> history, int lookbackPeriod = 25)
+        public static IEnumerable<AroonResult> GetAroon<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod = 25) where TQuote : IQuote
         {
 
             // clean quotes
-            List<Quote> historyList = history.Sort();
+            List<TQuote> historyList = history.Sort();
 
             // validate parameters
             ValidateAroon(history, lookbackPeriod);
@@ -22,7 +22,7 @@ namespace Skender.Stock.Indicators
             // roll through history
             for (int i = 0; i < historyList.Count; i++)
             {
-                Quote h = historyList[i];
+                TQuote h = historyList[i];
                 int index = i + 1;
 
                 AroonResult result = new AroonResult
@@ -40,7 +40,7 @@ namespace Skender.Stock.Indicators
 
                     for (int p = index - lookbackPeriod - 1; p < index; p++)
                     {
-                        Quote d = historyList[p];
+                        TQuote d = historyList[p];
 
                         if (d.High > lastHighPrice)
                         {
@@ -67,7 +67,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateAroon(IEnumerable<Quote> history, int lookbackPeriod)
+        private static void ValidateAroon<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod)
         {
             // check parameters
             if (lookbackPeriod <= 0)

--- a/indicators/Aroon/Aroon.cs
+++ b/indicators/Aroon/Aroon.cs
@@ -7,7 +7,10 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // AROON OSCILLATOR
-        public static IEnumerable<AroonResult> GetAroon<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod = 25) where TQuote : IQuote
+        public static IEnumerable<AroonResult> GetAroon<TQuote>(
+            IEnumerable<TQuote> history,
+            int lookbackPeriod = 25)
+            where TQuote : IQuote
         {
 
             // clean quotes

--- a/indicators/Aroon/README.md
+++ b/indicators/Aroon/README.md
@@ -13,7 +13,7 @@ IEnumerable<AroonResult> results = Indicator.GetAroon(history, lookbackPeriod);
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at `N` periods worth of `history`.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at `N` periods worth of `history`.
 | `lookbackPeriod` | int | Number of periods (`N`) for the lookback evaluation.  Must be greater than 0.  Default is 25.
 
 ## Response

--- a/indicators/Atr/Atr.cs
+++ b/indicators/Atr/Atr.cs
@@ -7,7 +7,10 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // AVERAGE TRUE RANGE
-        public static IEnumerable<AtrResult> GetAtr<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod = 14) where TQuote : IQuote
+        public static IEnumerable<AtrResult> GetAtr<TQuote>(
+            IEnumerable<TQuote> history,
+            int lookbackPeriod = 14)
+            where TQuote : IQuote
         {
 
             // clean quotes

--- a/indicators/Atr/Atr.cs
+++ b/indicators/Atr/Atr.cs
@@ -7,11 +7,11 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // AVERAGE TRUE RANGE
-        public static IEnumerable<AtrResult> GetAtr(IEnumerable<Quote> history, int lookbackPeriod = 14)
+        public static IEnumerable<AtrResult> GetAtr<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod = 14) where TQuote : IQuote
         {
 
             // clean quotes
-            List<Quote> historyList = history.Sort();
+            List<TQuote> historyList = history.Sort();
 
             // validate parameters
             ValidateAtr(history, lookbackPeriod);
@@ -27,7 +27,7 @@ namespace Skender.Stock.Indicators
             // roll through history
             for (int i = 0; i < historyList.Count; i++)
             {
-                Quote h = historyList[i];
+                TQuote h = historyList[i];
                 int index = i + 1;
 
                 AtrResult result = new AtrResult
@@ -73,7 +73,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateAtr(IEnumerable<Quote> history, int lookbackPeriod)
+        private static void ValidateAtr<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod) where TQuote : IQuote
         {
             // check parameters
             if (lookbackPeriod <= 1)

--- a/indicators/Atr/README.md
+++ b/indicators/Atr/README.md
@@ -13,7 +13,7 @@ IEnumerable<AtrResult> results = Indicator.GetAtr(history, lookbackPeriod);
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N`+1 periods of `history`.  Since this uses a smoothing technique, we recommend you use at least 2×`N` data points prior to the intended usage date for maximum precision.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N`+1 periods of `history`.  Since this uses a smoothing technique, we recommend you use at least 2×`N` data points prior to the intended usage date for maximum precision.
 | `lookbackPeriod` | int | Number of periods (`N`) to consider.  Must be greater than 1.
 
 ## Response

--- a/indicators/Beta/Beta.cs
+++ b/indicators/Beta/Beta.cs
@@ -7,11 +7,11 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // BETA COEFFICIENT
-        public static IEnumerable<BetaResult> GetBeta(
-            IEnumerable<Quote> historyMarket, IEnumerable<Quote> historyEval, int lookbackPeriod)
+        public static IEnumerable<BetaResult> GetBeta<TQuote>(
+            IEnumerable<TQuote> historyMarket, IEnumerable<TQuote> historyEval, int lookbackPeriod) where TQuote : IQuote
         {
             // clean quotes
-            List<Quote> historyEvalList = historyEval.Sort();
+            List<TQuote> historyEvalList = historyEval.Sort();
 
             // validate parameters
             ValidateBeta(historyMarket, historyEval, lookbackPeriod);
@@ -25,7 +25,7 @@ namespace Skender.Stock.Indicators
             // roll through history for interim data
             for (int i = 0; i < historyEvalList.Count; i++)
             {
-                Quote e = historyEvalList[i];
+                TQuote e = historyEvalList[i];
 
                 BetaResult result = new BetaResult
                 {
@@ -47,7 +47,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateBeta(IEnumerable<Quote> historyMarket, IEnumerable<Quote> historyEval, int lookbackPeriod)
+        private static void ValidateBeta<TQuote>(IEnumerable<TQuote> historyMarket, IEnumerable<TQuote> historyEval, int lookbackPeriod) where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/Beta/Beta.cs
+++ b/indicators/Beta/Beta.cs
@@ -8,7 +8,10 @@ namespace Skender.Stock.Indicators
     {
         // BETA COEFFICIENT
         public static IEnumerable<BetaResult> GetBeta<TQuote>(
-            IEnumerable<TQuote> historyMarket, IEnumerable<TQuote> historyEval, int lookbackPeriod) where TQuote : IQuote
+            IEnumerable<TQuote> historyMarket,
+            IEnumerable<TQuote> historyEval,
+            int lookbackPeriod)
+            where TQuote : IQuote
         {
             // clean quotes
             List<TQuote> historyEvalList = historyEval.Sort();

--- a/indicators/Beta/README.md
+++ b/indicators/Beta/README.md
@@ -13,8 +13,8 @@ IEnumerable<BetaResult> results = Indicator.GetBeta(historyMarket, historyEval, 
 
 | name | type | notes
 | -- |-- |--
-| `historyMarket` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical [market] Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N` periods of history.  This `market` history will be used to establish the baseline.
-| `historyEval` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical [evaluation stock] Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must have at least the same matching date elements of `historyMarket`.  Exception will be thrown if not matched.
+| `historyMarket` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical [market] Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N` periods of history.  This `market` history will be used to establish the baseline.
+| `historyEval` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical [evaluation stock] Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must have at least the same matching date elements of `historyMarket`.  Exception will be thrown if not matched.
 | `lookbackPeriod` | int | Number of periods (`N`) in the lookback period.  Must be greater than 0 to calculate; however we suggest a larger period for statistically appropriate sample size.
 
 ## Response

--- a/indicators/BollingerBands/BollingerBands.cs
+++ b/indicators/BollingerBands/BollingerBands.cs
@@ -8,7 +8,10 @@ namespace Skender.Stock.Indicators
     {
         // BOLLINGER BANDS
         public static IEnumerable<BollingerBandsResult> GetBollingerBands<TQuote>(
-            IEnumerable<TQuote> history, int lookbackPeriod = 20, decimal standardDeviations = 2) where TQuote : IQuote
+            IEnumerable<TQuote> history,
+            int lookbackPeriod = 20,
+            decimal standardDeviations = 2)
+            where TQuote : IQuote
         {
 
             // clean quotes

--- a/indicators/BollingerBands/BollingerBands.cs
+++ b/indicators/BollingerBands/BollingerBands.cs
@@ -7,12 +7,12 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // BOLLINGER BANDS
-        public static IEnumerable<BollingerBandsResult> GetBollingerBands(
-            IEnumerable<Quote> history, int lookbackPeriod = 20, decimal standardDeviations = 2)
+        public static IEnumerable<BollingerBandsResult> GetBollingerBands<TQuote>(
+            IEnumerable<TQuote> history, int lookbackPeriod = 20, decimal standardDeviations = 2) where TQuote : IQuote
         {
 
             // clean quotes
-            List<Quote> historyList = history.Sort();
+            List<TQuote> historyList = history.Sort();
 
             // validate parameters
             ValidateBollingerBands(history, lookbackPeriod, standardDeviations);
@@ -23,7 +23,7 @@ namespace Skender.Stock.Indicators
             // roll through history
             for (int i = 0; i < historyList.Count; i++)
             {
-                Quote h = historyList[i];
+                TQuote h = historyList[i];
                 int index = i + 1;
 
                 BollingerBandsResult r = new BollingerBandsResult
@@ -39,7 +39,7 @@ namespace Skender.Stock.Indicators
 
                     for (int p = index - lookbackPeriod; p < index; p++)
                     {
-                        Quote d = historyList[p];
+                        TQuote d = historyList[p];
                         periodClose[n] = (double)d.Close;
                         sum += d.Close;
                         n++;
@@ -66,8 +66,8 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateBollingerBands(
-            IEnumerable<Quote> history, int lookbackPeriod, decimal standardDeviations)
+        private static void ValidateBollingerBands<TQuote>(
+            IEnumerable<TQuote> history, int lookbackPeriod, decimal standardDeviations) where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/BollingerBands/README.md
+++ b/indicators/BollingerBands/README.md
@@ -13,7 +13,7 @@ IEnumerable<BollingerBandsResult> results = Indicator.GetBollingerBands(history,
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N` periods of `history`.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N` periods of `history`.
 | `lookbackPeriod` | int | Number of periods (`N`) for the center line moving average.  Must be greater than 1 to calculate; however we suggest a larger period for statistically appropriate sample size.  Default is 20.
 | `standardDeviation` | int | Width of bands.  Standard deviations (`D`) from the moving average.  Must be greater than 0.  Default is 2.
 

--- a/indicators/Cci/Cci.cs
+++ b/indicators/Cci/Cci.cs
@@ -7,11 +7,11 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // COMMODITY CHANNEL INDEX
-        public static IEnumerable<CciResult> GetCci(IEnumerable<Quote> history, int lookbackPeriod = 20)
+        public static IEnumerable<CciResult> GetCci<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod = 20) where TQuote : IQuote
         {
 
             // clean quotes
-            List<Quote> historyList = history.Sort();
+            List<TQuote> historyList = history.Sort();
 
             // validate parameters
             ValidateCci(history, lookbackPeriod);
@@ -23,7 +23,7 @@ namespace Skender.Stock.Indicators
             // roll through history
             for (int i = 0; i < historyList.Count; i++)
             {
-                Quote h = historyList[i];
+                TQuote h = historyList[i];
                 int index = i + 1;
 
                 CciResult result = new CciResult
@@ -62,7 +62,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateCci(IEnumerable<Quote> history, int lookbackPeriod)
+        private static void ValidateCci<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod) where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/Cci/Cci.cs
+++ b/indicators/Cci/Cci.cs
@@ -7,7 +7,10 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // COMMODITY CHANNEL INDEX
-        public static IEnumerable<CciResult> GetCci<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod = 20) where TQuote : IQuote
+        public static IEnumerable<CciResult> GetCci<TQuote>(
+            IEnumerable<TQuote> history,
+            int lookbackPeriod = 20)
+            where TQuote : IQuote
         {
 
             // clean quotes

--- a/indicators/Cci/README.md
+++ b/indicators/Cci/README.md
@@ -13,7 +13,7 @@ IEnumerable<CciResult> results = Indicator.GetCci(history, lookbackPeriod);
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N+1` periods of `history`.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N+1` periods of `history`.
 | `lookbackPeriod` | int | Number of periods (`N`) in the moving average.  Must be greater than 0.  Default is 20.
 
 ## Response

--- a/indicators/ChaikinOsc/ChaikinOsc.cs
+++ b/indicators/ChaikinOsc/ChaikinOsc.cs
@@ -10,7 +10,8 @@ namespace Skender.Stock.Indicators
         public static IEnumerable<ChaikinOscResult> GetChaikinOsc<TQuote>(
             IEnumerable<TQuote> history,
             int fastPeriod = 3,
-            int slowPeriod = 10) where TQuote : IQuote
+            int slowPeriod = 10)
+            where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/ChaikinOsc/ChaikinOsc.cs
+++ b/indicators/ChaikinOsc/ChaikinOsc.cs
@@ -7,10 +7,10 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // CHAIKIN OSCILLATOR
-        public static IEnumerable<ChaikinOscResult> GetChaikinOsc(
-            IEnumerable<Quote> history,
+        public static IEnumerable<ChaikinOscResult> GetChaikinOsc<TQuote>(
+            IEnumerable<TQuote> history,
             int fastPeriod = 3,
-            int slowPeriod = 10)
+            int slowPeriod = 10) where TQuote : IQuote
         {
 
             // check parameters
@@ -50,7 +50,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateChaikinOsc(IEnumerable<Quote> history, int fastPeriod, int slowPeriod)
+        private static void ValidateChaikinOsc<TQuote>(IEnumerable<TQuote> history, int fastPeriod, int slowPeriod) where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/ChaikinOsc/README.md
+++ b/indicators/ChaikinOsc/README.md
@@ -13,7 +13,7 @@ IEnumerable<ChaikinOscResult> results = Indicator.GetChaikinOsc(history, fastPer
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least 2×`S` or `S`+100 periods of `history`, whichever is more.  Since this uses a smoothing technique, we recommend you use at least `S`+250 data points prior to the intended usage date for maximum precision.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least 2×`S` or `S`+100 periods of `history`, whichever is more.  Since this uses a smoothing technique, we recommend you use at least `S`+250 data points prior to the intended usage date for maximum precision.
 | `fastPeriod` | int | Number of periods (`F`) in the ADL fast EMA.  Must be greater than 0 and smaller than `S`.  Default is 3.
 | `slowPeriod` | int | Number of periods (`S`) in the ADL slow EMA.  Must be greater `F`.  Default is 10.
 

--- a/indicators/Chandelier/Chandelier.cs
+++ b/indicators/Chandelier/Chandelier.cs
@@ -8,8 +8,11 @@ namespace Skender.Stock.Indicators
     {
         // CHANDELIER EXIT
         public static IEnumerable<ChandelierResult> GetChandelier<TQuote>(
-            IEnumerable<TQuote> history, int lookbackPeriod = 22,
-            decimal multiplier = 3.0m, ChandelierType type = ChandelierType.Long) where TQuote : IQuote
+            IEnumerable<TQuote> history,
+            int lookbackPeriod = 22,
+            decimal multiplier = 3.0m,
+            ChandelierType type = ChandelierType.Long)
+            where TQuote : IQuote
         {
 
             // clean quotes

--- a/indicators/Chandelier/Chandelier.cs
+++ b/indicators/Chandelier/Chandelier.cs
@@ -7,13 +7,13 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // CHANDELIER EXIT
-        public static IEnumerable<ChandelierResult> GetChandelier(
-            IEnumerable<Quote> history, int lookbackPeriod = 22,
-            decimal multiplier = 3.0m, ChandelierType type = ChandelierType.Long)
+        public static IEnumerable<ChandelierResult> GetChandelier<TQuote>(
+            IEnumerable<TQuote> history, int lookbackPeriod = 22,
+            decimal multiplier = 3.0m, ChandelierType type = ChandelierType.Long) where TQuote : IQuote
         {
 
             // clean quotes
-            List<Quote> historyList = history.Sort();
+            List<TQuote> historyList = history.Sort();
 
             // validate inputs
             ValidateChandelier(history, lookbackPeriod, multiplier);
@@ -25,7 +25,7 @@ namespace Skender.Stock.Indicators
             // roll through history
             for (int i = 0; i < historyList.Count; i++)
             {
-                Quote h = historyList[i];
+                TQuote h = historyList[i];
                 int index = i + 1;
 
                 ChandelierResult result = new ChandelierResult
@@ -46,7 +46,7 @@ namespace Skender.Stock.Indicators
                             decimal maxHigh = 0;
                             for (int p = index - lookbackPeriod; p < index; p++)
                             {
-                                Quote d = historyList[p];
+                                TQuote d = historyList[p];
                                 if (d.High > maxHigh)
                                 {
                                     maxHigh = d.High;
@@ -61,7 +61,7 @@ namespace Skender.Stock.Indicators
                             decimal minLow = decimal.MaxValue;
                             for (int p = index - lookbackPeriod; p < index; p++)
                             {
-                                Quote d = historyList[p];
+                                TQuote d = historyList[p];
                                 if (d.Low < minLow)
                                 {
                                     minLow = d.Low;
@@ -83,8 +83,8 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateChandelier(
-            IEnumerable<Quote> history, int lookbackPeriod, decimal multiplier)
+        private static void ValidateChandelier<TQuote>(
+            IEnumerable<TQuote> history, int lookbackPeriod, decimal multiplier) where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/Chandelier/README.md
+++ b/indicators/Chandelier/README.md
@@ -13,7 +13,7 @@ IEnumerable<ChandelierResult> results = Indicator.GetChandelier(history, lookbac
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at `N+1` periods worth of `history`.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at `N+1` periods worth of `history`.
 | `lookbackPeriod` | int | Number of periods (`N`) for the lookback evaluation.  Default is 22.
 | `multiplier` | decimal | Multiplier number must be a positive value.  Default is 3.
 | `type` | ChandelierType | Direction of exit.  See [ChandelierType options](#chandeliertype-options) below.  Default is `ChandelierType.Long`.

--- a/indicators/Cmf/Cmf.cs
+++ b/indicators/Cmf/Cmf.cs
@@ -7,7 +7,10 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // CHAIKIN MONEY FLOW
-        public static IEnumerable<CmfResult> GetCmf<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod = 20) where TQuote : IQuote
+        public static IEnumerable<CmfResult> GetCmf<TQuote>(
+            IEnumerable<TQuote> history,
+            int lookbackPeriod = 20)
+            where TQuote : IQuote
         {
 
             // clean quotes

--- a/indicators/Cmf/Cmf.cs
+++ b/indicators/Cmf/Cmf.cs
@@ -7,11 +7,11 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // CHAIKIN MONEY FLOW
-        public static IEnumerable<CmfResult> GetCmf(IEnumerable<Quote> history, int lookbackPeriod = 20)
+        public static IEnumerable<CmfResult> GetCmf<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod = 20) where TQuote : IQuote
         {
 
             // clean quotes
-            List<Quote> historyList = history.Sort();
+            List<TQuote> historyList = history.Sort();
 
             // check parameters
             ValidateCmf(history, lookbackPeriod);
@@ -40,7 +40,7 @@ namespace Skender.Stock.Indicators
 
                     for (int p = index - lookbackPeriod; p < index; p++)
                     {
-                        Quote h = historyList[p];
+                        TQuote h = historyList[p];
                         sumVol += h.Volume;
 
                         AdlResult d = adlResults[p];
@@ -63,7 +63,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateCmf(IEnumerable<Quote> history, int lookbackPeriod)
+        private static void ValidateCmf<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod) where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/Cmf/README.md
+++ b/indicators/Cmf/README.md
@@ -13,7 +13,7 @@ IEnumerable<CmfResult> results = Indicator.GetCmf(history, lookbackPeriod);
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N+1` periods of `history`.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N+1` periods of `history`.
 | `lookbackPeriod` | int | Number of periods (`N`) in the moving average.  Must be greater than 0.  Default is 20.
 
 ## Response

--- a/indicators/ConnorsRsi/ConnorsRsi.cs
+++ b/indicators/ConnorsRsi/ConnorsRsi.cs
@@ -7,8 +7,8 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // CONNORS RSI
-        public static IEnumerable<ConnorsRsiResult> GetConnorsRsi(
-            IEnumerable<Quote> history, int rsiPeriod = 3, int streakPeriod = 2, int rankPeriod = 100)
+        public static IEnumerable<ConnorsRsiResult> GetConnorsRsi<TQuote>(
+            IEnumerable<TQuote> history, int rsiPeriod = 3, int streakPeriod = 2, int rankPeriod = 100) where TQuote : IQuote
         {
 
             // convert history to basic format

--- a/indicators/ConnorsRsi/ConnorsRsi.cs
+++ b/indicators/ConnorsRsi/ConnorsRsi.cs
@@ -8,7 +8,11 @@ namespace Skender.Stock.Indicators
     {
         // CONNORS RSI
         public static IEnumerable<ConnorsRsiResult> GetConnorsRsi<TQuote>(
-            IEnumerable<TQuote> history, int rsiPeriod = 3, int streakPeriod = 2, int rankPeriod = 100) where TQuote : IQuote
+            IEnumerable<TQuote> history,
+            int rsiPeriod = 3,
+            int streakPeriod = 2,
+            int rankPeriod = 100)
+            where TQuote : IQuote
         {
 
             // convert history to basic format

--- a/indicators/ConnorsRsi/README.md
+++ b/indicators/ConnorsRsi/README.md
@@ -13,7 +13,7 @@ IEnumerable<ConnorsRsiResult> results = Indicator.GetConnorsRsi(history, rsiPeri
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).
 | `rsiPeriod` | int | Lookback period (`R`) for the close price RSI.  Must be greater than 1.  Default is 3.
 | `streakPeriod` | int | Lookback period (`S`) for the streak RSI.  Must be greater than 1.  Default is 2.
 | `rankPeriod` | int | Lookback period (`P`) for the Percentile Rank.  Must be greater than 1.  Default is 100.

--- a/indicators/Correlation/Correlation.cs
+++ b/indicators/Correlation/Correlation.cs
@@ -8,7 +8,10 @@ namespace Skender.Stock.Indicators
     {
         // CORRELATION COEFFICIENT
         public static IEnumerable<CorrResult> GetCorrelation<TQuote>(
-            IEnumerable<TQuote> historyA, IEnumerable<TQuote> historyB, int lookbackPeriod) where TQuote : IQuote
+            IEnumerable<TQuote> historyA,
+            IEnumerable<TQuote> historyB,
+            int lookbackPeriod)
+            where TQuote : IQuote
         {
             // clean quotes
             List<TQuote> historyListA = historyA.Sort();

--- a/indicators/Correlation/Correlation.cs
+++ b/indicators/Correlation/Correlation.cs
@@ -7,12 +7,12 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // CORRELATION COEFFICIENT
-        public static IEnumerable<CorrResult> GetCorrelation(
-            IEnumerable<Quote> historyA, IEnumerable<Quote> historyB, int lookbackPeriod)
+        public static IEnumerable<CorrResult> GetCorrelation<TQuote>(
+            IEnumerable<TQuote> historyA, IEnumerable<TQuote> historyB, int lookbackPeriod) where TQuote : IQuote
         {
             // clean quotes
-            List<Quote> historyListA = historyA.Sort();
-            List<Quote> historyListB = historyB.Sort();
+            List<TQuote> historyListA = historyA.Sort();
+            List<TQuote> historyListB = historyB.Sort();
 
             // validate parameters
             ValidateCorrelation(historyA, historyB, lookbackPeriod);
@@ -24,8 +24,8 @@ namespace Skender.Stock.Indicators
             // roll through history for interim data
             for (int i = 0; i < historyListA.Count; i++)
             {
-                Quote a = historyListA[i];
-                Quote b = historyListB[i];
+                TQuote a = historyListA[i];
+                TQuote b = historyListB[i];
                 int index = i + 1;
 
                 if (a.Date != b.Date)
@@ -50,8 +50,8 @@ namespace Skender.Stock.Indicators
 
                     for (int p = index - lookbackPeriod; p < index; p++)
                     {
-                        Quote qa = historyListA[p];
-                        Quote qb = historyListB[p];
+                        TQuote qa = historyListA[p];
+                        TQuote qb = historyListB[p];
 
                         sumPriceA += qa.Close;
                         sumPriceB += qb.Close;
@@ -83,7 +83,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateCorrelation(IEnumerable<Quote> historyA, IEnumerable<Quote> historyB, int lookbackPeriod)
+        private static void ValidateCorrelation<TQuote>(IEnumerable<TQuote> historyA, IEnumerable<TQuote> historyB, int lookbackPeriod) where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/Correlation/README.md
+++ b/indicators/Correlation/README.md
@@ -13,8 +13,8 @@ IEnumerable<CorrResult> results = Indicator.GetCorr(historyA, historyB, lookback
 
 | name | type | notes
 | -- |-- |--
-| `historyA` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical quotes (A).
-| `historyB` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical quotes (B) must have at least the same matching date elements of `historyA`.  Exception will be thrown if not matched.
+| `historyA` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical quotes (A).
+| `historyB` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical quotes (B) must have at least the same matching date elements of `historyA`.  Exception will be thrown if not matched.
 | `lookbackPeriod` | int | Number of periods (`N`) in the lookback period.  Must be greater than 0 to calculate; however we suggest a larger period for statistically appropriate sample size.
 
 Note: Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N` periods for both versions of `history`.  Mismatch histories will produce a `BadHistoryException`.

--- a/indicators/Donchian/Donchian.cs
+++ b/indicators/Donchian/Donchian.cs
@@ -7,12 +7,12 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // DONCHIAN CHANNEL
-        public static IEnumerable<DonchianResult> GetDonchian(
-            IEnumerable<Quote> history, int lookbackPeriod = 20)
+        public static IEnumerable<DonchianResult> GetDonchian<TQuote>(
+            IEnumerable<TQuote> history, int lookbackPeriod = 20) where TQuote : IQuote
         {
 
             // clean quotes
-            List<Quote> historyList = history.Sort();
+            List<TQuote> historyList = history.Sort();
 
             // validate parameters
             ValidateDonchian(history, lookbackPeriod);
@@ -23,7 +23,7 @@ namespace Skender.Stock.Indicators
             // roll through history
             for (int i = 0; i < historyList.Count; i++)
             {
-                Quote h = historyList[i];
+                TQuote h = historyList[i];
                 int index = i + 1;
 
                 DonchianResult result = new DonchianResult
@@ -38,7 +38,7 @@ namespace Skender.Stock.Indicators
 
                     for (int p = index - lookbackPeriod; p < index; p++)
                     {
-                        Quote d = historyList[p];
+                        TQuote d = historyList[p];
 
                         if (d.High > highHigh)
                         {
@@ -64,8 +64,8 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateDonchian(
-            IEnumerable<Quote> history, int lookbackPeriod)
+        private static void ValidateDonchian<TQuote>(
+            IEnumerable<TQuote> history, int lookbackPeriod) where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/Donchian/Donchian.cs
+++ b/indicators/Donchian/Donchian.cs
@@ -8,7 +8,9 @@ namespace Skender.Stock.Indicators
     {
         // DONCHIAN CHANNEL
         public static IEnumerable<DonchianResult> GetDonchian<TQuote>(
-            IEnumerable<TQuote> history, int lookbackPeriod = 20) where TQuote : IQuote
+            IEnumerable<TQuote> history,
+            int lookbackPeriod = 20)
+            where TQuote : IQuote
         {
 
             // clean quotes

--- a/indicators/Donchian/README.md
+++ b/indicators/Donchian/README.md
@@ -13,7 +13,7 @@ IEnumerable<DonchianResult> results = Indicator.GetDonchian(history, lookbackPer
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N` periods of `history`.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N` periods of `history`.
 | `lookbackPeriod` | int | Number of periods (`N`) for the center line moving average.  Must be greater than 1 to calculate; however we suggest a larger period for an appropriate sample size.  Default is 20.
 
 ## Response

--- a/indicators/Ema/DoubleEma.cs
+++ b/indicators/Ema/DoubleEma.cs
@@ -7,7 +7,7 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // DOUBLE EXPONENTIAL MOVING AVERAGE
-        public static IEnumerable<EmaResult> GetDoubleEma(IEnumerable<Quote> history, int lookbackPeriod)
+        public static IEnumerable<EmaResult> GetDoubleEma<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod) where TQuote : IQuote
         {
 
             // convert history to basic format

--- a/indicators/Ema/DoubleEma.cs
+++ b/indicators/Ema/DoubleEma.cs
@@ -7,7 +7,10 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // DOUBLE EXPONENTIAL MOVING AVERAGE
-        public static IEnumerable<EmaResult> GetDoubleEma<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod) where TQuote : IQuote
+        public static IEnumerable<EmaResult> GetDoubleEma<TQuote>(
+            IEnumerable<TQuote> history, 
+            int lookbackPeriod) 
+            where TQuote : IQuote
         {
 
             // convert history to basic format

--- a/indicators/Ema/Ema.cs
+++ b/indicators/Ema/Ema.cs
@@ -6,7 +6,7 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // EXPONENTIAL MOVING AVERAGE
-        public static IEnumerable<EmaResult> GetEma(IEnumerable<Quote> history, int lookbackPeriod)
+        public static IEnumerable<EmaResult> GetEma<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod) where TQuote : IQuote
         {
 
             // convert history to basic format

--- a/indicators/Ema/Ema.cs
+++ b/indicators/Ema/Ema.cs
@@ -6,7 +6,10 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // EXPONENTIAL MOVING AVERAGE
-        public static IEnumerable<EmaResult> GetEma<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod) where TQuote : IQuote
+        public static IEnumerable<EmaResult> GetEma<TQuote>(
+            IEnumerable<TQuote> history,
+            int lookbackPeriod)
+            where TQuote : IQuote
         {
 
             // convert history to basic format

--- a/indicators/Ema/README.md
+++ b/indicators/Ema/README.md
@@ -19,7 +19,7 @@ IEnumerable<EmaResult> results = Indicator.GetTripleEma(history, lookbackPeriod)
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) in the moving average.  Must be greater than 0.
 
 ### Minimum history requirements

--- a/indicators/Ema/TripleEma.cs
+++ b/indicators/Ema/TripleEma.cs
@@ -7,7 +7,10 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // TRIPLE EXPONENTIAL MOVING AVERAGE
-        public static IEnumerable<EmaResult> GetTripleEma<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod) where TQuote : IQuote
+        public static IEnumerable<EmaResult> GetTripleEma<TQuote>(
+            IEnumerable<TQuote> history,
+            int lookbackPeriod)
+            where TQuote : IQuote
         {
 
             // convert history to basic format

--- a/indicators/Ema/TripleEma.cs
+++ b/indicators/Ema/TripleEma.cs
@@ -7,7 +7,7 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // TRIPLE EXPONENTIAL MOVING AVERAGE
-        public static IEnumerable<EmaResult> GetTripleEma(IEnumerable<Quote> history, int lookbackPeriod)
+        public static IEnumerable<EmaResult> GetTripleEma<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod) where TQuote : IQuote
         {
 
             // convert history to basic format

--- a/indicators/HeikinAshi/HeikinAshi.cs
+++ b/indicators/HeikinAshi/HeikinAshi.cs
@@ -6,11 +6,11 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // HEIKIN-ASHI
-        public static IEnumerable<HeikinAshiResult> GetHeikinAshi(IEnumerable<Quote> history)
+        public static IEnumerable<HeikinAshiResult> GetHeikinAshi<TQuote>(IEnumerable<TQuote> history) where TQuote : IQuote
         {
 
             // clean quotes
-            List<Quote> historyList = history.Sort();
+            List<TQuote> historyList = history.Sort();
 
             // check parameters
             ValidateHeikinAshi(history);
@@ -23,7 +23,7 @@ namespace Skender.Stock.Indicators
 
             for (int i = 0; i < historyList.Count; i++)
             {
-                Quote h = historyList[i];
+                TQuote h = historyList[i];
 
                 // close
                 decimal close = (h.Open + h.High + h.Low + h.Close) / 4;
@@ -59,7 +59,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateHeikinAshi(IEnumerable<Quote> history)
+        private static void ValidateHeikinAshi<TQuote>(IEnumerable<TQuote> history) where TQuote : IQuote
         {
 
             // check history

--- a/indicators/HeikinAshi/HeikinAshi.cs
+++ b/indicators/HeikinAshi/HeikinAshi.cs
@@ -6,7 +6,9 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // HEIKIN-ASHI
-        public static IEnumerable<HeikinAshiResult> GetHeikinAshi<TQuote>(IEnumerable<TQuote> history) where TQuote : IQuote
+        public static IEnumerable<HeikinAshiResult> GetHeikinAshi<TQuote>(
+            IEnumerable<TQuote> history)
+            where TQuote : IQuote
         {
 
             // clean quotes

--- a/indicators/HeikinAshi/README.md
+++ b/indicators/HeikinAshi/README.md
@@ -13,7 +13,7 @@ IEnumerable<HeikinAshiResult> results = Indicator.GetHeikinAshi(history);
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least two historical quotes.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least two historical quotes.
 
 ## Response
 

--- a/indicators/Hma/Hma.cs
+++ b/indicators/Hma/Hma.cs
@@ -7,7 +7,10 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // HULL MOVING AVERAGE
-        public static IEnumerable<HmaResult> GetHma<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod) where TQuote : IQuote
+        public static IEnumerable<HmaResult> GetHma<TQuote>(
+            IEnumerable<TQuote> history,
+            int lookbackPeriod)
+            where TQuote : IQuote
         {
 
             // clean quotes

--- a/indicators/Hma/Hma.cs
+++ b/indicators/Hma/Hma.cs
@@ -7,11 +7,11 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // HULL MOVING AVERAGE
-        public static IEnumerable<HmaResult> GetHma(IEnumerable<Quote> history, int lookbackPeriod)
+        public static IEnumerable<HmaResult> GetHma<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod) where TQuote : IQuote
         {
 
             // clean quotes
-            List<Quote> historyList = history.Sort();
+            List<TQuote> historyList = history.Sort();
 
             // check parameters
             ValidateHma(history, lookbackPeriod);
@@ -26,7 +26,7 @@ namespace Skender.Stock.Indicators
             // roll through history
             for (int i = 0; i < historyList.Count; i++)
             {
-                Quote h = historyList[i];
+                TQuote h = historyList[i];
 
                 Quote sh = new Quote
                 {
@@ -72,7 +72,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateHma(IEnumerable<Quote> history, int lookbackPeriod)
+        private static void ValidateHma<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod) where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/Hma/README.md
+++ b/indicators/Hma/README.md
@@ -13,7 +13,7 @@ IEnumerable<HmaResult> results = Indicator.GetHma(history, lookbackPeriod);
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N` periods of `history`.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N` periods of `history`.
 | `lookbackPeriod` | int | Number of periods (`N`) in the moving average.  Must be greater than 1.
 
 ## Response

--- a/indicators/Ichimoku/Ichimoku.cs
+++ b/indicators/Ichimoku/Ichimoku.cs
@@ -7,8 +7,12 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // ICHIMOKU CLOUD
-        public static IEnumerable<IchimokuResult> GetIchimoku<TQuote>(IEnumerable<TQuote> history,
-            int signalPeriod = 9, int shortSpanPeriod = 26, int longSpanPeriod = 52) where TQuote : IQuote
+        public static IEnumerable<IchimokuResult> GetIchimoku<TQuote>(
+            IEnumerable<TQuote> history,
+            int signalPeriod = 9,
+            int shortSpanPeriod = 26,
+            int longSpanPeriod = 52)
+            where TQuote : IQuote
         {
 
             // clean quotes

--- a/indicators/Ichimoku/Ichimoku.cs
+++ b/indicators/Ichimoku/Ichimoku.cs
@@ -7,12 +7,12 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // ICHIMOKU CLOUD
-        public static IEnumerable<IchimokuResult> GetIchimoku(IEnumerable<Quote> history,
-            int signalPeriod = 9, int shortSpanPeriod = 26, int longSpanPeriod = 52)
+        public static IEnumerable<IchimokuResult> GetIchimoku<TQuote>(IEnumerable<TQuote> history,
+            int signalPeriod = 9, int shortSpanPeriod = 26, int longSpanPeriod = 52) where TQuote : IQuote
         {
 
             // clean quotes
-            List<Quote> historyList = history.Sort();
+            List<TQuote> historyList = history.Sort();
 
             // check parameters
             ValidateIchimoku(history, signalPeriod, shortSpanPeriod, longSpanPeriod);
@@ -23,7 +23,7 @@ namespace Skender.Stock.Indicators
             // roll through history
             for (int i = 0; i < historyList.Count; i++)
             {
-                Quote h = historyList[i];
+                TQuote h = historyList[i];
                 int index = i + 1;
 
                 IchimokuResult result = new IchimokuResult
@@ -63,8 +63,8 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void CalcIchimokuTenkanSen(
-            int index, List<Quote> historyList, IchimokuResult result, int signalPeriod)
+        private static void CalcIchimokuTenkanSen<TQuote>(
+            int index, List<TQuote> historyList, IchimokuResult result, int signalPeriod) where TQuote : IQuote
         {
             if (index >= signalPeriod)
             {
@@ -73,7 +73,7 @@ namespace Skender.Stock.Indicators
 
                 for (int p = index - signalPeriod; p < index; p++)
                 {
-                    Quote d = historyList[p];
+                    TQuote d = historyList[p];
 
                     if (d.High > max)
                     {
@@ -91,8 +91,8 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void CalcIchimokuKijunSen(
-            int index, List<Quote> historyList, IchimokuResult result, int shortSpanPeriod)
+        private static void CalcIchimokuKijunSen<TQuote>(
+            int index, List<TQuote> historyList, IchimokuResult result, int shortSpanPeriod) where TQuote : IQuote
         {
             if (index >= shortSpanPeriod)
             {
@@ -101,7 +101,7 @@ namespace Skender.Stock.Indicators
 
                 for (int p = index - shortSpanPeriod; p < index; p++)
                 {
-                    Quote d = historyList[p];
+                    TQuote d = historyList[p];
 
                     if (d.High > max)
                     {
@@ -119,8 +119,8 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void CalcIchimokuSenkouB(
-            int index, List<Quote> historyList, IchimokuResult result, int shortSpanPeriod, int longSpanPeriod)
+        private static void CalcIchimokuSenkouB<TQuote>(
+            int index, List<TQuote> historyList, IchimokuResult result, int shortSpanPeriod, int longSpanPeriod) where TQuote : IQuote
         {
             if (index >= shortSpanPeriod + longSpanPeriod)
             {
@@ -130,7 +130,7 @@ namespace Skender.Stock.Indicators
                 for (int p = index - shortSpanPeriod - longSpanPeriod;
                     p < index - shortSpanPeriod; p++)
                 {
-                    Quote d = historyList[p];
+                    TQuote d = historyList[p];
 
                     if (d.High > max)
                     {
@@ -148,8 +148,8 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateIchimoku(IEnumerable<Quote> history,
-            int signalPeriod, int shortSpanPeriod, int longSpanPeriod)
+        private static void ValidateIchimoku<TQuote>(IEnumerable<TQuote> history,
+            int signalPeriod, int shortSpanPeriod, int longSpanPeriod) where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/Ichimoku/README.md
+++ b/indicators/Ichimoku/README.md
@@ -13,7 +13,7 @@ IEnumerable<IchimokuResult> results = Indicator.GetIchimoku(history, lookbackPer
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least the maximum of `N` or `S` or `L` periods of `history`; though, given the leading and lagging nature, we recommend notably more.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least the maximum of `N` or `S` or `L` periods of `history`; though, given the leading and lagging nature, we recommend notably more.
 | `signalPeriod` | int | Number of periods (`N`) in the Tenkan-sen midpoint evaluation.  Must be greater than 0.  Default is 9.
 | `shortSpanPeriod` | int | Number of periods (`S`) in the shorter Kijun-sen midpoint evaluation.  It also sets the Chikou span lag/shift.  Must be greater than 0.  Default is 26.
 | `longSpanPeriod` | int | Number of periods (`L`) in the longer Senkou leading span B midpoint evaluation.  Must be greater than `S`.  Default is 52.

--- a/indicators/Keltner/Keltner.cs
+++ b/indicators/Keltner/Keltner.cs
@@ -8,7 +8,11 @@ namespace Skender.Stock.Indicators
     {
         // DONCHIAN CHANNEL
         public static IEnumerable<KeltnerResult> GetKeltner<TQuote>(
-            IEnumerable<TQuote> history, int emaPeriod = 20, decimal multiplier = 2, int atrPeriod = 10) where TQuote : IQuote
+            IEnumerable<TQuote> history,
+            int emaPeriod = 20,
+            decimal multiplier = 2,
+            int atrPeriod = 10)
+            where TQuote : IQuote
         {
 
             // clean quotes

--- a/indicators/Keltner/Keltner.cs
+++ b/indicators/Keltner/Keltner.cs
@@ -7,12 +7,12 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // DONCHIAN CHANNEL
-        public static IEnumerable<KeltnerResult> GetKeltner(
-            IEnumerable<Quote> history, int emaPeriod = 20, decimal multiplier = 2, int atrPeriod = 10)
+        public static IEnumerable<KeltnerResult> GetKeltner<TQuote>(
+            IEnumerable<TQuote> history, int emaPeriod = 20, decimal multiplier = 2, int atrPeriod = 10) where TQuote : IQuote
         {
 
             // clean quotes
-            List<Quote> historyList = history.Sort();
+            List<TQuote> historyList = history.Sort();
 
             // validate parameters
             ValidateKeltner(history, emaPeriod, multiplier, atrPeriod);
@@ -26,7 +26,7 @@ namespace Skender.Stock.Indicators
             // roll through history
             for (int i = 0; i < historyList.Count; i++)
             {
-                Quote h = historyList[i];
+                TQuote h = historyList[i];
                 int index = i + 1;
 
                 KeltnerResult result = new KeltnerResult
@@ -53,8 +53,8 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateKeltner(
-            IEnumerable<Quote> history, int emaPeriod, decimal multiplier, int atrPeriod)
+        private static void ValidateKeltner<TQuote>(
+            IEnumerable<TQuote> history, int emaPeriod, decimal multiplier, int atrPeriod) where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/Keltner/README.md
+++ b/indicators/Keltner/README.md
@@ -13,7 +13,7 @@ IEnumerable<KeltnerResult> results = Indicator.GetKeltner(history, emaPeriod, mu
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least 2×`N` or `N`+100 periods of `history`, whichever is more.  Since this uses a smoothing technique, we recommend you use at least `N`+250 data points prior to the intended usage date for maximum precision.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least 2×`N` or `N`+100 periods of `history`, whichever is more.  Since this uses a smoothing technique, we recommend you use at least `N`+250 data points prior to the intended usage date for maximum precision.
 | `emaPeriod` | int | Number of lookback periods (`E`) for the center line moving average.  Must be greater than 1 to calculate; however we suggest a larger period for an appropriate sample size.  Default is 20.
 | `multiplier` | decimal | ATR Multiplier. Must be greater than 0.  Default is 2.
 | `atrPeriod` | int | Number of lookback periods (`A`) for the Average True Range.  Must be greater than 1 to calculate; however we suggest a larger period for an appropriate sample size.  Default is 10.

--- a/indicators/Macd/Macd.cs
+++ b/indicators/Macd/Macd.cs
@@ -7,7 +7,12 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // MOVING AVERAGE CONVERGENCE/DIVERGENCE (MACD) OSCILLATOR
-        public static IEnumerable<MacdResult> GetMacd<TQuote>(IEnumerable<TQuote> history, int fastPeriod = 12, int slowPeriod = 26, int signalPeriod = 9) where TQuote : IQuote
+        public static IEnumerable<MacdResult> GetMacd<TQuote>(
+            IEnumerable<TQuote> history,
+            int fastPeriod = 12,
+            int slowPeriod = 26,
+            int signalPeriod = 9)
+            where TQuote : IQuote
         {
 
             // clean quotes

--- a/indicators/Macd/Macd.cs
+++ b/indicators/Macd/Macd.cs
@@ -7,11 +7,11 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // MOVING AVERAGE CONVERGENCE/DIVERGENCE (MACD) OSCILLATOR
-        public static IEnumerable<MacdResult> GetMacd(IEnumerable<Quote> history, int fastPeriod = 12, int slowPeriod = 26, int signalPeriod = 9)
+        public static IEnumerable<MacdResult> GetMacd<TQuote>(IEnumerable<TQuote> history, int fastPeriod = 12, int slowPeriod = 26, int signalPeriod = 9) where TQuote : IQuote
         {
 
             // clean quotes
-            List<Quote> historyList = history.Sort();
+            List<TQuote> historyList = history.Sort();
 
             // check parameters
             ValidateMacd(history, fastPeriod, slowPeriod, signalPeriod);
@@ -25,7 +25,7 @@ namespace Skender.Stock.Indicators
 
             for (int i = 0; i < historyList.Count; i++)
             {
-                Quote h = historyList[i];
+                TQuote h = historyList[i];
                 EmaResult df = emaFast[i];
                 EmaResult ds = emaSlow[i];
 
@@ -69,7 +69,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateMacd(IEnumerable<Quote> history, int fastPeriod, int slowPeriod, int signalPeriod)
+        private static void ValidateMacd<TQuote>(IEnumerable<TQuote> history, int fastPeriod, int slowPeriod, int signalPeriod) where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/Macd/README.md
+++ b/indicators/Macd/README.md
@@ -13,7 +13,7 @@ IEnumerable<MacdResult> results = Indicator.GetMacd(history, fastPeriod, slowPer
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least 2 × slow period + signal period worth of `history`.  Since this uses a smoothing technique, we recommend you use at least 250 data points prior to the intended usage date for maximum precision.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least 2 × slow period + signal period worth of `history`.  Since this uses a smoothing technique, we recommend you use at least 250 data points prior to the intended usage date for maximum precision.
 | `fastPeriod` | int | Number of periods (`F`) for the faster moving average.  Must be greater than 0.  Default is 12.
 | `slowPeriod` | int | Number of periods (`S`) for the slower moving average.  Must be greater than 0 and greater than `fastPeriod`.  Default is 26.
 | `signalPeriod` | int | Number of periods (`P`) for the moving average of MACD.  Must be greater than or equal to 0.  Default is 9.

--- a/indicators/Mfi/Mfi.cs
+++ b/indicators/Mfi/Mfi.cs
@@ -7,11 +7,11 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // Money Flow Index
-        public static IEnumerable<MfiResult> GetMfi(IEnumerable<Quote> history, int lookbackPeriod = 14)
+        public static IEnumerable<MfiResult> GetMfi<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod = 14) where TQuote : IQuote
         {
 
             // clean quotes
-            List<Quote> historyList = history.Sort();
+            List<TQuote> historyList = history.Sort();
 
             // check parameters
             ValidateMfi(history, lookbackPeriod);
@@ -24,7 +24,7 @@ namespace Skender.Stock.Indicators
             // preliminary data
             for (int i = 0; i < historyList.Count; i++)
             {
-                Quote h = historyList[i];
+                TQuote h = historyList[i];
 
                 MfiResult result = new MfiResult
                 {
@@ -94,7 +94,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateMfi(IEnumerable<Quote> history, int lookbackPeriod)
+        private static void ValidateMfi<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod) where TQuote : IQuote
         {
             // check parameters
             if (lookbackPeriod <= 1)

--- a/indicators/Mfi/Mfi.cs
+++ b/indicators/Mfi/Mfi.cs
@@ -7,7 +7,10 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // Money Flow Index
-        public static IEnumerable<MfiResult> GetMfi<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod = 14) where TQuote : IQuote
+        public static IEnumerable<MfiResult> GetMfi<TQuote>(
+            IEnumerable<TQuote> history, 
+            int lookbackPeriod = 14) 
+            where TQuote : IQuote
         {
 
             // clean quotes

--- a/indicators/Mfi/README.md
+++ b/indicators/Mfi/README.md
@@ -13,7 +13,7 @@ IEnumerable<MfiResult> results = Indicator.GetMfi(history,lookbackPeriod);
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N+1` historical quotes.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N+1` historical quotes.
 | `lookbackPeriod` | int | Number of periods (`N`) in the lookback period.  Must be greater than 1. Default is 14.
 
 ## Response

--- a/indicators/Obv/Obv.cs
+++ b/indicators/Obv/Obv.cs
@@ -7,11 +7,11 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // ON-BALANCE VOLUME
-        public static IEnumerable<ObvResult> GetObv(IEnumerable<Quote> history, int? smaPeriod = null)
+        public static IEnumerable<ObvResult> GetObv<TQuote>(IEnumerable<TQuote> history, int? smaPeriod = null) where TQuote : IQuote
         {
 
             // clean quotes
-            List<Quote> historyList = history.Sort();
+            List<TQuote> historyList = history.Sort();
 
             // check parameters
             ValidateObv(history, smaPeriod);
@@ -24,7 +24,7 @@ namespace Skender.Stock.Indicators
 
             for (int i = 0; i < historyList.Count; i++)
             {
-                Quote h = historyList[i];
+                TQuote h = historyList[i];
                 int index = i + 1;
 
                 if (prevClose == null || h.Close == prevClose)
@@ -66,7 +66,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateObv(IEnumerable<Quote> history, int? smaPeriod)
+        private static void ValidateObv<TQuote>(IEnumerable<TQuote> history, int? smaPeriod) where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/Obv/Obv.cs
+++ b/indicators/Obv/Obv.cs
@@ -7,7 +7,10 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // ON-BALANCE VOLUME
-        public static IEnumerable<ObvResult> GetObv<TQuote>(IEnumerable<TQuote> history, int? smaPeriod = null) where TQuote : IQuote
+        public static IEnumerable<ObvResult> GetObv<TQuote>(
+            IEnumerable<TQuote> history,
+            int? smaPeriod = null)
+            where TQuote : IQuote
         {
 
             // clean quotes

--- a/indicators/Obv/README.md
+++ b/indicators/Obv/README.md
@@ -16,7 +16,7 @@ IEnumerable<AdlResult> results = Indicator.GetObv(history,smaPeriod);
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least two historical quotes; however, since this is a trendline, more is recommended.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least two historical quotes; however, since this is a trendline, more is recommended.
 | `smaPeriod` | int | Optional.  Number of periods (`N`) in the moving average of OBV.  Must be greater than 0, if specified.
 
 ## Response

--- a/indicators/ParabolicSar/ParabolicSar.cs
+++ b/indicators/ParabolicSar/ParabolicSar.cs
@@ -10,7 +10,8 @@ namespace Skender.Stock.Indicators
         public static IEnumerable<ParabolicSarResult> GetParabolicSar<TQuote>(
             IEnumerable<TQuote> history,
             decimal accelerationStep = (decimal)0.02,
-            decimal maxAccelerationFactor = (decimal)0.2) where TQuote : IQuote
+            decimal maxAccelerationFactor = (decimal)0.2)
+            where TQuote : IQuote
         {
 
             // clean quotes

--- a/indicators/ParabolicSar/ParabolicSar.cs
+++ b/indicators/ParabolicSar/ParabolicSar.cs
@@ -7,21 +7,21 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // PARABOLIC SAR
-        public static IEnumerable<ParabolicSarResult> GetParabolicSar(
-            IEnumerable<Quote> history,
+        public static IEnumerable<ParabolicSarResult> GetParabolicSar<TQuote>(
+            IEnumerable<TQuote> history,
             decimal accelerationStep = (decimal)0.02,
-            decimal maxAccelerationFactor = (decimal)0.2)
+            decimal maxAccelerationFactor = (decimal)0.2) where TQuote : IQuote
         {
 
             // clean quotes
-            List<Quote> historyList = history.Sort();
+            List<TQuote> historyList = history.Sort();
 
             // check parameters
             ValidateParabolicSar(history, accelerationStep, maxAccelerationFactor);
 
             // initialize
             List<ParabolicSarResult> results = new List<ParabolicSarResult>();
-            Quote first = historyList[0];
+            TQuote first = historyList[0];
 
             decimal accelerationFactor = accelerationStep;
             decimal extremePoint = first.High;
@@ -31,7 +31,7 @@ namespace Skender.Stock.Indicators
             // roll through history
             for (int i = 0; i < historyList.Count; i++)
             {
-                Quote h = historyList[i];
+                TQuote h = historyList[i];
 
                 ParabolicSarResult result = new ParabolicSarResult
                 {
@@ -156,7 +156,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateParabolicSar(IEnumerable<Quote> history, decimal accelerationStep, decimal maxAccelerationFactor)
+        private static void ValidateParabolicSar<TQuote>(IEnumerable<TQuote> history, decimal accelerationStep, decimal maxAccelerationFactor) where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/ParabolicSar/README.md
+++ b/indicators/ParabolicSar/README.md
@@ -13,7 +13,7 @@ IEnumerable<ParabolicSarResult> results = Indicator.GetParabolicSar(history, acc
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  Provide sufficient history to capture prior trend reversals, before your usage period.  At least two history records are required to calculate; however, we recommend at least 100 data points.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  Provide sufficient history to capture prior trend reversals, before your usage period.  At least two history records are required to calculate; however, we recommend at least 100 data points.
 | `accelerationStep` | decimal | Incremental step size.  Must be greater than 0.  Default is 0.02
 | `maxAccelerationFactor` | decimal | Maximimum step limit.  Must be greater than `accelerationStep`.  Default is 0.2
 

--- a/indicators/Pmo/Pmo.cs
+++ b/indicators/Pmo/Pmo.cs
@@ -11,7 +11,8 @@ namespace Skender.Stock.Indicators
             IEnumerable<TQuote> history,
             int timePeriod = 35,
             int smoothingPeriod = 20,
-            int signalPeriod = 10) where TQuote : IQuote
+            int signalPeriod = 10)
+            where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/Pmo/Pmo.cs
+++ b/indicators/Pmo/Pmo.cs
@@ -7,11 +7,11 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // PRICE MOMENTUM OSCILLATOR (PMO)
-        public static IEnumerable<PmoResult> GetPmo(
-            IEnumerable<Quote> history,
+        public static IEnumerable<PmoResult> GetPmo<TQuote>(
+            IEnumerable<TQuote> history,
             int timePeriod = 35,
             int smoothingPeriod = 20,
-            int signalPeriod = 10)
+            int signalPeriod = 10) where TQuote : IQuote
         {
 
             // check parameters
@@ -55,7 +55,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static List<PmoResult> CalcPmoRocEma(IEnumerable<Quote> history, int timePeriod)
+        private static List<PmoResult> CalcPmoRocEma<TQuote>(IEnumerable<TQuote> history, int timePeriod) where TQuote : IQuote
         {
             // initialize
             decimal smoothingMultiplier = 2m / timePeriod;
@@ -138,11 +138,11 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidatePmo(
-            IEnumerable<Quote> history,
+        private static void ValidatePmo<TQuote>(
+            IEnumerable<TQuote> history,
             int timePeriod,
             int smoothingPeriod,
-            int signalPeriod)
+            int signalPeriod) where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/Pmo/README.md
+++ b/indicators/Pmo/README.md
@@ -13,7 +13,7 @@ IEnumerable<PmoResult> results = Indicator.GetPmo(history, timePeriod, smoothing
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `T+S` periods of `history`.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `T+S` periods of `history`.
 | `timePeriod` | int | Number of periods (`T`) for ROC EMA smoothing.  Must be greater than 1.  Default is 35.
 | `smoothingPeriod` | int | Number of periods (`S`) for PMO EMA smoothing.  Must be greater than 0.  Default is 20.
 | `signalPeriod` | int | Number of periods (`G`) for Signal line EMA.  Must be greater than 0.  Default is 10.

--- a/indicators/Prs/Prs.cs
+++ b/indicators/Prs/Prs.cs
@@ -7,12 +7,12 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // PRICE RELATIVE STRENGTH
-        public static IEnumerable<PrsResult> GetPrs(
-            IEnumerable<Quote> historyBase, IEnumerable<Quote> historyEval, int? lookbackPeriod = null, int? smaPeriod = null)
+        public static IEnumerable<PrsResult> GetPrs<TQuote>(
+            IEnumerable<TQuote> historyBase, IEnumerable<TQuote> historyEval, int? lookbackPeriod = null, int? smaPeriod = null) where TQuote : IQuote
         {
             // clean quotes
-            List<Quote> historyBaseList = historyBase.Sort();
-            List<Quote> historyEvalList = historyEval.Sort();
+            List<TQuote> historyBaseList = historyBase.Sort();
+            List<TQuote> historyEvalList = historyEval.Sort();
 
             // validate parameters
             ValidatePriceRelative(historyBase, historyEval, lookbackPeriod, smaPeriod);
@@ -24,8 +24,8 @@ namespace Skender.Stock.Indicators
             // roll through history for interim data
             for (int i = 0; i < historyEvalList.Count; i++)
             {
-                Quote bi = historyBaseList[i];
-                Quote ei = historyEvalList[i];
+                TQuote bi = historyBaseList[i];
+                TQuote ei = historyEvalList[i];
                 int index = i + 1;
 
                 if (ei.Date != bi.Date)
@@ -43,8 +43,8 @@ namespace Skender.Stock.Indicators
 
                 if (lookbackPeriod != null && index > lookbackPeriod)
                 {
-                    Quote bo = historyBaseList[i - (int)lookbackPeriod];
-                    Quote eo = historyEvalList[i - (int)lookbackPeriod];
+                    TQuote bo = historyBaseList[i - (int)lookbackPeriod];
+                    TQuote eo = historyEvalList[i - (int)lookbackPeriod];
 
                     if (bo.Close != 0 && eo.Close != 0)
                     {
@@ -73,8 +73,8 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidatePriceRelative(
-            IEnumerable<Quote> historyBase, IEnumerable<Quote> historyEval, int? lookbackPeriod, int? smaPeriod)
+        private static void ValidatePriceRelative<TQuote>(
+            IEnumerable<TQuote> historyBase, IEnumerable<TQuote> historyEval, int? lookbackPeriod, int? smaPeriod) where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/Prs/Prs.cs
+++ b/indicators/Prs/Prs.cs
@@ -8,7 +8,11 @@ namespace Skender.Stock.Indicators
     {
         // PRICE RELATIVE STRENGTH
         public static IEnumerable<PrsResult> GetPrs<TQuote>(
-            IEnumerable<TQuote> historyBase, IEnumerable<TQuote> historyEval, int? lookbackPeriod = null, int? smaPeriod = null) where TQuote : IQuote
+            IEnumerable<TQuote> historyBase,
+            IEnumerable<TQuote> historyEval,
+            int? lookbackPeriod = null,
+            int? smaPeriod = null)
+            where TQuote : IQuote
         {
             // clean quotes
             List<TQuote> historyBaseList = historyBase.Sort();

--- a/indicators/Prs/README.md
+++ b/indicators/Prs/README.md
@@ -16,8 +16,8 @@ IEnumerable<PrsResult> results = Indicator.GetPrs(historyBase, historyEval, smaP
 
 | name | type | notes
 | -- |-- |--
-| `historyBase` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | This is usually market index data, but could be any baseline data that you might use for comparison.  You must supply at least `N` periods of `historyBase` to calculate, but more is typically used if `lookbackPeriod` is specified.
-| `historyEval` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical quotes for evaluation.  You must supply the same number of periods as `historyBase`.
+| `historyBase` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | This is usually market index data, but could be any baseline data that you might use for comparison.  You must supply at least `N` periods of `historyBase` to calculate, but more is typically used if `lookbackPeriod` is specified.
+| `historyEval` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical quotes for evaluation.  You must supply the same number of periods as `historyBase`.
 | `lookbackPeriod` | int | Optional.  Number of periods (`N`) to lookback to compute % difference.  Must be greater than 0 if specified or `null`.
 | `smaPeriod` | int | Optional.  Number of periods (`S`) in the SMA lookback period for `Prs`.  Must be greater than 0.
 

--- a/indicators/Roc/README.md
+++ b/indicators/Roc/README.md
@@ -16,7 +16,7 @@ IEnumerable<RocResult> results = Indicator.GetRoc(history, lookbackPeriod, smaPe
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N+1` periods of `history`.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N+1` periods of `history`.
 | `lookbackPeriod` | int | Number of periods (`N`) to go back.  Must be greater than 0.
 | `smaPeriod` | int | Optional.  Number of periods in the moving average of ROC.  Must be greater than 0, if specified.
 

--- a/indicators/Roc/Roc.cs
+++ b/indicators/Roc/Roc.cs
@@ -8,7 +8,10 @@ namespace Skender.Stock.Indicators
     {
         // RATE OF CHANGE (ROC)
         public static IEnumerable<RocResult> GetRoc<TQuote>(
-            IEnumerable<TQuote> history, int lookbackPeriod, int? smaPeriod = null) where TQuote : IQuote
+            IEnumerable<TQuote> history,
+            int lookbackPeriod,
+            int? smaPeriod = null)
+            where TQuote : IQuote
         {
 
             // clean quotes

--- a/indicators/Roc/Roc.cs
+++ b/indicators/Roc/Roc.cs
@@ -7,12 +7,12 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // RATE OF CHANGE (ROC)
-        public static IEnumerable<RocResult> GetRoc(
-            IEnumerable<Quote> history, int lookbackPeriod, int? smaPeriod = null)
+        public static IEnumerable<RocResult> GetRoc<TQuote>(
+            IEnumerable<TQuote> history, int lookbackPeriod, int? smaPeriod = null) where TQuote : IQuote
         {
 
             // clean quotes
-            List<Quote> historyList = history.Sort();
+            List<TQuote> historyList = history.Sort();
 
             // check parameters
             ValidateRoc(history, lookbackPeriod, smaPeriod);
@@ -23,7 +23,7 @@ namespace Skender.Stock.Indicators
             // roll through history
             for (int i = 0; i < historyList.Count; i++)
             {
-                Quote h = historyList[i];
+                TQuote h = historyList[i];
                 int index = i + 1;
 
                 RocResult result = new RocResult
@@ -33,7 +33,7 @@ namespace Skender.Stock.Indicators
 
                 if (index > lookbackPeriod)
                 {
-                    Quote back = historyList[index - lookbackPeriod - 1];
+                    TQuote back = historyList[index - lookbackPeriod - 1];
 
                     result.Roc = (back.Close == 0) ? null
                         : 100 * (h.Close - back.Close) / back.Close;
@@ -58,7 +58,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateRoc(IEnumerable<Quote> history, int lookbackPeriod, int? smaPeriod)
+        private static void ValidateRoc<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod, int? smaPeriod) where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/Rsi/README.md
+++ b/indicators/Rsi/README.md
@@ -14,7 +14,7 @@ IEnumerable<RsiResult> results = Indicator.GetRsi(history, lookbackPeriod);
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N` periods of `history`.  Since this uses a smoothing technique, we recommend you use at least 250 data points prior to the intended usage date for maximum precision.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N` periods of `history`.  Since this uses a smoothing technique, we recommend you use at least 250 data points prior to the intended usage date for maximum precision.
 | `lookbackPeriod` | int | Number of periods (`N`) in the lookback period.  Must be greater than 0.
 
 ## Response

--- a/indicators/Rsi/Rsi.cs
+++ b/indicators/Rsi/Rsi.cs
@@ -6,7 +6,7 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // RELATIVE STRENGTH INDEX
-        public static IEnumerable<RsiResult> GetRsi(IEnumerable<Quote> history, int lookbackPeriod = 14)
+        public static IEnumerable<RsiResult> GetRsi<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod = 14) where TQuote : IQuote
         {
 
             // convert history to basic format

--- a/indicators/Rsi/Rsi.cs
+++ b/indicators/Rsi/Rsi.cs
@@ -6,7 +6,10 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // RELATIVE STRENGTH INDEX
-        public static IEnumerable<RsiResult> GetRsi<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod = 14) where TQuote : IQuote
+        public static IEnumerable<RsiResult> GetRsi<TQuote>(
+            IEnumerable<TQuote> history,
+            int lookbackPeriod = 14)
+            where TQuote : IQuote
         {
 
             // convert history to basic format

--- a/indicators/Slope/README.md
+++ b/indicators/Slope/README.md
@@ -13,7 +13,7 @@ IEnumerable<SlopeResult> results = Indicator.GetSlope(history, lookbackPeriod);
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N` periods.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N` periods.
 | `lookbackPeriod` | int | Number of periods (`N`) for the linear regression.  Must be greater than 0.
 
 ## Response

--- a/indicators/Slope/Slope.cs
+++ b/indicators/Slope/Slope.cs
@@ -7,7 +7,10 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // SLOPE AND LINEAR REGRESSION
-        public static IEnumerable<SlopeResult> GetSlope<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod) where TQuote : IQuote
+        public static IEnumerable<SlopeResult> GetSlope<TQuote>(
+            IEnumerable<TQuote> history,
+            int lookbackPeriod)
+            where TQuote : IQuote
         {
             // clean quotes
             List<TQuote> historyList = history.Sort();

--- a/indicators/Slope/Slope.cs
+++ b/indicators/Slope/Slope.cs
@@ -7,10 +7,10 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // SLOPE AND LINEAR REGRESSION
-        public static IEnumerable<SlopeResult> GetSlope(IEnumerable<Quote> history, int lookbackPeriod)
+        public static IEnumerable<SlopeResult> GetSlope<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod) where TQuote : IQuote
         {
             // clean quotes
-            List<Quote> historyList = history.Sort();
+            List<TQuote> historyList = history.Sort();
 
             // validate parameters
             ValidateSlope(history, lookbackPeriod);
@@ -21,7 +21,7 @@ namespace Skender.Stock.Indicators
             // roll through history for interim data
             for (int i = 0; i < historyList.Count; i++)
             {
-                Quote h = historyList[i];
+                TQuote h = historyList[i];
                 int index = i + 1;
 
                 SlopeResult r = new SlopeResult
@@ -43,7 +43,7 @@ namespace Skender.Stock.Indicators
 
                 for (int p = index - lookbackPeriod; p < index; p++)
                 {
-                    Quote d = historyList[p];
+                    TQuote d = historyList[p];
 
                     sumX += p + 1m;
                     sumY += d.Close;
@@ -59,7 +59,7 @@ namespace Skender.Stock.Indicators
 
                 for (int p = index - lookbackPeriod; p < index; p++)
                 {
-                    Quote d = historyList[p];
+                    TQuote d = historyList[p];
 
                     decimal devX = (p + 1m - avgX);
                     decimal devY = (d.Close - avgY);
@@ -98,7 +98,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateSlope(IEnumerable<Quote> history, int lookbackPeriod)
+        private static void ValidateSlope<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod) where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/Sma/README.md
+++ b/indicators/Sma/README.md
@@ -14,7 +14,7 @@ IEnumerable<SmaResult> results = Indicator.GetSma(history, lookbackPeriod);
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N` periods of `history`.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N` periods of `history`.
 | `lookbackPeriod` | int | Number of periods (`N`) in the moving average.  Must be greater than 0.
 | `extended` | bool | A `true` will include values for MAD, MSE, and MAPE.  Default is `false`.
 

--- a/indicators/Sma/Sma.cs
+++ b/indicators/Sma/Sma.cs
@@ -7,12 +7,12 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // SIMPLE MOVING AVERAGE
-        public static IEnumerable<SmaResult> GetSma(
-            IEnumerable<Quote> history, int lookbackPeriod, bool extended = false)
+        public static IEnumerable<SmaResult> GetSma<TQuote>(
+            IEnumerable<TQuote> history, int lookbackPeriod, bool extended = false) where TQuote : IQuote
         {
 
             // clean quotes
-            List<Quote> historyList = history.Sort();
+            List<TQuote> historyList = history.Sort();
 
             // check parameters
             ValidateSma(history, lookbackPeriod);
@@ -23,7 +23,7 @@ namespace Skender.Stock.Indicators
             // roll through history
             for (int i = 0; i < historyList.Count; i++)
             {
-                Quote h = historyList[i];
+                TQuote h = historyList[i];
                 int index = i + 1;
 
                 SmaResult result = new SmaResult
@@ -36,7 +36,7 @@ namespace Skender.Stock.Indicators
                     decimal sumSma = 0m;
                     for (int p = index - lookbackPeriod; p < index; p++)
                     {
-                        Quote d = historyList[p];
+                        TQuote d = historyList[p];
                         sumSma += d.Close;
                     }
 
@@ -51,7 +51,7 @@ namespace Skender.Stock.Indicators
 
                         for (int p = index - lookbackPeriod; p < index; p++)
                         {
-                            Quote d = historyList[p];
+                            TQuote d = historyList[p];
                             sumMad += Math.Abs(d.Close - (decimal)result.Sma);
                             sumMse += (d.Close - (decimal)result.Sma) * (d.Close - (decimal)result.Sma);
 
@@ -77,7 +77,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateSma(IEnumerable<Quote> history, int lookbackPeriod)
+        private static void ValidateSma<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod) where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/Sma/Sma.cs
+++ b/indicators/Sma/Sma.cs
@@ -8,7 +8,10 @@ namespace Skender.Stock.Indicators
     {
         // SIMPLE MOVING AVERAGE
         public static IEnumerable<SmaResult> GetSma<TQuote>(
-            IEnumerable<TQuote> history, int lookbackPeriod, bool extended = false) where TQuote : IQuote
+            IEnumerable<TQuote> history,
+            int lookbackPeriod,
+            bool extended = false)
+            where TQuote : IQuote
         {
 
             // clean quotes

--- a/indicators/StdDev/README.md
+++ b/indicators/StdDev/README.md
@@ -16,7 +16,7 @@ IEnumerable<StdDevResult> results = Indicator.GetStdDev(history, lookbackPeriod,
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N` periods of `history`.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N` periods of `history`.
 | `lookbackPeriod` | int | Number of periods (`N`) in the lookback period.  Must be greater than 1 to calculate; however we suggest a larger period for statistically appropriate sample size.
 | `smaPeriod` | int | Optional.  Number of periods in the moving average of STDEV.  Must be greater than 0, if specified.
 

--- a/indicators/StdDev/StdDev.cs
+++ b/indicators/StdDev/StdDev.cs
@@ -7,7 +7,10 @@ namespace Skender.Stock.Indicators
     {
         // STANDARD DEVIATION
         public static IEnumerable<StdDevResult> GetStdDev<TQuote>(
-            IEnumerable<TQuote> history, int lookbackPeriod, int? smaPeriod = null) where TQuote : IQuote
+            IEnumerable<TQuote> history,
+            int lookbackPeriod,
+            int? smaPeriod = null)
+            where TQuote : IQuote
         {
 
             // convert to basic data

--- a/indicators/StdDev/StdDev.cs
+++ b/indicators/StdDev/StdDev.cs
@@ -6,8 +6,8 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // STANDARD DEVIATION
-        public static IEnumerable<StdDevResult> GetStdDev(
-            IEnumerable<Quote> history, int lookbackPeriod, int? smaPeriod = null)
+        public static IEnumerable<StdDevResult> GetStdDev<TQuote>(
+            IEnumerable<TQuote> history, int lookbackPeriod, int? smaPeriod = null) where TQuote : IQuote
         {
 
             // convert to basic data

--- a/indicators/Stoch/README.md
+++ b/indicators/Stoch/README.md
@@ -13,7 +13,7 @@ IEnumerable<StochResult> results = Indicator.GetStoch(history, lookbackPeriod, s
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N+S` periods of `history`.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N+S` periods of `history`.
 | `lookbackPeriod` | int | Lookback period (`N`) for the oscillator (%K).  Must be greater than 0.  Default is 14.
 | `signalPeriod` | int | Lookback period for the signal (%D).  Must be greater than 0.  Default is 3.
 | `smoothingPeriod` | int | Smoothing period `S` for the Oscillator (%K).  "Slow" stochastic uses 3, "Fast" stochastic uses 1.  You can specify as needed here.  Must be greater than or equal to 1.  Default is 3.

--- a/indicators/Stoch/Stoch.cs
+++ b/indicators/Stoch/Stoch.cs
@@ -7,11 +7,11 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // STOCHASTIC OSCILLATOR
-        public static IEnumerable<StochResult> GetStoch(IEnumerable<Quote> history, int lookbackPeriod = 14, int signalPeriod = 3, int smoothPeriod = 3)
+        public static IEnumerable<StochResult> GetStoch<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod = 14, int signalPeriod = 3, int smoothPeriod = 3) where TQuote : IQuote
         {
 
             // clean quotes
-            List<Quote> historyList = history.Sort();
+            List<TQuote> historyList = history.Sort();
 
             // validate parameters
             ValidateStoch(history, lookbackPeriod, signalPeriod, smoothPeriod);
@@ -22,7 +22,7 @@ namespace Skender.Stock.Indicators
             // oscillator
             for (int i = 0; i < historyList.Count; i++)
             {
-                Quote h = historyList[i];
+                TQuote h = historyList[i];
                 int index = i + 1;
 
                 StochResult result = new StochResult
@@ -37,7 +37,7 @@ namespace Skender.Stock.Indicators
 
                     for (int p = index - lookbackPeriod; p < index; p++)
                     {
-                        Quote d = historyList[p];
+                        TQuote d = historyList[p];
 
                         if (d.High > highHigh)
                         {
@@ -134,7 +134,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateStoch(IEnumerable<Quote> history, int lookbackPeriod, int signalPeriod, int smoothPeriod)
+        private static void ValidateStoch<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod, int signalPeriod, int smoothPeriod) where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/Stoch/Stoch.cs
+++ b/indicators/Stoch/Stoch.cs
@@ -7,7 +7,12 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // STOCHASTIC OSCILLATOR
-        public static IEnumerable<StochResult> GetStoch<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod = 14, int signalPeriod = 3, int smoothPeriod = 3) where TQuote : IQuote
+        public static IEnumerable<StochResult> GetStoch<TQuote>(
+            IEnumerable<TQuote> history,
+            int lookbackPeriod = 14,
+            int signalPeriod = 3,
+            int smoothPeriod = 3)
+            where TQuote : IQuote
         {
 
             // clean quotes

--- a/indicators/StochRsi/README.md
+++ b/indicators/StochRsi/README.md
@@ -14,7 +14,7 @@ IEnumerable<StochRsiResult> results = Indicator.GetStochRsi(history, rsiPeriod, 
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `R+S` periods of `history`.  Since this uses a smoothing technique in the underlying RSI value, we recommend you use at least 250 data points prior to the intended usage date for maximum precision.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `R+S` periods of `history`.  Since this uses a smoothing technique in the underlying RSI value, we recommend you use at least 250 data points prior to the intended usage date for maximum precision.
 | `rsiPeriod` | int | Number of periods (`R`) in the lookback period.  Must be greater than 0.  Standard is 14.
 | `stochPeriod` | int | Number of periods (`S`) in the lookback period.  Must be greater than 0.  Typically the same value as `rsiPeriod`.
 | `signalPeriod` | int | Number of periods (`G`) in the signal line (SMA of the StochRSI).  Must be greater than 0.  Typically 3-5.

--- a/indicators/StochRsi/StochRsi.cs
+++ b/indicators/StochRsi/StochRsi.cs
@@ -7,8 +7,8 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // STOCHASTIC RSI
-        public static IEnumerable<StochRsiResult> GetStochRsi(IEnumerable<Quote> history,
-            int rsiPeriod, int stochPeriod, int signalPeriod, int smoothPeriod = 1)
+        public static IEnumerable<StochRsiResult> GetStochRsi<TQuote>(IEnumerable<TQuote> history,
+            int rsiPeriod, int stochPeriod, int signalPeriod, int smoothPeriod = 1) where TQuote : IQuote
         {
 
             // validate parameters
@@ -61,8 +61,8 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateStochRsi(IEnumerable<Quote> history,
-            int rsiPeriod, int stochPeriod, int signalPeriod, int smoothPeriod)
+        private static void ValidateStochRsi<TQuote>(IEnumerable<TQuote> history,
+            int rsiPeriod, int stochPeriod, int signalPeriod, int smoothPeriod) where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/StochRsi/StochRsi.cs
+++ b/indicators/StochRsi/StochRsi.cs
@@ -7,8 +7,13 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // STOCHASTIC RSI
-        public static IEnumerable<StochRsiResult> GetStochRsi<TQuote>(IEnumerable<TQuote> history,
-            int rsiPeriod, int stochPeriod, int signalPeriod, int smoothPeriod = 1) where TQuote : IQuote
+        public static IEnumerable<StochRsiResult> GetStochRsi<TQuote>(
+            IEnumerable<TQuote> history,
+            int rsiPeriod,
+            int stochPeriod,
+            int signalPeriod,
+            int smoothPeriod = 1)
+            where TQuote : IQuote
         {
 
             // validate parameters

--- a/indicators/Trix/README.md
+++ b/indicators/Trix/README.md
@@ -16,7 +16,7 @@ IEnumerable<TrixResult> results = Indicator.GetTrix(history, lookbackPeriod, sig
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) in each of the the exponential moving averages.  Must be greater than 0.
 | `signalPeriod` | int | Optional.  Number of periods in the moving average of TRIX.  Must be greater than 0, if specified.
 

--- a/indicators/Trix/Trix.cs
+++ b/indicators/Trix/Trix.cs
@@ -7,8 +7,8 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // TRIPLE EMA OSCILLATOR (TRIX)
-        public static IEnumerable<TrixResult> GetTrix(
-            IEnumerable<Quote> history, int lookbackPeriod, int? signalPeriod = null)
+        public static IEnumerable<TrixResult> GetTrix<TQuote>(
+            IEnumerable<TQuote> history, int lookbackPeriod, int? signalPeriod = null) where TQuote : IQuote
         {
 
             // convert history to basic format

--- a/indicators/Trix/Trix.cs
+++ b/indicators/Trix/Trix.cs
@@ -8,7 +8,10 @@ namespace Skender.Stock.Indicators
     {
         // TRIPLE EMA OSCILLATOR (TRIX)
         public static IEnumerable<TrixResult> GetTrix<TQuote>(
-            IEnumerable<TQuote> history, int lookbackPeriod, int? signalPeriod = null) where TQuote : IQuote
+            IEnumerable<TQuote> history,
+            int lookbackPeriod,
+            int? signalPeriod = null)
+            where TQuote : IQuote
         {
 
             // convert history to basic format

--- a/indicators/UlcerIndex/README.md
+++ b/indicators/UlcerIndex/README.md
@@ -13,7 +13,7 @@ IEnumerable<UlcerIndexResult> results = Indicator.GetUlcerIndex(history, lookbac
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N` periods of `history`.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N` periods of `history`.
 | `lookbackPeriod` | int | Number of periods (`N`) for review.  Must be greater than 0.  Default is 14.
 
 ## Response

--- a/indicators/UlcerIndex/Ulcer.cs
+++ b/indicators/UlcerIndex/Ulcer.cs
@@ -7,7 +7,10 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // ULCER INDEX (UI)
-        public static IEnumerable<UlcerIndexResult> GetUlcerIndex<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod = 14) where TQuote : IQuote
+        public static IEnumerable<UlcerIndexResult> GetUlcerIndex<TQuote>(
+            IEnumerable<TQuote> history,
+            int lookbackPeriod = 14)
+            where TQuote : IQuote
         {
 
             // clean quotes

--- a/indicators/UlcerIndex/Ulcer.cs
+++ b/indicators/UlcerIndex/Ulcer.cs
@@ -7,11 +7,11 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // ULCER INDEX (UI)
-        public static IEnumerable<UlcerIndexResult> GetUlcerIndex(IEnumerable<Quote> history, int lookbackPeriod = 14)
+        public static IEnumerable<UlcerIndexResult> GetUlcerIndex<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod = 14) where TQuote : IQuote
         {
 
             // clean quotes
-            List<Quote> historyList = history.Sort();
+            List<TQuote> historyList = history.Sort();
 
             // validate parameters
             ValidateUlcer(history, lookbackPeriod);
@@ -22,7 +22,7 @@ namespace Skender.Stock.Indicators
             // roll through history
             for (int i = 0; i < historyList.Count; i++)
             {
-                Quote h = historyList[i];
+                TQuote h = historyList[i];
                 int index = i + 1;
 
                 UlcerIndexResult result = new UlcerIndexResult
@@ -35,13 +35,13 @@ namespace Skender.Stock.Indicators
                     double? sumSquared = 0;
                     for (int p = index - lookbackPeriod; p < index; p++)
                     {
-                        Quote d = historyList[p];
+                        TQuote d = historyList[p];
                         int dIndex = p + 1;
 
                         decimal maxClose = 0;
                         for (int q = index - lookbackPeriod; q < dIndex; q++)
                         {
-                            Quote dd = historyList[q];
+                            TQuote dd = historyList[q];
                             if (dd.Close > maxClose)
                             {
                                 maxClose = dd.Close;
@@ -64,7 +64,7 @@ namespace Skender.Stock.Indicators
             return results;
         }
 
-        private static void ValidateUlcer(IEnumerable<Quote> history, int lookbackPeriod)
+        private static void ValidateUlcer<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod) where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/Ultimate/README.md
+++ b/indicators/Ultimate/README.md
@@ -13,7 +13,7 @@ IEnumerable<UltimateResult> results = Indicator.GetUltimate(history, shortPeriod
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `L+1` periods of `history`.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `L+1` periods of `history`.
 | `shortPeriod` | int | Number of periods (`S`) in the short lookback.  Must be greater than 0.  Default is 7.
 | `middlePeriod` | int | Number of periods (`M`) in the middle lookback.  Must be greater than `S`.  Default is 14.
 | `longPeriod` | int | Number of periods (`L`) in the long lookback.  Must be greater than `M`.  Default is 28.

--- a/indicators/Ultimate/Ultimate.cs
+++ b/indicators/Ultimate/Ultimate.cs
@@ -7,12 +7,12 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // ULTIMATE OSCILLATOR
-        public static IEnumerable<UltimateResult> GetUltimate(
-            IEnumerable<Quote> history, int shortPeriod = 7, int middlePeriod = 14, int longPeriod = 28)
+        public static IEnumerable<UltimateResult> GetUltimate<TQuote>(
+            IEnumerable<TQuote> history, int shortPeriod = 7, int middlePeriod = 14, int longPeriod = 28) where TQuote : IQuote
         {
 
             // clean quotes
-            List<Quote> historyList = history.Sort();
+            List<TQuote> historyList = history.Sort();
 
             // check parameters
             ValidateUltimate(history, shortPeriod, middlePeriod, longPeriod);
@@ -24,7 +24,7 @@ namespace Skender.Stock.Indicators
             // roll through history
             for (int i = 0; i < historyList.Count; i++)
             {
-                Quote h = historyList[i];
+                TQuote h = historyList[i];
                 int index = i + 1;
 
                 UltimateResult r = new UltimateResult
@@ -87,8 +87,8 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateUltimate(
-            IEnumerable<Quote> history, int shortPeriod = 7, int middleAverage = 14, int longPeriod = 28)
+        private static void ValidateUltimate<TQuote>(
+            IEnumerable<TQuote> history, int shortPeriod = 7, int middleAverage = 14, int longPeriod = 28) where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/Ultimate/Ultimate.cs
+++ b/indicators/Ultimate/Ultimate.cs
@@ -8,7 +8,11 @@ namespace Skender.Stock.Indicators
     {
         // ULTIMATE OSCILLATOR
         public static IEnumerable<UltimateResult> GetUltimate<TQuote>(
-            IEnumerable<TQuote> history, int shortPeriod = 7, int middlePeriod = 14, int longPeriod = 28) where TQuote : IQuote
+            IEnumerable<TQuote> history,
+            int shortPeriod = 7,
+            int middlePeriod = 14,
+            int longPeriod = 28)
+            where TQuote : IQuote
         {
 
             // clean quotes

--- a/indicators/VolSma/README.md
+++ b/indicators/VolSma/README.md
@@ -13,7 +13,7 @@ IEnumerable<VolSmaResult> results = Indicator.GetVolSma(history, lookbackPeriod)
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N` periods of `history`.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N` periods of `history`.
 | `lookbackPeriod` | int | Number of periods (`N`) in the moving average.  Must be greater than 0.
 
 ## Response

--- a/indicators/VolSma/VolSma.cs
+++ b/indicators/VolSma/VolSma.cs
@@ -7,7 +7,10 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // SIMPLE MOVING AVERAGE of VOLUME
-        public static IEnumerable<VolSmaResult> GetVolSma<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod) where TQuote : IQuote
+        public static IEnumerable<VolSmaResult> GetVolSma<TQuote>(
+            IEnumerable<TQuote> history,
+            int lookbackPeriod)
+            where TQuote : IQuote
         {
 
             // clean quotes and initialize results

--- a/indicators/VolSma/VolSma.cs
+++ b/indicators/VolSma/VolSma.cs
@@ -7,7 +7,7 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // SIMPLE MOVING AVERAGE of VOLUME
-        public static IEnumerable<VolSmaResult> GetVolSma(IEnumerable<Quote> history, int lookbackPeriod)
+        public static IEnumerable<VolSmaResult> GetVolSma<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod) where TQuote : IQuote
         {
 
             // clean quotes and initialize results
@@ -42,7 +42,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateVolSma(IEnumerable<Quote> history, int lookbackPeriod)
+        private static void ValidateVolSma<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod) where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/WilliamsR/README.md
+++ b/indicators/WilliamsR/README.md
@@ -13,7 +13,7 @@ IEnumerable<WilliamsResult> results = Indicator.GetWilliamsR(history, lookbackPe
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N` periods of `history`.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N` periods of `history`.
 | `lookbackPeriod` | int | Number of periods (`N`) in the lookback period.  Must be greater than 0.  Default is 14.
 
 ## Response

--- a/indicators/WilliamsR/WilliamsR.cs
+++ b/indicators/WilliamsR/WilliamsR.cs
@@ -7,7 +7,10 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // WILLIAM %R OSCILLATOR
-        public static IEnumerable<WilliamsResult> GetWilliamsR<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod = 14) where TQuote : IQuote
+        public static IEnumerable<WilliamsResult> GetWilliamsR<TQuote>(
+            IEnumerable<TQuote> history,
+            int lookbackPeriod = 14)
+            where TQuote : IQuote
         {
 
             // validate parameters

--- a/indicators/WilliamsR/WilliamsR.cs
+++ b/indicators/WilliamsR/WilliamsR.cs
@@ -7,7 +7,7 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // WILLIAM %R OSCILLATOR
-        public static IEnumerable<WilliamsResult> GetWilliamsR(IEnumerable<Quote> history, int lookbackPeriod = 14)
+        public static IEnumerable<WilliamsResult> GetWilliamsR<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod = 14) where TQuote : IQuote
         {
 
             // validate parameters
@@ -24,7 +24,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateWilliam(IEnumerable<Quote> history, int lookbackPeriod)
+        private static void ValidateWilliam<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod) where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/Wma/README.md
+++ b/indicators/Wma/README.md
@@ -13,7 +13,7 @@ IEnumerable<WmaResult> results = Indicator.GetWma(history, lookbackPeriod);
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N` periods of `history`.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least `N` periods of `history`.
 | `lookbackPeriod` | int | Number of periods (`N`) in the moving average.  Must be greater than 0.
 
 ## Response

--- a/indicators/Wma/Wma.cs
+++ b/indicators/Wma/Wma.cs
@@ -7,7 +7,10 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // WEIGHTED MOVING AVERAGE
-        public static IEnumerable<WmaResult> GetWma<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod) where TQuote : IQuote
+        public static IEnumerable<WmaResult> GetWma<TQuote>(
+            IEnumerable<TQuote> history,
+            int lookbackPeriod)
+            where TQuote : IQuote
         {
 
             // clean quotes

--- a/indicators/Wma/Wma.cs
+++ b/indicators/Wma/Wma.cs
@@ -7,11 +7,11 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // WEIGHTED MOVING AVERAGE
-        public static IEnumerable<WmaResult> GetWma(IEnumerable<Quote> history, int lookbackPeriod)
+        public static IEnumerable<WmaResult> GetWma<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod) where TQuote : IQuote
         {
 
             // clean quotes
-            List<Quote> historyList = history.Sort();
+            List<TQuote> historyList = history.Sort();
 
             // check parameters
             ValidateWma(history, lookbackPeriod);
@@ -23,7 +23,7 @@ namespace Skender.Stock.Indicators
             // roll through history
             for (int i = 0; i < historyList.Count; i++)
             {
-                Quote h = historyList[i];
+                TQuote h = historyList[i];
                 int index = i + 1;
 
                 WmaResult result = new WmaResult
@@ -36,7 +36,7 @@ namespace Skender.Stock.Indicators
                     decimal wma = 0;
                     for (int p = index - lookbackPeriod; p < index; p++)
                     {
-                        Quote d = historyList[p];
+                        TQuote d = historyList[p];
                         wma += d.Close * (lookbackPeriod - (decimal)(index - p - 1)) / divisor;
                     }
 
@@ -50,7 +50,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateWma(IEnumerable<Quote> history, int lookbackPeriod)
+        private static void ValidateWma<TQuote>(IEnumerable<TQuote> history, int lookbackPeriod) where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/ZigZag/README.md
+++ b/indicators/ZigZag/README.md
@@ -13,7 +13,7 @@ IEnumerable<ZigZagResult> results = Indicator.GetZigZag(history,type,percentChan
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[Quote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least two periods to calculate, but notably more is needed to be useful.
+| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#quote)\> | Historical Quotes data should be at any consistent frequency (day, hour, minute, etc).  You must supply at least two periods to calculate, but notably more is needed to be useful.
 | `type` | ZigZagType | Determines whether `Close` or `High/Low` are used to measure percent change.  See [ZigZagType options](#zigzagtype-options) below.  Default is `ZigZagType.Close`.
 | `percentChange` | decimal | Percent change required to establish a line endpoint.  Example: 3.5% would be entered as 3.5 (not 0.035).  Must be greater than 0.  Typical values range from 3 to 10.  Default is 5.
 

--- a/indicators/ZigZag/ZigZag.cs
+++ b/indicators/ZigZag/ZigZag.cs
@@ -8,7 +8,10 @@ namespace Skender.Stock.Indicators
     {
         // ZIG ZAG
         public static IEnumerable<ZigZagResult> GetZigZag<TQuote>(
-            IEnumerable<TQuote> history, ZigZagType type = ZigZagType.Close, decimal percentChange = 5) where TQuote : IQuote
+            IEnumerable<TQuote> history,
+            ZigZagType type = ZigZagType.Close,
+            decimal percentChange = 5)
+            where TQuote : IQuote
         {
 
             // clean quotes

--- a/indicators/ZigZag/ZigZag.cs
+++ b/indicators/ZigZag/ZigZag.cs
@@ -7,12 +7,12 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // ZIG ZAG
-        public static IEnumerable<ZigZagResult> GetZigZag(
-            IEnumerable<Quote> history, ZigZagType type = ZigZagType.Close, decimal percentChange = 5)
+        public static IEnumerable<ZigZagResult> GetZigZag<TQuote>(
+            IEnumerable<TQuote> history, ZigZagType type = ZigZagType.Close, decimal percentChange = 5) where TQuote : IQuote
         {
 
             // clean quotes
-            List<Quote> historyList = history.Sort();
+            List<TQuote> historyList = history.Sort();
 
             // check parameters
             ValidateZigZag(history, percentChange);
@@ -20,7 +20,7 @@ namespace Skender.Stock.Indicators
             // initialize
             List<ZigZagResult> results = new List<ZigZagResult>();
             decimal changeThreshold = percentChange / 100m;
-            Quote firstQuote = historyList[0];
+            TQuote firstQuote = historyList[0];
             ZigZagEval eval = GetZigZagEval(type, 1, firstQuote);
 
             ZigZagPoint lastPoint = new ZigZagPoint
@@ -49,7 +49,7 @@ namespace Skender.Stock.Indicators
             // roll through history until to find initial trend
             for (int i = 0; i < historyList.Count; i++)
             {
-                Quote h = historyList[i];
+                TQuote h = historyList[i];
                 int index = i + 1;
 
                 eval = GetZigZagEval(type, index, h);
@@ -97,10 +97,10 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static ZigZagPoint EvaluateNextPoint(List<Quote> historyList,
-            ZigZagType type, decimal changeThreshold, ZigZagPoint lastPoint)
+        private static ZigZagPoint EvaluateNextPoint<TQuote>(List<TQuote> historyList,
+            ZigZagType type, decimal changeThreshold, ZigZagPoint lastPoint) where TQuote : IQuote
         {
-            // initialize 
+            // initialize
             bool trendUp = (lastPoint.PointType == "L");
             decimal? change = 0;
 
@@ -114,7 +114,7 @@ namespace Skender.Stock.Indicators
             // find extreme point before reversal point
             for (int i = lastPoint.Index; i < historyList.Count; i++)
             {
-                Quote h = historyList[i];
+                TQuote h = historyList[i];
                 int index = i + 1;
 
                 ZigZagEval eval = GetZigZagEval(type, index, h);
@@ -171,8 +171,8 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void DrawZigZagLine(List<ZigZagResult> results, List<Quote> historyList,
-            ZigZagPoint lastPoint, ZigZagPoint nextPoint)
+        private static void DrawZigZagLine<TQuote>(List<ZigZagResult> results, List<TQuote> historyList,
+            ZigZagPoint lastPoint, ZigZagPoint nextPoint) where TQuote : IQuote
         {
 
             decimal increment = (nextPoint.Value - lastPoint.Value) / (nextPoint.Index - lastPoint.Index);
@@ -180,7 +180,7 @@ namespace Skender.Stock.Indicators
             // add new line segment
             for (int i = lastPoint.Index; i < nextPoint.Index; i++)
             {
-                Quote h = historyList[i];
+                TQuote h = historyList[i];
                 int index = i + 1;
 
                 ZigZagResult result = new ZigZagResult
@@ -253,7 +253,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static ZigZagEval GetZigZagEval(ZigZagType type, int index, Quote q)
+        private static ZigZagEval GetZigZagEval<TQuote>(ZigZagType type, int index, TQuote q) where TQuote : IQuote
         {
             ZigZagEval eval = new ZigZagEval()
             {
@@ -280,7 +280,7 @@ namespace Skender.Stock.Indicators
         }
 
 
-        private static void ValidateZigZag(IEnumerable<Quote> history, decimal percentChange)
+        private static void ValidateZigZag<TQuote>(IEnumerable<TQuote> history, decimal percentChange) where TQuote : IQuote
         {
 
             // check parameters

--- a/indicators/_Common/Cleaners.cs
+++ b/indicators/_Common/Cleaners.cs
@@ -11,17 +11,17 @@ namespace Skender.Stock.Indicators
     {
         private static readonly CultureInfo nativeCulture = Thread.CurrentThread.CurrentUICulture;
 
-        public static List<Quote> ValidateHistory(IEnumerable<Quote> history)
+        public static List<TQuote> ValidateHistory<TQuote>(IEnumerable<TQuote> history) where TQuote : IQuote
         {
             // we cannot rely on date consistency when looking back, so we add an index and sort
 
-            List<Quote> historyList = history.Sort();
+            List<TQuote> historyList = history.Sort();
 
             // check for duplicates
             DateTime lastDate = DateTime.MinValue;
             for (int i = 0; i < historyList.Count; i++)
             {
-                Quote h = historyList[i];
+                TQuote h = historyList[i];
 
                 if (lastDate == h.Date)
                 {
@@ -35,9 +35,9 @@ namespace Skender.Stock.Indicators
             return historyList;
         }
 
-        internal static List<Quote> Sort(this IEnumerable<Quote> history)
+        internal static List<TQuote> Sort<TQuote>(this IEnumerable<TQuote> history) where TQuote : IQuote
         {
-            List<Quote> historyList = history.OrderBy(x => x.Date).ToList();
+            List<TQuote> historyList = history.OrderBy(x => x.Date).ToList();
 
             // validate
             if (historyList == null || historyList.Count == 0)
@@ -48,7 +48,7 @@ namespace Skender.Stock.Indicators
             return historyList;
         }
 
-        internal static List<BasicData> ConvertHistoryToBasic(IEnumerable<Quote> history, string element = "C")
+        internal static List<BasicData> ConvertHistoryToBasic<TQuote>(IEnumerable<TQuote> history, string element = "C") where TQuote : IQuote
         {
             // elements represents the targeted OHLCV parts, so use "O" to return <Open> as base data, etc.
             // convert to basic data format

--- a/indicators/_Common/Models.cs
+++ b/indicators/_Common/Models.cs
@@ -4,12 +4,12 @@ namespace Skender.Stock.Indicators
 {
     public interface IQuote
     {
-        decimal Close { get; set; }
-        DateTime Date { get; set; }
-        decimal High { get; set; }
-        decimal Low { get; set; }
-        decimal Open { get; set; }
-        decimal Volume { get; set; }
+        public DateTime Date { get; set; }
+        public decimal Open { get; set; }
+        public decimal High { get; set; }
+        public decimal Low { get; set; }
+        public decimal Close { get; set; }
+        public decimal Volume { get; set; }
     }
 
     [Serializable]

--- a/indicators/_Common/Models.cs
+++ b/indicators/_Common/Models.cs
@@ -2,8 +2,18 @@
 
 namespace Skender.Stock.Indicators
 {
+    public interface IQuote
+    {
+        decimal Close { get; set; }
+        DateTime Date { get; set; }
+        decimal High { get; set; }
+        decimal Low { get; set; }
+        decimal Open { get; set; }
+        decimal Volume { get; set; }
+    }
+
     [Serializable]
-    public class Quote
+    public class Quote : IQuote
     {
         public DateTime Date { get; set; }
         public decimal Open { get; set; }

--- a/indicators/_Common/Models.cs
+++ b/indicators/_Common/Models.cs
@@ -4,12 +4,12 @@ namespace Skender.Stock.Indicators
 {
     public interface IQuote
     {
-        public DateTime Date { get; set; }
-        public decimal Open { get; set; }
-        public decimal High { get; set; }
-        public decimal Low { get; set; }
-        public decimal Close { get; set; }
-        public decimal Volume { get; set; }
+        public DateTime Date { get; }
+        public decimal Open { get; }
+        public decimal High { get; }
+        public decimal Low { get; }
+        public decimal Close { get; }
+        public decimal Volume { get; }
     }
 
     [Serializable]

--- a/tests/external/Test.PublicClass.cs
+++ b/tests/external/Test.PublicClass.cs
@@ -19,13 +19,28 @@ namespace External.Tests
         public float MyEma { get; set; }
     }
 
+    public class MyGenericQuote : IQuote
+    {
+        // required base properties
+        DateTime IQuote.Date => CloseDate;
+        public decimal Open { get; set; }
+        public decimal High { get; set; }
+        public decimal Low { get; set; }
+        public decimal Close { get; set; }
+        public decimal Volume { get; set; }
+
+        // custom properties
+        public int MyOtherProperty { get; set; }
+        public DateTime CloseDate { get; set; }
+    }
+
 
     [TestClass]
     public class PublicClassTests
     {
 
         [TestMethod()]
-        public void CleanHistory()
+        public void ValidateHistory()
         {
             IEnumerable<Quote> history = History.GetHistory();
             history = Cleaners.ValidateHistory(history);
@@ -73,6 +88,25 @@ namespace External.Tests
                 });
 
             Assert.IsTrue(myHistory.Any());
+        }
+
+        [TestMethod()]
+        public void CustomQuoteClass()
+        {
+            IEnumerable<MyGenericQuote> myGenericHistory = History.GetHistory()
+                .Select(x => new MyGenericQuote
+                {
+                    CloseDate = x.Date,
+                    Open = x.Open,
+                    High = x.High,
+                    Low = x.Low,
+                    Close = x.Close,
+                    Volume = x.Volume,
+                    MyOtherProperty = 123456
+                });
+
+            IEnumerable<EmaResult> emaResults = Indicator.GetEma(myGenericHistory, 14);
+            Assert.IsTrue(emaResults.Any());
         }
 
         [TestMethod()]

--- a/tests/external/Test.PublicClass.cs
+++ b/tests/external/Test.PublicClass.cs
@@ -26,12 +26,13 @@ namespace External.Tests
         public decimal Open { get; set; }
         public decimal High { get; set; }
         public decimal Low { get; set; }
-        public decimal Close { get; set; }
+        decimal IQuote.Close => CloseValue;
         public decimal Volume { get; set; }
 
         // custom properties
         public int MyOtherProperty { get; set; }
         public DateTime CloseDate { get; set; }
+        public decimal CloseValue { get; set; }
     }
 
 
@@ -93,20 +94,38 @@ namespace External.Tests
         [TestMethod()]
         public void CustomQuoteClass()
         {
-            IEnumerable<MyGenericQuote> myGenericHistory = History.GetHistory()
+            List<MyGenericQuote> myGenericHistory = History.GetHistory()
                 .Select(x => new MyGenericQuote
                 {
                     CloseDate = x.Date,
                     Open = x.Open,
                     High = x.High,
                     Low = x.Low,
-                    Close = x.Close,
+                    CloseValue = x.Close,
                     Volume = x.Volume,
                     MyOtherProperty = 123456
-                });
+                })
+                .ToList();
 
-            IEnumerable<EmaResult> emaResults = Indicator.GetEma(myGenericHistory, 14);
-            Assert.IsTrue(emaResults.Any());
+            List<EmaResult> results = Indicator.GetEma(myGenericHistory, 20)
+                .ToList();
+
+            // assertions
+
+            // proper quantities
+            // should always be the same number of results as there is history
+            Assert.AreEqual(502, results.Count);
+            Assert.AreEqual(483, results.Where(x => x.Ema != null).Count());
+
+            // sample values
+            EmaResult r1 = results[501];
+            Assert.AreEqual(249.3519m, Math.Round((decimal)r1.Ema, 4));
+
+            EmaResult r2 = results[249];
+            Assert.AreEqual(255.3873m, Math.Round((decimal)r2.Ema, 4));
+
+            EmaResult r3 = results[29];
+            Assert.AreEqual(216.6228m, Math.Round((decimal)r3.Ema, 4));
         }
 
         [TestMethod()]

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -1,4 +1,4 @@
-# Performance benchmarks for v1.1.7
+# Performance benchmarks for v1.2.0
 
 These are the execution times for the current indicators using two years of historical daily stock quotes (502 periods) with default or typical parameters.
 
@@ -14,61 +14,61 @@ Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical co
 
 |             Method |        Mean |     Error |    StdDev |      Median |
 |------------------- |------------:|----------:|----------:|------------:|
-|             GetAdl |   137.24 μs |  1.534 μs |  1.281 μs |   137.30 μs |
-|      GetAdlWithSma |   376.36 μs |  5.379 μs |  4.768 μs |   374.32 μs |
-|             GetAdx |   745.02 μs | 10.035 μs |  8.896 μs |   743.31 μs |
-|           GetAroon |   293.20 μs |  3.375 μs |  2.992 μs |   292.89 μs |
-|             GetAtr |   156.83 μs |  1.939 μs |  1.813 μs |   156.16 μs |
-|            GetBeta |   936.10 μs | 18.649 μs | 47.468 μs |   917.91 μs |
-|  GetBollingerBands |   421.22 μs |  2.632 μs |  2.198 μs |   420.23 μs |
-|             GetCci |   938.87 μs | 18.736 μs | 38.692 μs |   947.69 μs |
-|      GetChaikinOsc |   261.66 μs |  2.004 μs |  1.777 μs |   260.88 μs |
-|      GetChandelier |   347.84 μs |  4.633 μs |  5.149 μs |   344.90 μs |
-|             GetCmf |   650.66 μs | 11.334 μs | 10.048 μs |   645.57 μs |
-|      GetConnorsRsi | 1,239.76 μs | 19.696 μs | 22.682 μs | 1,226.99 μs |
-|     GetCorrelation |   798.39 μs |  8.640 μs |  7.659 μs |   795.42 μs |
-|        GetDonchian |   311.99 μs |  3.047 μs |  2.702 μs |   311.41 μs |
-|       GetDoubleEma |   187.94 μs |  3.722 μs |  7.519 μs |   183.50 μs |
-|             GetEma |    99.38 μs |  0.982 μs |  0.919 μs |    98.93 μs |
-|      GetHeikinAshi |   168.49 μs |  0.527 μs |  0.467 μs |   168.40 μs |
-|             GetHma | 1,376.12 μs | 14.132 μs | 13.219 μs | 1,371.61 μs |
-|        GetIchimoku |   791.79 μs | 10.578 μs |  9.895 μs |   786.88 μs |
-|         GetKeltner |   464.88 μs |  3.340 μs |  3.124 μs |   463.44 μs |
-|            GetMacd |   301.04 μs |  1.449 μs |  1.284 μs |   300.77 μs |
-|             GetMfi |   483.38 μs |  5.222 μs |  4.884 μs |   482.29 μs |
-|             GetObv |    57.22 μs |  0.360 μs |  0.301 μs |    57.12 μs |
-|      GetObvWithSma |   140.01 μs |  2.717 μs |  3.627 μs |   141.21 μs |
-|    GetParabolicSar |    92.30 μs |  0.940 μs |  0.785 μs |    92.00 μs |
-|             GetPmo |   256.93 μs |  1.358 μs |  1.271 μs |   256.58 μs |
-|             GetPrs |   124.44 μs |  1.214 μs |  1.136 μs |   124.66 μs |
-|      GetPrsWithSma |   182.98 μs |  3.401 μs |  3.340 μs |   181.38 μs |
-|             GetRoc |    90.65 μs |  1.727 μs |  1.848 μs |    89.81 μs |
-|      GetRocWithSma |   303.77 μs |  2.919 μs |  2.730 μs |   302.55 μs |
-|             GetRsi |   342.30 μs |  3.700 μs |  3.461 μs |   341.25 μs |
-|           GetSlope |   853.82 μs |  8.382 μs |  7.840 μs |   848.86 μs |
-|             GetSma |   103.24 μs |  0.947 μs |  0.839 μs |   102.81 μs |
-|     GetSmaExtended |   823.31 μs |  9.011 μs |  8.429 μs |   818.74 μs |
-|          GetStdDev |   286.72 μs |  1.441 μs |  1.203 μs |   286.63 μs |
-|   GetStdDevWithSma |   374.83 μs |  3.881 μs |  3.440 μs |   374.10 μs |
-|           GetStoch |   341.61 μs |  3.872 μs |  3.622 μs |   339.28 μs |
-|        GetStochRsi |   649.50 μs |  2.592 μs |  2.297 μs |   649.88 μs |
-|       GetTripleEma |   264.51 μs |  1.983 μs |  1.758 μs |   263.68 μs |
-|            GetTrix |   325.91 μs |  1.490 μs |  1.244 μs |   325.41 μs |
-|     GetTrixWithSma |   386.88 μs |  3.600 μs |  3.367 μs |   387.34 μs |
-|      GetUlcerIndex | 1,362.65 μs | 21.196 μs | 17.700 μs | 1,353.32 μs |
-|        GetUltimate |   583.55 μs |  2.676 μs |  2.089 μs |   583.80 μs |
-|          GetVolSma |   116.47 μs |  1.187 μs |  1.110 μs |   116.11 μs |
-|       GetWilliamsR |   257.74 μs |  0.407 μs |  0.340 μs |   257.77 μs |
-|             GetWma |   742.48 μs |  8.612 μs |  8.056 μs |   737.53 μs |
-|          GetZigZag |   138.55 μs |  0.722 μs |  0.603 μs |   138.42 μs |
+|             GetAdl |   145.86 μs |  1.167 μs |  0.975 μs |   145.81 μs |
+|      GetAdlWithSma |   386.60 μs |  3.934 μs |  3.680 μs |   385.25 μs |
+|             GetAdx |   748.81 μs |  5.807 μs |  5.148 μs |   746.60 μs |
+|           GetAroon |   348.75 μs |  6.633 μs |  6.204 μs |   346.48 μs |
+|             GetAtr |   158.31 μs |  0.361 μs |  0.282 μs |   158.26 μs |
+|            GetBeta |   991.38 μs |  7.127 μs |  6.667 μs |   988.38 μs |
+|  GetBollingerBands |   470.79 μs |  8.007 μs | 13.155 μs |   464.10 μs |
+|             GetCci |   901.68 μs | 14.738 μs | 13.786 μs |   899.12 μs |
+|      GetChaikinOsc |   271.32 μs |  3.455 μs |  3.063 μs |   270.74 μs |
+|      GetChandelier |   369.23 μs |  4.169 μs |  3.899 μs |   367.52 μs |
+|             GetCmf |   676.63 μs |  6.819 μs |  6.378 μs |   676.22 μs |
+|      GetConnorsRsi | 1,228.35 μs | 13.353 μs | 11.837 μs | 1,222.89 μs |
+|     GetCorrelation |   905.19 μs |  8.713 μs |  8.557 μs |   901.41 μs |
+|        GetDonchian |   380.03 μs |  9.039 μs | 24.127 μs |   375.37 μs |
+|       GetDoubleEma |   193.67 μs |  3.806 μs |  7.512 μs |   192.17 μs |
+|             GetEma |   107.79 μs |  1.051 μs |  0.983 μs |   107.62 μs |
+|      GetHeikinAshi |   187.63 μs |  3.678 μs |  5.505 μs |   185.66 μs |
+|             GetHma | 1,473.86 μs | 18.819 μs | 15.714 μs | 1,467.52 μs |
+|        GetIchimoku | 1,005.75 μs |  1.881 μs |  1.468 μs | 1,006.13 μs |
+|         GetKeltner |   475.64 μs |  6.446 μs |  6.619 μs |   473.79 μs |
+|            GetMacd |   318.17 μs |  6.602 μs | 18.941 μs |   307.08 μs |
+|             GetMfi |   499.35 μs |  9.119 μs | 17.786 μs |   489.52 μs |
+|             GetObv |    61.98 μs |  0.419 μs |  0.372 μs |    61.89 μs |
+|      GetObvWithSma |   137.18 μs |  0.336 μs |  0.281 μs |   137.24 μs |
+|    GetParabolicSar |    95.59 μs |  0.738 μs |  0.616 μs |    95.41 μs |
+|             GetPmo |   264.77 μs |  0.737 μs |  0.616 μs |   264.56 μs |
+|             GetPrs |   133.95 μs |  0.880 μs |  0.780 μs |   133.74 μs |
+|      GetPrsWithSma |   221.04 μs |  4.194 μs |  9.635 μs |   219.82 μs |
+|             GetRoc |   101.99 μs |  0.850 μs |  0.710 μs |   101.88 μs |
+|      GetRocWithSma |   381.61 μs |  7.324 μs |  9.523 μs |   378.57 μs |
+|             GetRsi |   366.58 μs |  6.997 μs |  9.578 μs |   363.40 μs |
+|           GetSlope |   907.30 μs | 12.244 μs | 10.225 μs |   903.66 μs |
+|             GetSma |   111.67 μs |  1.745 μs |  2.077 μs |   110.69 μs |
+|     GetSmaExtended |   909.31 μs | 10.283 μs |  9.115 μs |   905.78 μs |
+|          GetStdDev |   294.74 μs |  1.719 μs |  1.435 μs |   294.28 μs |
+|   GetStdDevWithSma |   384.92 μs |  3.834 μs |  3.586 μs |   383.55 μs |
+|           GetStoch |   381.52 μs |  1.546 μs |  1.291 μs |   381.54 μs |
+|        GetStochRsi |   692.48 μs | 10.243 μs |  9.581 μs |   686.51 μs |
+|       GetTripleEma |   267.39 μs |  1.703 μs |  1.509 μs |   266.97 μs |
+|            GetTrix |   340.33 μs |  6.789 μs |  9.737 μs |   344.31 μs |
+|     GetTrixWithSma |   388.53 μs |  3.513 μs |  3.286 μs |   386.77 μs |
+|      GetUlcerIndex | 1,551.25 μs | 20.299 μs | 18.988 μs | 1,542.66 μs |
+|        GetUltimate |   602.90 μs |  7.759 μs |  6.879 μs |   600.57 μs |
+|          GetVolSma |   119.89 μs |  0.693 μs |  0.579 μs |   119.70 μs |
+|       GetWilliamsR |   287.91 μs |  0.556 μs |  0.464 μs |   287.93 μs |
+|             GetWma |   747.89 μs |  8.326 μs |  7.381 μs |   745.02 μs |
+|          GetZigZag |   146.63 μs |  0.746 μs |  0.623 μs |   146.49 μs |
 
 ## internal cleaners
 
 |             Method |     Mean |    Error |   StdDev |   Median |
 |------------------- |---------:|---------:|---------:|---------:|
-|        SortHistory | 37.42 μs | 0.702 μs | 0.751 μs | 37.33 μs |
-|    ValidateHistory | 37.37 μs | 0.361 μs | 0.337 μs | 37.42 μs |
-| ConvertToBasicData | 44.66 μs | 1.066 μs | 3.025 μs | 43.16 μs |
+|        SortHistory | 37.69 μs | 0.614 μs | 0.544 μs | 37.50 μs |
+|    ValidateHistory | 40.63 μs | 0.769 μs | 1.306 μs | 40.04 μs |
+| ConvertToBasicData | 44.88 μs | 0.862 μs | 0.806 μs | 44.56 μs |
 
 ## internal math functions
 


### PR DESCRIPTION
all indicators makes use of generics and IQuote
implements #179 

Tests aren't affected because works as they were out of the box

Documentation need to be updated

With this change we are no forced to use the built in `Quote` type so we can use our own models (that have to implement the IQuote interface)

performance wise is good to have to cast or convert objects to use indicators (this mean that even memory allocation is saved in such scenarios)