### PR TITLE
chore: unit test naming consistency

### DIFF
--- a/tests/indicators/Test.Adl.cs
+++ b/tests/indicators/Test.Adl.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetAdl()
+        public void Standard()
         {
 
             List<AdlResult> results = Indicator.GetAdl(history).ToList();
@@ -37,14 +37,14 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetAdlBadData()
+        public void BadData()
         {
             IEnumerable<AdlResult> r = Indicator.GetAdl(historyBad);
             Assert.AreEqual(502, r.Count());
         }
 
         [TestMethod()]
-        public void GetAdlWithSma()
+        public void WithSma()
         {
 
             List<AdlResult> results = Indicator.GetAdl(history, 20).ToList();

--- a/tests/indicators/Test.Alma.cs
+++ b/tests/indicators/Test.Alma.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetAlma()
+        public void Standard()
         {
             int lookbackPeriod = 10;
             double offset = 0.85;
@@ -48,7 +48,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetAlmaBadData()
+        public void BadData()
         {
             IEnumerable<AlmaResult> r = Indicator.GetAlma(historyBad, 14, 0.5, 3);
             Assert.AreEqual(502, r.Count());

--- a/tests/indicators/Test.Aroon.cs
+++ b/tests/indicators/Test.Aroon.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetAroon()
+        public void Standard()
         {
             int lookbackPeriod = 25;
             List<AroonResult> results = Indicator.GetAroon(history, lookbackPeriod).ToList();
@@ -53,7 +53,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetAroonBadData()
+        public void BadData()
         {
             IEnumerable<AroonResult> r = Indicator.GetAroon(historyBad, 20);
             Assert.AreEqual(502, r.Count());

--- a/tests/indicators/Test.Beta.cs
+++ b/tests/indicators/Test.Beta.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetBeta()
+        public void Standard()
         {
             int lookbackPeriod = 20;
             List<BetaResult> results = Indicator.GetBeta(history, historyOther, lookbackPeriod).ToList();
@@ -29,14 +29,14 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetBetaBadData()
+        public void BadData()
         {
             IEnumerable<BetaResult> r = Indicator.GetBeta(historyBad, historyBad, 15);
             Assert.AreEqual(502, r.Count());
         }
 
         [TestMethod()]
-        public void GetBetaSame()
+        public void SameSame()
         {
             // Beta should be 1 if evaluating against self
             int lookbackPeriod = 20;

--- a/tests/indicators/Test.BollingerBands.cs
+++ b/tests/indicators/Test.BollingerBands.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetBollingerBands()
+        public void Standard()
         {
             int lookbackPeriod = 20;
             int standardDeviations = 2;
@@ -52,7 +52,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetBollingerBandsBadData()
+        public void BadData()
         {
             IEnumerable<BollingerBandsResult> r = Indicator.GetBollingerBands(historyBad, 15, 3);
             Assert.AreEqual(502, r.Count());

--- a/tests/indicators/Test.Cci.cs
+++ b/tests/indicators/Test.Cci.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetCci()
+        public void Standard()
         {
             int lookbackPeriod = 20;
 
@@ -30,7 +30,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetCciBadData()
+        public void BadData()
         {
             IEnumerable<CciResult> r = Indicator.GetCci(historyBad, 15);
             Assert.AreEqual(502, r.Count());

--- a/tests/indicators/Test.Chandelier.cs
+++ b/tests/indicators/Test.Chandelier.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetChandlier()
+        public void Standard()
         {
             int lookbackPeriod = 22;
             List<ChandelierResult> longResult =
@@ -42,7 +42,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetChandlierBadData()
+        public void BadData()
         {
             IEnumerable<ChandelierResult> r = Indicator.GetChandelier(historyBad, 15, 2m);
             Assert.AreEqual(502, r.Count());

--- a/tests/indicators/Test.Cmf.cs
+++ b/tests/indicators/Test.Cmf.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetCmf()
+        public void Standard()
         {
             int lookbackPeriod = 20;
             List<CmfResult> results = Indicator.GetCmf(history, lookbackPeriod).ToList();
@@ -40,7 +40,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetCmfBadData()
+        public void BadData()
         {
             IEnumerable<CmfResult> r = Indicator.GetCmf(historyBad, 15);
             Assert.AreEqual(502, r.Count());

--- a/tests/indicators/Test.Correlation.cs
+++ b/tests/indicators/Test.Correlation.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetCorrelation()
+        public void Standard()
         {
             int lookbackPeriod = 20;
             List<CorrResult> results =
@@ -32,7 +32,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetCorrelationBadData()
+        public void BadData()
         {
             IEnumerable<CorrResult> r = Indicator.GetCorrelation(historyBad, historyBad, 15);
             Assert.AreEqual(502, r.Count());
@@ -67,7 +67,7 @@ namespace Internal.Tests
 
         [TestMethod()]
         [ExpectedException(typeof(BadHistoryException), "Mismatch history.")]
-        public void GetCorrelationMismatchTest()
+        public void MismatchHistory()
         {
             IEnumerable<Quote> historyMismatch = History.GetHistoryWithMismatchDates();
             Indicator.GetCorrelation(historyMismatch, historyOther, 20);

--- a/tests/indicators/Test.Donchian.cs
+++ b/tests/indicators/Test.Donchian.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetDonchian()
+        public void Standard()
         {
             int lookbackPeriod = 20;
             List<DonchianResult> results = Indicator.GetDonchian(history, lookbackPeriod).ToList();
@@ -41,7 +41,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetDonchianBadData()
+        public void BadData()
         {
             IEnumerable<DonchianResult> r = Indicator.GetDonchian(historyBad, 15);
             Assert.AreEqual(502, r.Count());

--- a/tests/indicators/Test.DoubleEma.cs
+++ b/tests/indicators/Test.DoubleEma.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetDoubleEma()
+        public void Standard()
         {
             int lookbackPeriod = 20;
             List<EmaResult> results = Indicator.GetDoubleEma(history, lookbackPeriod).ToList();
@@ -35,14 +35,14 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetDoubleEmaBadData()
+        public void BadData()
         {
             IEnumerable<EmaResult> r = Indicator.GetDoubleEma(historyBad, 15);
             Assert.AreEqual(502, r.Count());
         }
 
         [TestMethod()]
-        public void GetDemaConvergence()
+        public void Convergence()
         {
             foreach (int qty in convergeQuantities)
             {

--- a/tests/indicators/Test.Fractal.cs
+++ b/tests/indicators/Test.Fractal.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetFractal()
+        public void Standard()
         {
             List<FractalResult> results = Indicator.GetFractal(history)
                 .ToList();
@@ -56,7 +56,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetFractalBadData()
+        public void BadData()
         {
             IEnumerable<FractalResult> r = Indicator.GetFractal(historyBad);
             Assert.AreEqual(502, r.Count());

--- a/tests/indicators/Test.HeikinAshi.cs
+++ b/tests/indicators/Test.HeikinAshi.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetHeikinAshi()
+        public void Standard()
         {
 
             List<HeikinAshiResult> results = Indicator.GetHeikinAshi(history).ToList();
@@ -30,7 +30,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetHeikinAshiBadData()
+        public void BadData()
         {
             IEnumerable<HeikinAshiResult> r = Indicator.GetHeikinAshi(historyBad);
             Assert.AreEqual(502, r.Count());

--- a/tests/indicators/Test.Hma.cs
+++ b/tests/indicators/Test.Hma.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetHma()
+        public void Standard()
         {
             int lookbackPeriod = 20;
             List<HmaResult> results = Indicator.GetHma(history, lookbackPeriod).ToList();
@@ -32,7 +32,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetHmaBadData()
+        public void BadData()
         {
             IEnumerable<HmaResult> r = Indicator.GetHma(historyBad, 15);
             Assert.AreEqual(502, r.Count());

--- a/tests/indicators/Test.Ichimoku.cs
+++ b/tests/indicators/Test.Ichimoku.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetIchimoku()
+        public void Standard()
         {
             int signalPeriod = 9;
             int shortSpanPeriod = 26;
@@ -63,7 +63,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetIchimokuBadData()
+        public void BadData()
         {
             IEnumerable<IchimokuResult> r = Indicator.GetIchimoku(historyBad, 8, 20, 35);
             Assert.AreEqual(502, r.Count());

--- a/tests/indicators/Test.Mfi.cs
+++ b/tests/indicators/Test.Mfi.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetMfi()
+        public void Standard()
         {
             int lookbackPeriod = 14;
             List<MfiResult> results = Indicator.GetMfi(history, lookbackPeriod).ToList();
@@ -32,14 +32,14 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetMfiBadData()
+        public void BadData()
         {
             IEnumerable<MfiResult> r = Indicator.GetMfi(historyBad, 15);
             Assert.AreEqual(502, r.Count());
         }
 
         [TestMethod()]
-        public void GetMfiSmall()
+        public void SmallLookback()
         {
             int lookbackPeriod = 4;
             List<MfiResult> results = Indicator.GetMfi(history, lookbackPeriod).ToList();

--- a/tests/indicators/Test.Obv.cs
+++ b/tests/indicators/Test.Obv.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetObv()
+        public void Standard()
         {
 
             List<ObvResult> results = Indicator.GetObv(history).ToList();
@@ -33,14 +33,14 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetObvBadData()
+        public void BadData()
         {
             IEnumerable<ObvResult> r = Indicator.GetObv(historyBad);
             Assert.AreEqual(502, r.Count());
         }
 
         [TestMethod()]
-        public void GetObvWithSma()
+        public void WithSma()
         {
 
             List<ObvResult> results = Indicator.GetObv(history, 20).ToList();

--- a/tests/indicators/Test.ParabolicSar.cs
+++ b/tests/indicators/Test.ParabolicSar.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetParabolicSar()
+        public void Standard()
         {
             decimal acclerationStep = (decimal)0.02;
             decimal maxAccelerationFactor = (decimal)0.2;
@@ -42,7 +42,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetParabolicSarBadData()
+        public void BadData()
         {
             IEnumerable<ParabolicSarResult> r = Indicator.GetParabolicSar(historyBad);
             Assert.AreEqual(502, r.Count());

--- a/tests/indicators/Test.PivotPoints.cs
+++ b/tests/indicators/Test.PivotPoints.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetPivotPointsStandard()
+        public void Standard()
         {
             PeriodSize periodSize = PeriodSize.Month;
             PivotPointType pointType = PivotPointType.Standard;
@@ -99,7 +99,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetPivotPointsCamarilla()
+        public void Camarilla()
         {
             PeriodSize periodSize = PeriodSize.Week;
             PivotPointType pointType = PivotPointType.Camarilla;
@@ -173,7 +173,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetPivotPointsDemark()
+        public void Demark()
         {
             PeriodSize periodSize = PeriodSize.Month;
             PivotPointType pointType = PivotPointType.Demark;
@@ -257,7 +257,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetPivotPointsFibonacci()
+        public void Fibonacci()
         {
             PeriodSize periodSize = PeriodSize.Hour;
             PivotPointType pointType = PivotPointType.Fibonacci;
@@ -332,7 +332,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetPivotPointsWoodie()
+        public void Woodie()
         {
             PeriodSize periodSize = PeriodSize.Day;
             PivotPointType pointType = PivotPointType.Woodie;
@@ -399,7 +399,7 @@ namespace Internal.Tests
 
 
         [TestMethod()]
-        public void GetPivotPointsBadData()
+        public void BadData()
         {
             IEnumerable<PivotPointsResult> r = Indicator.GetPivotPoints(historyBad, PeriodSize.Week);
             Assert.AreEqual(502, r.Count());

--- a/tests/indicators/Test.Prs.cs
+++ b/tests/indicators/Test.Prs.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetPrs()
+        public void Standard()
         {
             int lookbackPeriod = 30;
             int smaPeriod = 10;
@@ -46,7 +46,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetPrsBadData()
+        public void BadData()
         {
             IEnumerable<PrsResult> r = Indicator.GetPrs(historyBad, historyBad, 15, 4);
             Assert.AreEqual(502, r.Count());

--- a/tests/indicators/Test.Roc.cs
+++ b/tests/indicators/Test.Roc.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetRoc()
+        public void Standard()
         {
             int lookbackPeriod = 20;
             List<RocResult> results = Indicator.GetRoc(history, lookbackPeriod).ToList();
@@ -35,14 +35,14 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetRocBadData()
+        public void BadData()
         {
             IEnumerable<RocResult> r = Indicator.GetRoc(historyBad, 35, 2);
             Assert.AreEqual(502, r.Count());
         }
 
         [TestMethod()]
-        public void GetRocWithSma()
+        public void WithSma()
         {
             int lookbackPeriod = 20;
             int smaPeriod = 5;

--- a/tests/indicators/Test.Rsi.cs
+++ b/tests/indicators/Test.Rsi.cs
@@ -45,7 +45,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void SmallRsi()
+        public void SmallLookback()
         {
             int lookbackPeriod = 1;
             List<RsiResult> results = Indicator.GetRsi(history, lookbackPeriod).ToList();

--- a/tests/indicators/Test.Slope.cs
+++ b/tests/indicators/Test.Slope.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetSlope()
+        public void Standard()
         {
             int lookbackPeriod = 20;
             List<SlopeResult> results = Indicator.GetSlope(history, lookbackPeriod).ToList();
@@ -49,7 +49,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetSlopeBadData()
+        public void BadData()
         {
             IEnumerable<SlopeResult> r = Indicator.GetSlope(historyBad, 15);
             Assert.AreEqual(502, r.Count());

--- a/tests/indicators/Test.Sma.cs
+++ b/tests/indicators/Test.Sma.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetSma()
+        public void Standard()
         {
             int lookbackPeriod = 20;
             List<SmaResult> results = Indicator.GetSma(history, lookbackPeriod, true).ToList();
@@ -32,7 +32,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetSmaBadData()
+        public void BadData()
         {
             IEnumerable<SmaResult> r = Indicator.GetSma(historyBad, 15, true);
             Assert.AreEqual(502, r.Count());

--- a/tests/indicators/Test.StdDev.cs
+++ b/tests/indicators/Test.StdDev.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetStdDev()
+        public void Standard()
         {
             int lookbackPeriod = 10;
             List<StdDevResult> results = Indicator.GetStdDev(history, lookbackPeriod).ToList();
@@ -53,7 +53,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetStdDevBadData()
+        public void BadData()
         {
             IEnumerable<StdDevResult> r = Indicator.GetStdDev(historyBad, 15, 3);
             Assert.AreEqual(502, r.Count());

--- a/tests/indicators/Test.Stoch.cs
+++ b/tests/indicators/Test.Stoch.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetStochStandard()
+        public void Standard()
         {
             int lookbackPeriod = 14;
             int signalPeriod = 3;
@@ -36,14 +36,14 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetStochBadData()
+        public void BadData()
         {
             IEnumerable<StochResult> r = Indicator.GetStoch(historyBad, 15);
             Assert.AreEqual(502, r.Count());
         }
 
         [TestMethod()]
-        public void GetStochNoSignal()
+        public void NoSignal()
         {
             int lookbackPeriod = 5;
             int signalPeriod = 1;
@@ -62,7 +62,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetStochFast()
+        public void Fast()
         {
             int lookbackPeriod = 5;
             int signalPeriod = 10;
@@ -83,7 +83,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetStochFastSmall()
+        public void FastSmall()
         {
             int lookbackPeriod = 1;
             int signalPeriod = 10;

--- a/tests/indicators/Test.SuperTrend.cs
+++ b/tests/indicators/Test.SuperTrend.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetSuperTrend()
+        public void Standard()
         {
             int lookbackPeriod = 14;
             decimal multiplier = 3;
@@ -58,7 +58,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetSuperTrendBadData()
+        public void BadData()
         {
             IEnumerable<SuperTrendResult> r = Indicator.GetSuperTrend(historyBad, 7);
             Assert.AreEqual(502, r.Count());

--- a/tests/indicators/Test.TripleEma.cs
+++ b/tests/indicators/Test.TripleEma.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetTripleEma()
+        public void Standard()
         {
             int lookbackPeriod = 20;
             List<EmaResult> results = Indicator.GetTripleEma(history, lookbackPeriod).ToList();
@@ -35,14 +35,14 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetTripleEmaBadData()
+        public void BadData()
         {
             IEnumerable<EmaResult> r = Indicator.GetTripleEma(historyBad, 15);
             Assert.AreEqual(502, r.Count());
         }
 
         [TestMethod()]
-        public void GetTemaConvergence()
+        public void Convergence()
         {
             foreach (int qty in convergeQuantities)
             {

--- a/tests/indicators/Test.UlcerIndex.cs
+++ b/tests/indicators/Test.UlcerIndex.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetUlcerIndex()
+        public void Standard()
         {
             int lookbackPeriod = 14;
             List<UlcerIndexResult> results = Indicator.GetUlcerIndex(history, lookbackPeriod).ToList();
@@ -29,7 +29,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetUlcerIndexBadData()
+        public void BadData()
         {
             IEnumerable<UlcerIndexResult> r = Indicator.GetUlcerIndex(historyBad, 15);
             Assert.AreEqual(502, r.Count());

--- a/tests/indicators/Test.Ultimate.cs
+++ b/tests/indicators/Test.Ultimate.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetUltimate()
+        public void Standard()
         {
             List<UltimateResult> results = Indicator.GetUltimate(history, 7, 14, 28).ToList();
 
@@ -35,7 +35,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetUltimateBadData()
+        public void BadData()
         {
             IEnumerable<UltimateResult> r = Indicator.GetUltimate(historyBad, 1, 2, 3);
             Assert.AreEqual(502, r.Count());

--- a/tests/indicators/Test.VolSma.cs
+++ b/tests/indicators/Test.VolSma.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetVolSma()
+        public void Standard()
         {
             int lookbackPeriod = 20;
             List<VolSmaResult> results = Indicator.GetVolSma(history, lookbackPeriod).ToList();
@@ -37,7 +37,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetVolSmaBadData()
+        public void BadData()
         {
             IEnumerable<VolSmaResult> r = Indicator.GetVolSma(historyBad, 15);
             Assert.AreEqual(502, r.Count());

--- a/tests/indicators/Test.WilliamsR.cs
+++ b/tests/indicators/Test.WilliamsR.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetWilliamsR()
+        public void Standard()
         {
             int lookbackPeriod = 14;
             List<WilliamsResult> results = Indicator.GetWilliamsR(history, lookbackPeriod).ToList();
@@ -32,7 +32,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetWilliamsRBadData()
+        public void BadData()
         {
             IEnumerable<WilliamsResult> r = Indicator.GetWilliamsR(historyBad, 20);
             Assert.AreEqual(502, r.Count());

--- a/tests/indicators/Test.Wma.cs
+++ b/tests/indicators/Test.Wma.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetWma()
+        public void Standard()
         {
             int lookbackPeriod = 20;
             List<WmaResult> results = Indicator.GetWma(history, lookbackPeriod).ToList();
@@ -32,7 +32,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetWmaBadData()
+        public void BadData()
         {
             IEnumerable<WmaResult> r = Indicator.GetWma(historyBad, 15);
             Assert.AreEqual(502, r.Count());

--- a/tests/indicators/Test.ZigZag.cs
+++ b/tests/indicators/Test.ZigZag.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void GetZigZagClose()
+        public void StandardClose()
         {
             decimal percentChange = 3;
             List<ZigZagResult> results =
@@ -67,7 +67,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetZigZagHighLow()
+        public void StandardHighLow()
         {
             decimal percentChange = 3;
             List<ZigZagResult> results =
@@ -123,7 +123,7 @@ namespace Internal.Tests
         }
 
         [TestMethod()]
-        public void GetZigZagBadData()
+        public void BadData()
         {
             IEnumerable<ZigZagResult> r = Indicator.GetZigZag(historyBad);
             Assert.AreEqual(502, r.Count());

--- a/tests/indicators/common/Test.Cleaner.cs
+++ b/tests/indicators/common/Test.Cleaner.cs
@@ -11,7 +11,7 @@ namespace Internal.Tests
     {
 
         [TestMethod()]
-        public void ValidateHistoryTest()
+        public void ValidateHistory()
         {
             IEnumerable<Quote> history = History.GetHistory();
 
@@ -34,7 +34,7 @@ namespace Internal.Tests
 
 
         [TestMethod()]
-        public void ValidateLongHistoryTest()
+        public void ValidateLongHistory()
         {
             IEnumerable<Quote> historyLong = History.GetHistoryLong();
 
@@ -52,7 +52,7 @@ namespace Internal.Tests
 
 
         [TestMethod()]
-        public void CutHistoryTest()
+        public void CutHistory()
         {
             // if history post-cleaning, is cut down in size it should not corrupt the results
 
@@ -93,7 +93,7 @@ namespace Internal.Tests
 
 
         [TestMethod()]
-        public void SortHistoryTest()
+        public void SortHistory()
         {
             IEnumerable<Quote> history = History.GetHistory();
 
@@ -116,7 +116,7 @@ namespace Internal.Tests
 
 
         [TestMethod()]
-        public void CleanBasicDataTest()
+        public void ConvertBasicData()
         {
             // compose basic data
             List<BasicData> o = Cleaners.ConvertHistoryToBasic(history, "O");
@@ -186,7 +186,7 @@ namespace Internal.Tests
 
         [TestMethod()]
         [ExpectedException(typeof(BadHistoryException), "Bad element.")]
-        public void CleanBasicDataBadParamTest()
+        public void ConvertBasicDataBadParam()
         {
             // compose basic data
             Cleaners.ConvertHistoryToBasic(history, "E");

--- a/tests/indicators/common/Test.Functions.cs
+++ b/tests/indicators/common/Test.Functions.cs
@@ -15,7 +15,7 @@ namespace Internal.Tests
 
 
         [TestMethod()]
-        public void StdDevTest()
+        public void StdDev()
         {
             double sd = Functions.StdDev(closePrice);
 


### PR DESCRIPTION
- rename unit test methods for consistency