### PR TITLE
add Efficiency Ratio to KAMA results

### DIFF
--- a/indicators/Kama/Kama.Models.cs
+++ b/indicators/Kama/Kama.Models.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Skender.Stock.Indicators
 {
@@ -6,5 +6,6 @@ namespace Skender.Stock.Indicators
     public class KamaResult : ResultBase
     {
         public decimal? Kama { get; set; }
+        public decimal? ER { get; set; }
     }
 }

--- a/indicators/Kama/Kama.Models.cs
+++ b/indicators/Kama/Kama.Models.cs
@@ -1,11 +1,11 @@
-using System;
+﻿using System;
 
 namespace Skender.Stock.Indicators
 {
     [Serializable]
     public class KamaResult : ResultBase
     {
-        public decimal? Kama { get; set; }
         public decimal? ER { get; set; }
+        public decimal? Kama { get; set; }
     }
 }

--- a/indicators/Kama/Kama.cs
+++ b/indicators/Kama/Kama.cs
@@ -60,12 +60,14 @@ namespace Skender.Stock.Indicators
                         // kama calculation
                         decimal? pk = results[i - 1].Kama;  // prior KAMA
                         r.Kama = pk + sc * sc * (h.Close - pk);
+                        r.ER = er;
                     }
 
                     // handle flatline case
                     else
                     {
                         r.Kama = h.Close;
+                        r.ER = 0;
                     }
                 }
 
@@ -73,6 +75,7 @@ namespace Skender.Stock.Indicators
                 else if (index == erPeriod)
                 {
                     r.Kama = h.Close;
+                    r.ER = 0;
                 }
 
                 results.Add(r);

--- a/indicators/Kama/Kama.cs
+++ b/indicators/Kama/Kama.cs
@@ -53,21 +53,23 @@ namespace Skender.Stock.Indicators
 
                     if (sumPV != 0)
                     {
-                        // efficiency ratio and smoothing constant
+                        // efficiency ratio
                         decimal er = change / sumPV;
+                        r.ER = er;
+
+                        // smoothing constant
                         decimal sc = er * (scFast - scSlow) + scSlow;  // squared later
 
                         // kama calculation
                         decimal? pk = results[i - 1].Kama;  // prior KAMA
                         r.Kama = pk + sc * sc * (h.Close - pk);
-                        r.ER = er;
                     }
 
                     // handle flatline case
                     else
                     {
-                        r.Kama = h.Close;
                         r.ER = 0;
+                        r.Kama = h.Close;
                     }
                 }
 
@@ -75,7 +77,6 @@ namespace Skender.Stock.Indicators
                 else if (index == erPeriod)
                 {
                     r.Kama = h.Close;
-                    r.ER = 0;
                 }
 
                 results.Add(r);

--- a/indicators/Kama/README.md
+++ b/indicators/Kama/README.md
@@ -39,8 +39,10 @@ The first `N-1` periods will have `null` values since there's not enough data to
 | name | type | notes
 | -- |-- |--
 | `Date` | DateTime | Date
+| `ER`   | decimal | Efficiency Ratio is the fractal efficiency of price changes
 | `Kama` | decimal | Kaufman's adaptive moving average
-| `ER`   | decimal | Efficiency Ratio tells us the fractal efficiency of price changes. ER fluctuates between 1 and 0, but these extremes are the exception, not the norm. ER would be 1 if prices moved up 10 consecutive periods or down 10 consecutive periods. ER would be zero if price is unchanged over the 10 periods.
+
+**More about Efficiency Ratio:** ER fluctuates between 0 and 1, but these extremes are the exception, not the norm. ER would be 1 if prices moved up 10 consecutive periods or down 10 consecutive periods. ER would be zero if price is unchanged over the 10 periods.
 
 ## Example
 

--- a/indicators/Kama/README.md
+++ b/indicators/Kama/README.md
@@ -1,4 +1,4 @@
-﻿# Kaufman's Adaptive Moving Average (KAMA)
+# Kaufman's Adaptive Moving Average (KAMA)
 
 Created by Perry Kaufman, [KAMA](https://school.stockcharts.com/doku.php?id=technical_indicators:kaufman_s_adaptive_moving_average) is an volatility adaptive moving average of Close price over configurable lookback periods.
 [[Discuss] :speech_balloon:](https://github.com/DaveSkender/Stock.Indicators/discussions/210 "Community discussion about this indicator")
@@ -40,6 +40,7 @@ The first `N-1` periods will have `null` values since there's not enough data to
 | -- |-- |--
 | `Date` | DateTime | Date
 | `Kama` | decimal | Kaufman's adaptive moving average
+| `ER`   | decimal | Efficiency Ratio tells us the fractal efficiency of price changes. ER fluctuates between 1 and 0, but these extremes are the exception, not the norm. ER would be 1 if prices moved up 10 consecutive periods or down 10 consecutive periods. ER would be zero if price is unchanged over the 10 periods.
 
 ## Example
 

--- a/tests/indicators/Test.Kama.cs
+++ b/tests/indicators/Test.Kama.cs
@@ -26,28 +26,36 @@ namespace Internal.Tests
             // should always be the same number of results as there is history
             Assert.AreEqual(502, results.Count);
             Assert.AreEqual(493, results.Where(x => x.Kama != null).Count());
+            Assert.AreEqual(493, results.Where(x => x.ER != null).Count());
 
             // sample values
             KamaResult r1 = results[8];
             Assert.AreEqual(null, r1.Kama);
+            Assert.AreEqual(null, r1.ER);
 
             KamaResult r2 = results[9];
             Assert.AreEqual(213.75m, r2.Kama);
+            Assert.AreEqual(0, r2.ER);
 
             KamaResult r3 = results[10];
             Assert.AreEqual(213.7713m, Math.Round((decimal)r3.Kama, 4));
+            Assert.AreEqual(0.2465m, Math.Round((decimal)r3.ER, 4));
 
             KamaResult r4 = results[24];
             Assert.AreEqual(214.7423m, Math.Round((decimal)r4.Kama, 4));
+            Assert.AreEqual(0.2136m, Math.Round((decimal)r4.ER, 4));
 
             KamaResult r5 = results[149];
             Assert.AreEqual(235.5510m, Math.Round((decimal)r5.Kama, 4));
+            Assert.AreEqual(0.3165m, Math.Round((decimal)r5.ER, 4));
 
             KamaResult r6 = results[249];
             Assert.AreEqual(256.0898m, Math.Round((decimal)r6.Kama, 4));
+            Assert.AreEqual(0.3182m, Math.Round((decimal)r6.ER, 4));
 
             KamaResult r7 = results[501];
             Assert.AreEqual(240.1138m, Math.Round((decimal)r7.Kama, 4));
+            Assert.AreEqual(0.2214m, Math.Round((decimal)r7.ER, 4));
         }
 
         [TestMethod]

--- a/tests/indicators/Test.Kama.cs
+++ b/tests/indicators/Test.Kama.cs
@@ -25,37 +25,37 @@ namespace Internal.Tests
             // proper quantities
             // should always be the same number of results as there is history
             Assert.AreEqual(502, results.Count);
+            Assert.AreEqual(492, results.Where(x => x.ER != null).Count());
             Assert.AreEqual(493, results.Where(x => x.Kama != null).Count());
-            Assert.AreEqual(493, results.Where(x => x.ER != null).Count());
 
             // sample values
             KamaResult r1 = results[8];
-            Assert.AreEqual(null, r1.Kama);
             Assert.AreEqual(null, r1.ER);
+            Assert.AreEqual(null, r1.Kama);
 
             KamaResult r2 = results[9];
+            Assert.AreEqual(null, r2.ER);
             Assert.AreEqual(213.75m, r2.Kama);
-            Assert.AreEqual(0, r2.ER);
 
             KamaResult r3 = results[10];
-            Assert.AreEqual(213.7713m, Math.Round((decimal)r3.Kama, 4));
             Assert.AreEqual(0.2465m, Math.Round((decimal)r3.ER, 4));
+            Assert.AreEqual(213.7713m, Math.Round((decimal)r3.Kama, 4));
 
             KamaResult r4 = results[24];
-            Assert.AreEqual(214.7423m, Math.Round((decimal)r4.Kama, 4));
             Assert.AreEqual(0.2136m, Math.Round((decimal)r4.ER, 4));
+            Assert.AreEqual(214.7423m, Math.Round((decimal)r4.Kama, 4));
 
             KamaResult r5 = results[149];
-            Assert.AreEqual(235.5510m, Math.Round((decimal)r5.Kama, 4));
             Assert.AreEqual(0.3165m, Math.Round((decimal)r5.ER, 4));
+            Assert.AreEqual(235.5510m, Math.Round((decimal)r5.Kama, 4));
 
             KamaResult r6 = results[249];
-            Assert.AreEqual(256.0898m, Math.Round((decimal)r6.Kama, 4));
             Assert.AreEqual(0.3182m, Math.Round((decimal)r6.ER, 4));
+            Assert.AreEqual(256.0898m, Math.Round((decimal)r6.Kama, 4));
 
             KamaResult r7 = results[501];
-            Assert.AreEqual(240.1138m, Math.Round((decimal)r7.Kama, 4));
             Assert.AreEqual(0.2214m, Math.Round((decimal)r7.ER, 4));
+            Assert.AreEqual(240.1138m, Math.Round((decimal)r7.Kama, 4));
         }
 
         [TestMethod]


### PR DESCRIPTION
I would find it usefull if KamaResult included Efficiency Ratio so that I can filter out busy/noisy periods where there is risk for false signals. 

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, including INDICATORS.md, README.md, info.xml, etc
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage
- [ ] I have added or run the performance tests that depict execution times similar to others
- [x] New and existing unit tests pass locally with my changes

- [x] I have read and understand [the Apache 2.0 license](https://opensource.org/licenses/Apache-2.0)
- [x] I agree to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)
