### PR TITLE
fix: Zig Zag initialization bug

### DIFF
--- a/indicators/ZigZag/README.md
+++ b/indicators/ZigZag/README.md
@@ -1,4 +1,4 @@
-﻿# Zig Zag
+# Zig Zag
 
 [Zig Zag](https://school.stockcharts.com/doku.php?id=technical_indicators:zigzag) is a price chart overlay that simplifies the up and down movements and transitions based on a percent change smoothing threshold.
 [[Discuss] :speech_balloon:](https://github.com/DaveSkender/Stock.Indicators/discussions/226 "Community discussion about this indicator")
@@ -36,7 +36,9 @@ You must supply at least two periods of `history` to calculate, but notably more
 IEnumerable<ZigZagResult>
 ```
 
-If you do not supply enough points to cover the percent change, there will be no valid Zig Zag points or lines.  The first line segment starts after the first confirmed point; ZigZag values before the first confirmed point will be `null`.  The last line segment is an approximation as the direction is indeterminant.  Swing high and low points are denoted with `PointType` values of `H` or `L`.  We always return the same number of result elements as there are in the historical quotes.
+:warning: **Warning**:  depending on the specified `type`, the indicator cannot be initialized if the first `Quote` in `history` has a `High`,`Low`, or `Close` value of 0 (zero).
+
+Also, if you do not supply enough points to cover the percent change, there will be no Zig Zag points or lines.  The first line segment starts after the first confirmed point; ZigZag values before the first confirmed point will be `null`.  The last line segment is an approximation as the direction is indeterminant.  Swing high and low points are denoted with `PointType` values of `H` or `L`.  We always return the same number of result elements as there are in the historical quotes.
 
 ### ZigZagResult
 

--- a/indicators/ZigZag/ZigZag.cs
+++ b/indicators/ZigZag/ZigZag.cs
@@ -58,8 +58,12 @@ namespace Skender.Stock.Indicators
                 int index = i + 1;
 
                 eval = GetZigZagEval(type, index, h);
-                decimal changeUp = (eval.High - lastLowPoint.Value) / lastLowPoint.Value;
-                decimal changeDn = (lastHighPoint.Value - eval.Low) / lastHighPoint.Value;
+
+                decimal? changeUp = (lastLowPoint.Value == 0) ? null
+                    : (eval.High - lastLowPoint.Value) / lastLowPoint.Value;
+
+                decimal? changeDn = (lastHighPoint.Value == 0) ? null
+                    : (lastHighPoint.Value - eval.Low) / lastHighPoint.Value;
 
                 if (changeUp >= changeThreshold && changeUp > changeDn)
                 {
@@ -174,6 +178,11 @@ namespace Skender.Stock.Indicators
         private static void DrawZigZagLine<TQuote>(List<ZigZagResult> results, List<TQuote> historyList,
             ZigZagPoint lastPoint, ZigZagPoint nextPoint) where TQuote : IQuote
         {
+            // handle error case
+            if (nextPoint.Index == lastPoint.Index)
+            {
+                return;
+            }
 
             decimal increment = (nextPoint.Value - lastPoint.Value) / (nextPoint.Index - lastPoint.Index);
 
@@ -227,6 +236,12 @@ namespace Skender.Stock.Indicators
 
             // nothing to do if first line
             if (priorPoint.Index == 1)
+            {
+                return;
+            }
+
+            // handle error case
+            if (nextPoint.Index == priorPoint.Index)
             {
                 return;
             }


### PR DESCRIPTION
## Description

Handles divide by zero during initialization when `history` starts with zero `High`, `Low`, or `Close` values.

Fixes #400 

## Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, including INDICATORS.md, README.md, info.xml, etc
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage
- [x] I have added or run the performance tests that depict execution times similar to others
- [x] New and existing unit tests pass locally with my changes

## Acknowledgements

- [x] I have read and understand [the Apache 2.0 license](https://opensource.org/licenses/Apache-2.0)
- [x] I agree to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)
