### PR TITLE
fix: fix Quote to be null-acceptable

### DIFF
--- a/wraps/python/SkenderStockIndicators/indicators/common/Quote.py
+++ b/wraps/python/SkenderStockIndicators/indicators/common/Quote.py
@@ -4,8 +4,8 @@ from SkenderStockIndicators._cstypes import DateTime, Decimal
 class Quote(CsQuote):
     def __init__(self, date, open = None, high = None, low = None, close = None, volume = None):
         self.Date = DateTime(date)
-        self.Open = Decimal(open)
-        self.High = Decimal(high)
-        self.Low = Decimal(low)
-        self.Close = Decimal(close)
-        self.Volume = Decimal(volume)
+        self.Open = Decimal(open) if open else super().Open
+        self.High = Decimal(high) if high else super().High
+        self.Low = Decimal(low) if low else super().Low
+        self.Close = Decimal(close) if close else super().Close
+        self.Volume = Decimal(volume) if volume else super().Volume


### PR DESCRIPTION
## Description

Fixes Quote to be null-acceptable.

The constructor of `Quote` can accept `None` as a parameter, but `_cstypes.Decimal` cannot accept it and error occurred.

Improves #397 

## Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, including `INDICATORS.md`, `README.md`, `info.xml`, etc
- [ ] I have made corresponding changes to the `wraps` interoperability files
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [ ] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage
- [ ] I have added or run the performance tests that depict optimal execution times
- [x] New and existing unit tests pass locally and in the build (below) with my changes

## Acknowledgements

- [x] I have read and understand [the Apache 2.0 license](https://opensource.org/licenses/Apache-2.0)
- [x] I agree to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)
