### PR TITLE
Fix implicit importing

### DIFF
--- a/wraps/python/SkenderStockIndicators/_cslib/__init__.py
+++ b/wraps/python/SkenderStockIndicators/_cslib/__init__.py
@@ -13,3 +13,4 @@ import clr
 dir = os.path.dirname(__file__)
 path = os.path.join(dir, "../../lib/Skender.Stock.Indicators.dll")
 clr.AddReference(path)
+clr.AddReference('System.Collections')


### PR DESCRIPTION
## Description

Fix the warning on testing:
```
>>> pytest

SkenderStockIndicators\_cstypes\list.py:1
  C:\Users\matth\Desktop\Stock.Indicators\wraps\python\SkenderStockIndicators\_cstypes\list.py:1: DeprecationWarning: The module was found, but not in a referenced namespace.
  Implicit loading is deprecated. Please use clr.AddReference('System.Collections').
    from System.Collections.Generic import List as CsList

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```

Improves #397

## Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, including `INDICATORS.md`, `README.md`, `info.xml`, etc
- [ ] I have made corresponding changes to the `wraps` interoperability files
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage
- [ ] I have added or run the performance tests that depict optimal execution times
- [x] New and existing unit tests pass locally and in the build (below) with my changes

## Acknowledgements

- [x] I have read and understand [the Apache 2.0 license](https://opensource.org/licenses/Apache-2.0)
- [x] I agree to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)
