### PR TITLE
harden KVO volume force

### DIFF
--- a/indicators/Kvo/Kvo.cs
+++ b/indicators/Kvo/Kvo.cs
@@ -77,14 +77,14 @@ namespace Skender.Stock.Indicators
                         (cm[i - 1] + dm[i]) : (dm[i - 1] + dm[i]);
 
                 // volume force (VF)
-                vf[i] = cm[i] != 0 ?
-                    h.Volume * Math.Abs(2 * (dm[i] / cm[i] - 1)) * t[i] * 100m
-                    : null;
+                vf[i] = (dm[i] == cm[i] || h.Volume == 0) ? 0
+                    : (dm[i] == 0) ? h.Volume * 2 * t[i] * 100m
+                    : (cm[i] != 0) ? h.Volume * Math.Abs(2 * (dm[i] / cm[i] - 1)) * t[i] * 100m
+                    : vf[i - 1];
 
                 // fast-period EMA of VF
                 if (index > fastPeriod + 2)
                 {
-                    // lastEma + k * (h.Value - lastEma);
                     vfFastEma[i] = vf[i] * kFast + vfFastEma[i - 1] * (1 - kFast);
                 }
                 else if (index == fastPeriod + 2)


### PR DESCRIPTION
## Description

Hardening the Volume Force calculation in Klinger Volume Oscillator so it has fewer edge case propagating problems.  Since this calculation does EMA of VF, any `null` in VF will end its ability to continue computing KVO values; as a result, creating fewer opportunities for `null` is less prone to these scenarios.

Inspired by #450

## Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, including `INDICATORS.md`, `README.md`, `info.xml`, etc
- [ ] I have made corresponding changes to the `wraps` interoperability files
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage
- [x] I have added or run the performance tests that depict optimal execution times
- [x] New and existing unit tests pass locally and in the build (below) with my changes

## Acknowledgements

- [x] I have read and understand [the Apache 2.0 license](https://opensource.org/licenses/Apache-2.0)
- [x] I agree to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)
