### PR TITLE
fix: aggregator missing 30 minute interval

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -294,7 +294,6 @@ IEnumerable<Quote> dayBarHistory =
 
 #### PeriodSize options (for newSize)
 
-- `PeriodSize.Month`
 - `PeriodSize.Week`
 - `PeriodSize.Day`
 - `PeriodSize.FourHours`

--- a/indicators/_Common/Functions.cs
+++ b/indicators/_Common/Functions.cs
@@ -55,6 +55,7 @@ namespace Skender.Stock.Indicators
                 PeriodSize.ThreeMinutes => TimeSpan.FromMinutes(3),
                 PeriodSize.FiveMinutes => TimeSpan.FromMinutes(5),
                 PeriodSize.FifteenMinutes => TimeSpan.FromMinutes(15),
+                PeriodSize.ThirtyMinutes => TimeSpan.FromMinutes(30),
                 PeriodSize.OneHour => TimeSpan.FromHours(1),
                 PeriodSize.TwoHours => TimeSpan.FromHours(2),
                 PeriodSize.FourHours => TimeSpan.FromHours(4),

--- a/tests/indicators/common/Test.Functions.cs
+++ b/tests/indicators/common/Test.Functions.cs
@@ -44,11 +44,13 @@ namespace Internal.Tests
             Assert.AreEqual(PeriodSize.ThreeMinutes.ToTimeSpan(), TimeSpan.FromMinutes(3));
             Assert.AreEqual(PeriodSize.FiveMinutes.ToTimeSpan(), TimeSpan.FromMinutes(5));
             Assert.AreEqual(PeriodSize.FifteenMinutes.ToTimeSpan(), TimeSpan.FromHours(0.25));
+            Assert.AreEqual(PeriodSize.ThirtyMinutes.ToTimeSpan(), TimeSpan.FromHours(0.5));
             Assert.AreEqual(PeriodSize.OneHour.ToTimeSpan(), TimeSpan.FromMinutes(60));
             Assert.AreEqual(PeriodSize.TwoHours.ToTimeSpan(), TimeSpan.FromHours(2));
             Assert.AreEqual(PeriodSize.FourHours.ToTimeSpan(), TimeSpan.FromHours(4));
             Assert.AreEqual(PeriodSize.Day.ToTimeSpan(), TimeSpan.FromHours(24));
             Assert.AreEqual(PeriodSize.Week.ToTimeSpan(), TimeSpan.FromDays(7));
+
             Assert.AreEqual(PeriodSize.Month.ToTimeSpan(), TimeSpan.Zero);
         }
     }


### PR DESCRIPTION
## Description

Add missing 30 minute interval to `history.Aggregate()`

Fixes #458

## Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, including `INDICATORS.md`, `README.md`, `info.xml`, etc
- [ ] I have made corresponding changes to the `wraps` interoperability files
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage
- [ ] I have added or run the performance tests that depict optimal execution times
- [x] New and existing unit tests pass locally and in the build (below) with my changes

## Acknowledgements

- [x] I have read and understand [the Apache 2.0 license](https://opensource.org/licenses/Apache-2.0)
- [x] I agree to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)
