### PR TITLE
indicators as history extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ using Skender.Stock.Indicators;
 [..]  // prerequisite: get quote history from your own source
 
 // example: get 20-period simple moving average
-IEnumerable<SmaResult> results = Indicator.GetSma(history,20);
+IEnumerable<SmaResult> results = history.GetSma(20);
 ```
 
 See the [guide](https://daveskender.github.io/Stock.Indicators/docs/GUIDE.html) and the [full list of indicators and overlays](https://daveskender.github.io/Stock.Indicators/docs/INDICATORS.html) for more information.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -49,7 +49,7 @@ using Skender.Stock.Indicators;
 IEnumerable<Quote> history = GetHistoryFromFeed("MSFT");
 
 // calculate 20-period SMA
-IEnumerable<SmaResult> results = Indicator.GetSma(history,20);
+IEnumerable<SmaResult> results = history.GetSma(history,20);
 
 // use results as needed
 SmaResult result = results.LastOrDefault();
@@ -58,6 +58,13 @@ Console.WriteLine("SMA on {0} was ${1}", result.Date, result.Sma);
 
 ```bash
 SMA on 12/31/2018 was $251.86
+```
+
+If you do not prefer using the history extension syntax, a full method syntax can also be used.
+
+```csharp
+// alternate full syntax example
+IEnumerable<SmaResult> results = Indicator.GetSma(history,20);
 ```
 
 See [individual indicator pages](INDICATORS.md) for specific usage guidance.
@@ -116,7 +123,7 @@ public class MyCustomQuote : IQuote
 IEnumerable<MyCustomQuote> myHistory = GetHistoryFromFeed("MSFT");
 
 // example: get 20-period simple moving average
-IEnumerable<SmaResult> results = Indicator.GetSma(myHistory,20);
+IEnumerable<SmaResult> results = myHistory.GetSma(20);
 ```
 
 #### Using custom quote property names
@@ -174,7 +181,7 @@ public void MyClass(){
   IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
   // compute indicator
-  INumerable<EmaResult> emaResults = Indicator.GetEma(history,14);
+  INumerable<EmaResult> emaResults = history.GetEma(14);
 
   // convert to my Ema class list [using LINQ]
   List<MyEma> myEmaResults = emaResults
@@ -213,7 +220,7 @@ public void MyClass(){
   IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
   // compute indicator
-  INumerable<EmaResult> emaResults = Indicator.GetEma(history,14);
+  INumerable<EmaResult> emaResults = history.GetEma(14);
 
   // convert to my Ema class list [using LINQ]
   List<MyEma> myEmaResults = emaResults
@@ -242,7 +249,7 @@ If you want to compute an indicator of indicators, such as an SMA of an ADX or a
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate OBV
-IEnumerable<ObvResult> obvResults = Indicator.GetObv(history);
+IEnumerable<ObvResult> obvResults = history.GetObv();
 
 // convert to synthetic history [using LINQ]
 List<Quote> obvHistory = obvResults
@@ -256,7 +263,7 @@ List<Quote> obvHistory = obvResults
 
 // calculate RSI of OBV
 int lookbackPeriod = 14;
-IEnumerable<RsiResult> results = Indicator.GetRsi(obvHistory, lookbackPeriod);
+IEnumerable<RsiResult> results = obvHistory.GetRsi(lookbackPeriod);
 ```
 
 ## Helper functions
@@ -270,7 +277,7 @@ IEnumerable<RsiResult> results = Indicator.GetRsi(obvHistory, lookbackPeriod);
 IEnumerable<Quote> history = GetHistoryFromFeed("MSFT");
 
 // calculate indicator series
-IEnumerable<SmaResult> results = Indicator.GetSma(history,20);
+IEnumerable<SmaResult> results = history.GetSma(20);
 
 // find result on a specific date
 DateTime lookupDate = [..] // the date you want to find

--- a/indicators/Adl/Adl.cs
+++ b/indicators/Adl/Adl.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<AdlResult> GetAdl<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int? smaPeriod = null)
             where TQuote : IQuote
         {

--- a/indicators/Adl/README.md
+++ b/indicators/Adl/README.md
@@ -8,23 +8,24 @@ Created by Marc Chaikin, the [Accumulation/Distribution Line/Index](https://en.w
 ```csharp
 // usage
 IEnumerable<AdlResult> results =
-  Indicator.GetAdl(history);  
+  history.GetAdl();  
 
 // usage with optional overlay SMA of ADL (shown above)
 IEnumerable<AdlResult> results =
-  Indicator.GetAdl(history, smaPeriod);  
+  history.GetAdl(smaPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `smaPeriod` | int | Optional.  Number of periods (`N`) in the moving average of ADL.  Must be greater than 0, if specified.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least two historical quotes; however, since this is a trendline, more is recommended.
+You must have at least two historical quotes; however, since this is a trendline, more is recommended.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -53,7 +54,7 @@ We always return the same number of elements as there are in the historical quot
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate
-IEnumerable<AdlResult> results = Indicator.GetAdl(history);
+IEnumerable<AdlResult> results = history.GetAdl();
 
 // use results as needed
 AdlResult result = results.LastOrDefault();

--- a/indicators/Adx/Adx.cs
+++ b/indicators/Adx/Adx.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<AdxResult> GetAdx<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod = 14)
             where TQuote : IQuote
         {

--- a/indicators/Adx/README.md
+++ b/indicators/Adx/README.md
@@ -8,19 +8,20 @@ Created by J. Welles Wilder, the [Average Directional Movement Index](https://en
 ```csharp
 // usage
 IEnumerable<AdxResult> results =
-  Indicator.GetAdx(history, lookbackPeriod);  
+  history.GetAdx(lookbackPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) to consider.  Must be greater than 1.  Default is 14.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `2×N+100` periods of `history` to allow for smoothing convergence.  We generally recommend you use at least `2×N+250` data points prior to the intended usage date for better precision.
+You must have at least `2×N+100` periods of `history` to allow for smoothing convergence.  We generally recommend you use at least `2×N+250` data points prior to the intended usage date for better precision.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -48,7 +49,7 @@ The first `2×N-1` periods will have `null` values for ADX since there's not eno
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate 14-period ADX
-IEnumerable<AdxResult> results = Indicator.GetAdx(history,14);
+IEnumerable<AdxResult> results = history.GetAdx(14);
 
 // use results as needed
 AdxResult result = results.LastOrDefault();

--- a/indicators/Alligator/Alligator.cs
+++ b/indicators/Alligator/Alligator.cs
@@ -9,7 +9,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<AlligatorResult> GetAlligator<TQuote>(
-            IEnumerable<TQuote> history)
+            this IEnumerable<TQuote> history)
             where TQuote : IQuote
         {
 

--- a/indicators/Alligator/README.md
+++ b/indicators/Alligator/README.md
@@ -8,18 +8,14 @@ Created by Bill Williams, Alligator is a depiction of three smoothed moving aver
 ```csharp
 // usage
 IEnumerable<AlligatorResult> results =
-  Indicator.GetAlligator(history);
+  history.GetAlligator();
 ```
 
-## Parameters
+## Historical quotes requirements
 
-| name | type | notes
-| -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
+You must have at least 115 periods of `history`. Since this uses a smoothing technique, we recommend you use at least 265 data points prior to the intended usage date for better precision.
 
-### Minimum history requirements
-
-You must supply at least 115 periods of `history`. Since this uses a smoothing technique, we recommend you use at least 265 data points prior to the intended usage date for better precision.
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ### Internal parameters
 
@@ -57,7 +53,7 @@ The first 10-20 periods will have `null` values since there's not enough data to
 IEnumerable<Quote> history = GetHistoryFromFeed("MSFT");
 
 // calculate the Williams Alligator
-IEnumerable<AlligatorResult> results = Indicator.GetAlligator(history);
+IEnumerable<AlligatorResult> results = history.GetAlligator();
 
 // use results as needed
 AlligatorResult result = results.LastOrDefault();

--- a/indicators/Alma/Alma.cs
+++ b/indicators/Alma/Alma.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<AlmaResult> GetAlma<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod = 9,
             double offset = 0.85,
             double sigma = 6)

--- a/indicators/Alma/README.md
+++ b/indicators/Alma/README.md
@@ -8,21 +8,22 @@ Created by Arnaud Legoux and Dimitrios Kouzis-Loukas, [ALMA](https://github.com/
 ```csharp
 // usage
 IEnumerable<AlmaResult> results =
-  Indicator.GetAlma(history, lookbackPeriod, offset, sigma);  
+  history.GetAlma(lookbackPeriod, offset, sigma);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) in the moving average.  Must be greater than 1, but is typically in the 5-20 range.  Default is 9.
 | `offset` | double | Adjusts smoothness versus responsiveness on a scale from 0 to 1; where 1 is max responsiveness.  Default is 0.85.
 | `sigma` | double | Defines the width of the Gaussian [normal distribution](https://en.wikipedia.org/wiki/Normal_distribution).  Must be greater than 0.  Default is 6.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N` periods of `history`.
+You must have at least `N` periods of `history`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -46,7 +47,7 @@ The first `N-1` periods will have `null` values since there's not enough data to
 IEnumerable<Quote> history = GetHistoryFromFeed("MSFT");
 
 // calculate Alma(10,0.5,6)
-IEnumerable<AlmaResult> results = Indicator.GetAlma(history,10,0.5,6);
+IEnumerable<AlmaResult> results = history.GetAlma(10,0.5,6);
 
 // use results as needed
 AlmaResult result = results.LastOrDefault();

--- a/indicators/Aroon/Aroon.cs
+++ b/indicators/Aroon/Aroon.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<AroonResult> GetAroon<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod = 25)
             where TQuote : IQuote
         {

--- a/indicators/Aroon/README.md
+++ b/indicators/Aroon/README.md
@@ -8,19 +8,20 @@ Created by Tushar Chande, [Aroon](https://school.stockcharts.com/doku.php?id=tec
 ```csharp
 // usage
 IEnumerable<AroonResult> results =
-  Indicator.GetAroon(history, lookbackPeriod);  
+  history.GetAroon(lookbackPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) for the lookback evaluation.  Must be greater than 0.  Default is 25.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N` periods of `history`.
+You must have at least `N` periods of `history`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -46,7 +47,7 @@ The first `N-1` periods will have `null` Aroon values since there's not enough d
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate Aroon(25)
-IEnumerable<AroonResult> results = Indicator.GetAroon(history,25);
+IEnumerable<AroonResult> results = history.GetAroon(25);
 
 // use results as needed
 AroonResult result = results.LastOrDefault();

--- a/indicators/Atr/Atr.cs
+++ b/indicators/Atr/Atr.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<AtrResult> GetAtr<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod = 14)
             where TQuote : IQuote
         {

--- a/indicators/Atr/README.md
+++ b/indicators/Atr/README.md
@@ -8,19 +8,20 @@ Created by J. Welles Wilder, [Average True Range](https://en.wikipedia.org/wiki/
 ```csharp
 // usage
 IEnumerable<AtrResult> results =
-  Indicator.GetAtr(history, lookbackPeriod);  
+  history.GetAtr(lookbackPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) to consider.  Must be greater than 1.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N+100` periods of `history`.  Since this uses a smoothing technique, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.
+You must have at least `N+100` periods of `history`.  Since this uses a smoothing technique, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -48,7 +49,7 @@ The first `N-1` periods will have `null` values for ATR since there's not enough
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate 14-period ATR
-IEnumerable<AtrResult> results = Indicator.GetAtr(history,14);
+IEnumerable<AtrResult> results = history.GetAtr(14);
 
 // use results as needed
 AtrResult result = results.LastOrDefault();

--- a/indicators/Awesome/Awesome.cs
+++ b/indicators/Awesome/Awesome.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<AwesomeResult> GetAwesome<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int fastPeriod = 5,
             int slowPeriod = 34)
             where TQuote : IQuote

--- a/indicators/Awesome/README.md
+++ b/indicators/Awesome/README.md
@@ -8,20 +8,21 @@ Created by Bill Williams, the Awesome Oscillator (aka Super AO) is a measure of 
 ```csharp
 // usage
 IEnumerable<AwesomeResult> results =
-  Indicator.GetAwesome(history, fastPeriod, slowPeriod);  
+  history.GetAwesome(fastPeriod, slowPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `fastPeriod` | int | Number of periods (`F`) for the faster moving average.  Must be greater than 0.  Default is 5.
 | `slowPeriod` | int | Number of periods (`S`) for the slower moving average.  Must be greater than `fastPeriod`.  Default is 34.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `S` periods of `history`.
+You must have at least `S` periods of `history`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -46,7 +47,7 @@ The first period `S-1` periods will have `null` values since there's not enough 
 IEnumerable<Quote> history = GetHistoryFromFeed("MSFT");
 
 // calculate
-IEnumerable<AwesomeResult> results = Indicator.GetAwesome(history,5,34);
+IEnumerable<AwesomeResult> results = history.GetAwesome(5,34);
 
 // use results as needed
 AwesomeResult r = results.LastOrDefault();

--- a/indicators/Beta/README.md
+++ b/indicators/Beta/README.md
@@ -19,9 +19,9 @@ IEnumerable<BetaResult> results =
 | `historyEval` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical [evaluation stock] Quotes data should be at any consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) in the lookback period.  Must be greater than 0 to calculate; however we suggest a larger period for statistically appropriate sample size.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N` periods of history.  You must have at least the same matching date elements of `historyMarket`.  Exception will be thrown if not matched.  Historical price quotes should have a consistent frequency (day, hour, minute, etc).
+You must have at least `N` periods of history.  You must have at least the same matching date elements of `historyMarket`.  Exception will be thrown if not matched.  Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 
 ## Response
 

--- a/indicators/BollingerBands/BollingerBands.cs
+++ b/indicators/BollingerBands/BollingerBands.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<BollingerBandsResult> GetBollingerBands<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod = 20,
             decimal standardDeviations = 2)
             where TQuote : IQuote

--- a/indicators/BollingerBands/README.md
+++ b/indicators/BollingerBands/README.md
@@ -8,20 +8,21 @@ Created by John Bollinger, [Bollinger Bands](https://en.wikipedia.org/wiki/Bolli
 ```csharp
 // usage
 IEnumerable<BollingerBandsResult> results =
-  Indicator.GetBollingerBands(history, lookbackPeriod, standardDeviation);  
+  history.GetBollingerBands(lookbackPeriod, standardDeviation);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) for the center line moving average.  Must be greater than 1 to calculate; however we suggest a larger period for statistically appropriate sample size.  Default is 20.
 | `standardDeviations` | int | Width of bands.  Standard deviations (`D`) from the moving average.  Must be greater than 0.  Default is 2.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N` periods of `history`.
+You must have at least `N` periods of `history`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -51,7 +52,7 @@ IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate BollingerBands(12,26,9)
 IEnumerable<BollingerBandsResult> results =
-  Indicator.GetBollingerBands(history,20,2);
+  history.GetBollingerBands(20,2);
 
 // use results as needed
 BollingerBandsResult result = results.LastOrDefault();

--- a/indicators/Bop/Bop.cs
+++ b/indicators/Bop/Bop.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<BopResult> GetBop<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int smoothPeriod = 14)
             where TQuote : IQuote
         {

--- a/indicators/Bop/README.md
+++ b/indicators/Bop/README.md
@@ -8,19 +8,20 @@ Created by Igor Levshin, the [Balance of Power](https://school.stockcharts.com/d
 ```csharp
 // usage
 IEnumerable<BopResult> results =
-  Indicator.GetBop(history, smoothPeriod);  
+  history.GetBop(smoothPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `smoothPeriod` | int | Number of periods (`N`) for smoothing.  Must be greater than 0.  Default is 14.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N` periods of `history`.
+You must have at least `N` periods of `history`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -44,7 +45,7 @@ The first `N-1` periods will have `null` values since there's not enough data to
 IEnumerable<Quote> history = GetHistoryFromFeed("MSFT");
 
 // calculate 14-period BOP
-IEnumerable<BopResult> results = Indicator.GetBop(history,14);
+IEnumerable<BopResult> results = history.GetBop(14);
 
 // use results as needed
 BopResult result = results.LastOrDefault();

--- a/indicators/Cci/Cci.cs
+++ b/indicators/Cci/Cci.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<CciResult> GetCci<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod = 20)
             where TQuote : IQuote
         {

--- a/indicators/Cci/README.md
+++ b/indicators/Cci/README.md
@@ -8,15 +8,20 @@ Created by Donald Lambert, the [Commodity Channel Index](https://en.wikipedia.or
 ```csharp
 // usage
 IEnumerable<CciResult> results =
-  Indicator.GetCci(history, lookbackPeriod);  
+  history.GetCci(lookbackPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).  You must supply at least `N+1` periods of `history`.
 | `lookbackPeriod` | int | Number of periods (`N`) in the moving average.  Must be greater than 0.  Default is 20.
+
+### Historical quotes requirements
+
+You must have at least `N+1` periods of `history`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -40,7 +45,7 @@ The first `N-1` periods will have `null` values since there's not enough data to
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate 20-period CCI
-IEnumerable<CciResult> results = Indicator.GetCci(history,20);
+IEnumerable<CciResult> results = history.GetCci(20);
 
 // use results as needed
 CciResult result = results.LastOrDefault();

--- a/indicators/ChaikinOsc/ChaikinOsc.cs
+++ b/indicators/ChaikinOsc/ChaikinOsc.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<ChaikinOscResult> GetChaikinOsc<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int fastPeriod = 3,
             int slowPeriod = 10)
             where TQuote : IQuote

--- a/indicators/ChaikinOsc/README.md
+++ b/indicators/ChaikinOsc/README.md
@@ -8,20 +8,21 @@ Created by Marc Chaikin, the [Chaikin Oscillator](https://en.wikipedia.org/wiki/
 ```csharp
 // usage
 IEnumerable<ChaikinOscResult> results =
-  Indicator.GetChaikinOsc(history, fastPeriod, slowPeriod);  
+  history.GetChaikinOsc(fastPeriod, slowPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `fastPeriod` | int | Number of periods (`F`) in the ADL fast EMA.  Must be greater than 0 and smaller than `S`.  Default is 3.
 | `slowPeriod` | int | Number of periods (`S`) in the ADL slow EMA.  Must be greater `F`.  Default is 10.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `2×S` or `S+100` periods of `history`, whichever is more.  Since this uses a smoothing technique, we recommend you use at least `S+250` data points prior to the intended usage date for better precision.
+You must have at least `2×S` or `S+100` periods of `history`, whichever is more.  Since this uses a smoothing technique, we recommend you use at least `S+250` data points prior to the intended usage date for better precision.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -52,7 +53,7 @@ The first `S-1` periods will have `null` values for `Oscillator` since there's n
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate 20-period Chaikin Oscillator
-IEnumerable<ChaikinOscResult> results = Indicator.GetChaikinOsc(history,20);
+IEnumerable<ChaikinOscResult> results = history.GetChaikinOsc(20);
 
 // use results as needed
 ChaikinOscResult result = results.LastOrDefault();

--- a/indicators/Chandelier/Chandelier.cs
+++ b/indicators/Chandelier/Chandelier.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<ChandelierResult> GetChandelier<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod = 22,
             decimal multiplier = 3.0m,
             ChandelierType type = ChandelierType.Long)

--- a/indicators/Chandelier/README.md
+++ b/indicators/Chandelier/README.md
@@ -8,21 +8,22 @@ Created by Charles Le Beau, the [Chandelier Exit](https://school.stockcharts.com
 ```csharp
 // usage
 IEnumerable<ChandelierResult> results =
-  Indicator.GetChandelier(history, lookbackPeriod, multiplier, type);  
+  history.GetChandelier(lookbackPeriod, multiplier, type);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) for the lookback evaluation.  Default is 22.
 | `multiplier` | decimal | Multiplier number must be a positive value.  Default is 3.
 | `type` | ChandelierType | Direction of exit.  See [ChandelierType options](#chandeliertype-options) below.  Default is `ChandelierType.Long`.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N+1` periods of `history`.
+You must have at least `N+1` periods of `history`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ### ChandelierType options
 
@@ -54,7 +55,7 @@ IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate Chandelier(22,3,LONG)
 IEnumerable<ChandelierResult> results =
-  Indicator.GetChandelier(history,22,3,ChandelierType.Long);
+  history.GetChandelier(22,3,ChandelierType.Long);
 
 // use results as needed
 ChandelierResult result = results.LastOrDefault();

--- a/indicators/Chop/Chop.cs
+++ b/indicators/Chop/Chop.cs
@@ -9,7 +9,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         ///
         public static IEnumerable<ChopResult> GetChop<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod = 14)
             where TQuote : IQuote
         {

--- a/indicators/Chop/README.md
+++ b/indicators/Chop/README.md
@@ -7,19 +7,20 @@ Created by E.W. Dreiss, the Choppiness Index measures the trendiness or choppine
 ```csharp
 // usage
 IEnumerable<ChopResult> results =
-  Indicator.GetChop(history, lookbackPeriod);  
+  history.GetChop(lookbackPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) for the lookback evaluation.  Must be greater than 1.  Default is 14.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N+1` periods of `history`.
+You must have at least `N+1` periods of `history`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -43,7 +44,7 @@ The first `N` periods will have `null` values since there's not enough data to c
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate CHOP(14)
-IEnumerable<ChopResult> results = Indicator.GetChop(history,14);
+IEnumerable<ChopResult> results = history.GetChop(14);
 
 // use results as needed
 ChopResult result = results.LastOrDefault();

--- a/indicators/Cmf/Cmf.cs
+++ b/indicators/Cmf/Cmf.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<CmfResult> GetCmf<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod = 20)
             where TQuote : IQuote
         {

--- a/indicators/Cmf/README.md
+++ b/indicators/Cmf/README.md
@@ -8,19 +8,20 @@ Created by Marc Chaikin, [Chaikin Money Flow](https://en.wikipedia.org/wiki/Chai
 ```csharp
 // usage
 IEnumerable<CmfResult> results =
-  Indicator.GetCmf(history, lookbackPeriod);  
+  history.GetCmf(lookbackPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) in the moving average.  Must be greater than 0.  Default is 20.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N+1` periods of `history`.
+You must have at least `N+1` periods of `history`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -48,7 +49,7 @@ The first `N-1` periods will have `null` values since there's not enough data to
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate 20-period CMF
-IEnumerable<CmfResult> results = Indicator.GetCmf(history,20);
+IEnumerable<CmfResult> results = history.GetCmf(20);
 
 // use results as needed
 CmfResult result = results.LastOrDefault();

--- a/indicators/ConnorsRsi/ConnorsRsi.cs
+++ b/indicators/ConnorsRsi/ConnorsRsi.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<ConnorsRsiResult> GetConnorsRsi<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int rsiPeriod = 3,
             int streakPeriod = 2,
             int rankPeriod = 100)

--- a/indicators/ConnorsRsi/README.md
+++ b/indicators/ConnorsRsi/README.md
@@ -8,21 +8,22 @@ Created by Laurence Connors, the [ConnorsRSI](https://alvarezquanttrading.com/wp
 ```csharp
 // usage
 IEnumerable<ConnorsRsiResult> results =
-  Indicator.GetConnorsRsi(history, rsiPeriod, streakPeriod, rankPeriod);  
+  history.GetConnorsRsi(rsiPeriod, streakPeriod, rankPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `rsiPeriod` | int | Lookback period (`R`) for the close price RSI.  Must be greater than 1.  Default is 3.
 | `streakPeriod` | int | Lookback period (`S`) for the streak RSI.  Must be greater than 1.  Default is 2.
 | `rankPeriod` | int | Lookback period (`P`) for the Percentile Rank.  Must be greater than 1.  Default is 100.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-`N` is the greater of `R+100` and `S`, and `P+2`.  You must supply at least `N` periods of `history`.  Since this uses a smoothing technique, we recommend you use at least `N+150` data points prior to the intended usage date for better precision.
+`N` is the greater of `R+100` and `S`, and `P+2`.  You must have at least `N` periods of `history`.  Since this uses a smoothing technique, we recommend you use at least `N+150` data points prior to the intended usage date for better precision.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -51,7 +52,7 @@ The first `R+S+P-1` periods will have `null` values since there's not enough dat
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate ConnorsRsi(3,2.100)
-IEnumerable<ConnorsRsiResult> results = Indicator.GetConnorsRsi(history,3,2,100);
+IEnumerable<ConnorsRsiResult> results = history.GetConnorsRsi(3,2,100);
 
 // use results as needed
 ConnorsRsiResult result = results.LastOrDefault();

--- a/indicators/Correlation/Correlation.cs
+++ b/indicators/Correlation/Correlation.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<CorrResult> GetCorrelation<TQuote>(
-            IEnumerable<TQuote> historyA,
+            this IEnumerable<TQuote> historyA,
             IEnumerable<TQuote> historyB,
             int lookbackPeriod)
             where TQuote : IQuote

--- a/indicators/Correlation/README.md
+++ b/indicators/Correlation/README.md
@@ -8,20 +8,21 @@
 ```csharp
 // usage
 IEnumerable<CorrResult> results =
-  Indicator.GetCorr(historyA, historyB, lookbackPeriod);  
+  historyA.GetCorr(historyB, lookbackPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `historyA` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical quotes (A).
 | `historyB` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical quotes (B) must have at least the same matching date elements of `historyA`.
 | `lookbackPeriod` | int | Number of periods (`N`) in the lookback period.  Must be greater than 0 to calculate; however we suggest a larger period for statistically appropriate sample size.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N` periods for both versions of `history`.  Mismatch histories will produce a `BadHistoryException`.  Historical price quotes should have a consistent frequency (day, hour, minute, etc).
+You must have at least `N` periods for both versions of `history`.  Mismatch histories will produce a `BadHistoryException`.  Historical price quotes should have a consistent frequency (day, hour, minute, etc).
+
+`historyA` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -50,7 +51,7 @@ IEnumerable<Quote> historySPX = GetHistoryFromFeed("SPX");
 IEnumerable<Quote> historyTSLA = GetHistoryFromFeed("TSLA");
 
 // calculate 20-period Correlation
-IEnumerable<CorrResult> results = Indicator.GetCorr(historySPX,historyTSLA,20);
+IEnumerable<CorrResult> results = historySPX.GetCorr(historyTSLA,20);
 
 // use results as needed
 CorrResult result = results.LastOrDefault();

--- a/indicators/Donchian/Donchian.cs
+++ b/indicators/Donchian/Donchian.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<DonchianResult> GetDonchian<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod = 20)
             where TQuote : IQuote
         {

--- a/indicators/Donchian/README.md
+++ b/indicators/Donchian/README.md
@@ -8,19 +8,20 @@ Created by Richard Donchian, [Donchian Channels](https://en.wikipedia.org/wiki/D
 ```csharp
 // usage
 IEnumerable<DonchianResult> results =
-  Indicator.GetDonchian(history, lookbackPeriod);  
+  history.GetDonchian(lookbackPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) for lookback period.  Must be greater than 0 to calculate; however we suggest a larger value for an appropriate sample size.  Default is 20.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N+1` periods of `history`.
+You must have at least `N+1` periods of `history`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -47,7 +48,7 @@ The first `N` periods will have `null` values since there's not enough data to c
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate Donchian(20)
-IEnumerable<DonchianResult> results = Indicator.GetDonchian(history,20);
+IEnumerable<DonchianResult> results = history.GetDonchian(20);
 
 // use results as needed
 DonchianResult result = results.LastOrDefault();

--- a/indicators/ElderRay/ElderRay.cs
+++ b/indicators/ElderRay/ElderRay.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<ElderRayResult> GetElderRay<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod = 13)
             where TQuote : IQuote
         {

--- a/indicators/ElderRay/README.md
+++ b/indicators/ElderRay/README.md
@@ -8,19 +8,20 @@ Created by Alexander Elder, the [Elder-ray Index](https://www.investopedia.com/t
 ```csharp
 // usage
 IEnumerable<ElderRayResult> results =
-  Indicator.GetElderRay(history, lookbackPeriod);  
+  history.GetElderRay(lookbackPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) for the underlying EMA evaluation.  Must be greater than 0.  Default is 13.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `2×N` or `N+100` periods of `history`, whichever is more.  Since this uses a smoothing technique, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.
+You must have at least `2×N` or `N+100` periods of `history`, whichever is more.  Since this uses a smoothing technique, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -50,7 +51,7 @@ IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate ElderRay(13)
 IEnumerable<ElderRayResult> results
-  = Indicator.GetElderRay(history,13);
+  = history.GetElderRay(13);
 
 // use results as needed
 ElderRayResult r = results.LastOrDefault();

--- a/indicators/Ema/DoubleEma.cs
+++ b/indicators/Ema/DoubleEma.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicators/type[@name="DEMA"]/*' />
         /// 
         public static IEnumerable<EmaResult> GetDoubleEma<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod)
             where TQuote : IQuote
         {

--- a/indicators/Ema/Ema.cs
+++ b/indicators/Ema/Ema.cs
@@ -9,7 +9,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicators/type[@name="EMA"]/*' />
         /// 
         public static IEnumerable<EmaResult> GetEma<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod)
             where TQuote : IQuote
         {

--- a/indicators/Ema/README.md
+++ b/indicators/Ema/README.md
@@ -8,31 +8,32 @@
 ```csharp
 // usage for EMA (standard)
 IEnumerable<EmaResult> results =
-  Indicator.GetEma(history, lookbackPeriod);
+  history.GetEma(lookbackPeriod);
 
 // usage for Double EMA
 IEnumerable<EmaResult> results =
-  Indicator.GetDoubleEma(history, lookbackPeriod);
+  history.GetDoubleEma(lookbackPeriod);
 
 // usage for Triple EMA
 IEnumerable<EmaResult> results =
-  Indicator.GetTripleEma(history, lookbackPeriod);
+  history.GetTripleEma(lookbackPeriod);
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) in the moving average.  Must be greater than 0.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-**EMA** (standard): You must supply at least `2×N` or `N+100` periods of `history`, whichever is more.  Since this uses a smoothing technique, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.
+**EMA** (standard): You must have at least `2×N` or `N+100` periods of `history`, whichever is more.  Since this uses a smoothing technique, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.
 
-**Double EMA**: You must supply at least `3×N` or `2×N+100` periods of `history`, whichever is more.  Since this uses a smoothing technique, we recommend you use at least `2×N+250` data points prior to the intended usage date for better precision.
+**Double EMA**: You must have at least `3×N` or `2×N+100` periods of `history`, whichever is more.  Since this uses a smoothing technique, we recommend you use at least `2×N+250` data points prior to the intended usage date for better precision.
 
-**Triple EMA**: You must supply at least `4×N` or `3×N+100` periods of `history`, whichever is more.  Since this uses a smoothing technique, we recommend you use at least `3×N+250` data points prior to the intended usage date for better precision.
+**Triple EMA**: You must have at least `4×N` or `3×N+100` periods of `history`, whichever is more.  Since this uses a smoothing technique, we recommend you use at least `3×N+250` data points prior to the intended usage date for better precision.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -64,7 +65,7 @@ Triple EMA: The first `3×N-2` periods will have `null` values since there's not
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate 20-period EMA
-IEnumerable<EmaResult> results = Indicator.GetEma(history,20);
+IEnumerable<EmaResult> results = history.GetEma(20);
 
 // use results as needed
 EmaResult result = results.LastOrDefault();

--- a/indicators/Ema/TripleEma.cs
+++ b/indicators/Ema/TripleEma.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicators/type[@name="TEMA"]/*' />
         /// 
         public static IEnumerable<EmaResult> GetTripleEma<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod)
             where TQuote : IQuote
         {

--- a/indicators/Epma/Epma.cs
+++ b/indicators/Epma/Epma.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicators/type[@name="Main"]/*' />
         /// 
         public static IEnumerable<EpmaResult> GetEpma<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod)
             where TQuote : IQuote
         {

--- a/indicators/Epma/README.md
+++ b/indicators/Epma/README.md
@@ -8,19 +8,20 @@ Endpoint Moving Average (EPMA), also known as Least Squares Moving Average (LSMA
 ```csharp
 // usage
 IEnumerable<EpmaResult> results =
-  Indicator.GetEpma(history, lookbackPeriod);  
+  history.GetEpma(lookbackPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) in the moving average.  Must be greater than 0.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N` periods of `history`.
+You must have at least `N` periods of `history`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -44,7 +45,7 @@ The first `N-1` periods will have `null` values since there's not enough data to
 IEnumerable<Quote> history = GetHistoryFromFeed("MSFT");
 
 // calculate 20-period EPMA
-IEnumerable<EpmaResult> results = Indicator.GetEpma(history,20);
+IEnumerable<EpmaResult> results = history.GetEpma(20);
 
 // use results as needed
 EpmaResult result = results.LastOrDefault();

--- a/indicators/Fcb/Fcb.cs
+++ b/indicators/Fcb/Fcb.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<FcbResult> GetFcb<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int windowSpan = 2)
             where TQuote : IQuote
         {

--- a/indicators/Fcb/README.md
+++ b/indicators/Fcb/README.md
@@ -8,21 +8,22 @@ Created by Edward William Dreiss, Fractal Chaos Bands outline high and low price
 ```csharp
 // usage
 IEnumerable<FcbResult> results =
-  Indicator.GetFcb(history, lookbackPeriod);  
+  history.GetFcb(lookbackPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `windowSpan` | int | Fractal evaluation window span width (`S`).  Must be at least 2.  Default is 2.
 
 The total evaluation window size is `2×S+1`, representing `±S` from the evalution date.  See [Williams Fractal](../Fractal/README.md#content) for more information about Fractals and `windowSpan`.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `2×S+1` periods of `history`; however, more is typically provided since this is a chartable candlestick pattern.
+You must have at least `2×S+1` periods of `history`; however, more is typically provided since this is a chartable candlestick pattern.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -48,7 +49,7 @@ We always return the same number of elements as there are in the historical quot
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate Fcb(14)
-IEnumerable<FcbResult> results = Indicator.GetFcb(history,14);
+IEnumerable<FcbResult> results = history.GetFcb(14);
 
 // use results as needed
 FcbResult result = results.LastOrDefault();

--- a/indicators/FisherTransform/FisherTransform.cs
+++ b/indicators/FisherTransform/FisherTransform.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<FisherTransformResult> GetFisherTransform<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod = 10)
             where TQuote : IQuote
         {

--- a/indicators/FisherTransform/README.md
+++ b/indicators/FisherTransform/README.md
@@ -8,19 +8,20 @@ Created by John Ehlers, the [Fisher Transform](https://www.investopedia.com/term
 ```csharp
 // usage
 IEnumerable<FisherTransformResult> results =
-  Indicator.GetFisherTransform(history, lookbackPeriod);  
+  history.GetFisherTransform(lookbackPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) in the lookback window.  Must be greater than 0.  Default is 10.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N` periods of `history`.
+You must have at least `N` periods of `history`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -48,7 +49,7 @@ IEnumerable<Quote> history = GetHistoryFromFeed("MSFT");
 
 // calculate 10-period FisherTransform
 IEnumerable<FisherTransformResult> results =
-  Indicator.GetFisherTransform(history,10);
+  history.GetFisherTransform(10);
 
 // use results as needed
 FisherTransformResult result = results.LastOrDefault();

--- a/indicators/ForceIndex/ForceIndex.cs
+++ b/indicators/ForceIndex/ForceIndex.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<ForceIndexResult> GetForceIndex<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod)
             where TQuote : IQuote
         {

--- a/indicators/ForceIndex/README.md
+++ b/indicators/ForceIndex/README.md
@@ -8,19 +8,20 @@ Created by Alexander Elder, the [Force Index](https://en.wikipedia.org/wiki/Forc
 ```csharp
 // usage
 IEnumerable<ForceIndexResult> results =
-  Indicator.GetForceIndex(history, lookbackPeriod);  
+  history.GetForceIndex(lookbackPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Lookback window (`N`) for the EMA of Force Index.  Must be greater than 0 and is commonly 2 or 13 (shorter/longer view).
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N+100` for `2×N` periods of `history`, whichever is more.  Since this uses a smoothing technique for EMA, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.
+You must have at least `N+100` for `2×N` periods of `history`, whichever is more.  Since this uses a smoothing technique for EMA, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -47,7 +48,7 @@ We always return the same number of elements as there are in the historical quot
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate ForceIndex(13)
-IEnumerable<ForceIndexResult> results = Indicator.GetForceIndex(history,13);
+IEnumerable<ForceIndexResult> results = history.GetForceIndex(13);
 
 // use results as needed
 ForceIndexResult result = results.LastOrDefault();

--- a/indicators/Fractal/Fractal.cs
+++ b/indicators/Fractal/Fractal.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<FractalResult> GetFractal<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int windowSpan = 2)
             where TQuote : IQuote
         {

--- a/indicators/Fractal/README.md
+++ b/indicators/Fractal/README.md
@@ -8,21 +8,22 @@ Created by Larry Williams, [Fractal](https://www.investopedia.com/terms/f/fracta
 ```csharp
 // usage
 IEnumerable<FractalResult> results =
-  Indicator.GetFractal(history,windowSpan);  
+  history.GetFractal(windowSpan);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `windowSpan` | int | Evaluation window span width (`S`).  Must be at least 2.  Default is 2.
 
 The total evaluation window size is `2×S+1`, representing `±S` from the evalution date.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `2×S+1` periods of `history`; however, more is typically provided since this is a chartable candlestick pattern.
+You must have at least `2×S+1` periods of `history`; however, more is typically provided since this is a chartable candlestick pattern.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -50,7 +51,7 @@ We always return the same number of elements as there are in the historical quot
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate Fractal(5)
-IEnumerable<FractalResult> results = Indicator.GetFractal(history,5);
+IEnumerable<FractalResult> results = history.GetFractal(5);
 
 // use results as needed
 FractalResult r = results.Where(x=>x.FractalBear!=null).LastOrDefault();

--- a/indicators/Gator/Gator.cs
+++ b/indicators/Gator/Gator.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<GatorResult> GetGator<TQuote>(
-            IEnumerable<TQuote> history)
+            this IEnumerable<TQuote> history)
             where TQuote : IQuote
         {
 

--- a/indicators/Gator/README.md
+++ b/indicators/Gator/README.md
@@ -8,18 +8,14 @@ Created by Bill Williams, the Gator Oscillator is an expanded view of [Williams 
 ```csharp
 // usage
 IEnumerable<GatorResult> results =
-  Indicator.GetGator(history);
+  history.GetGator();
 ```
 
-## Parameters
+## Historical quotes requirements
 
-| name | type | notes
-| -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
+You must have at least 115 periods of `history`. Since this uses a smoothing technique, we recommend you use at least 265 data points prior to the intended usage date for better precision.
 
-### Minimum history requirements
-
-You must supply at least 115 periods of `history`. Since this uses a smoothing technique, we recommend you use at least 265 data points prior to the intended usage date for better precision.
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -48,7 +44,7 @@ The first 10-20 periods will have `null` values since there's not enough data to
 IEnumerable<Quote> history = GetHistoryFromFeed("MSFT");
 
 // calculate the Gator Oscillator
-IEnumerable<GatorResult> results = Indicator.GetGator(history);
+IEnumerable<GatorResult> results = history.GetGator();
 
 // use results as needed
 GatorResult result = results.LastOrDefault();

--- a/indicators/HeikinAshi/HeikinAshi.cs
+++ b/indicators/HeikinAshi/HeikinAshi.cs
@@ -9,7 +9,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<HeikinAshiResult> GetHeikinAshi<TQuote>(
-            IEnumerable<TQuote> history)
+            this IEnumerable<TQuote> history)
             where TQuote : IQuote
         {
 

--- a/indicators/HeikinAshi/README.md
+++ b/indicators/HeikinAshi/README.md
@@ -8,18 +8,14 @@ Created by Munehisa Homma, [Heikin-Ashi](https://en.wikipedia.org/wiki/Candlesti
 ```csharp
 // usage
 IEnumerable<HeikinAshiResult> results =
-  Indicator.GetHeikinAshi(history);  
+  history.GetHeikinAshi();  
 ```
 
-## Parameters
+## Historical quotes requirements
 
-| name | type | notes
-| -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
+You must have at least two periods of `history`; however, more is typically provided since this is a chartable candlestick pattern.
 
-### Minimum history requirements
-
-You must supply at least two periods of `history`; however, more is typically provided since this is a chartable candlestick pattern.
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -46,7 +42,7 @@ The first period will have `null` values since there's not enough data to calcul
 IEnumerable<Quote> history = GetHistoryFromFeed("MSFT");
 
 // calculate
-IEnumerable<HeikinAshiResult> results = Indicator.GetHeikinAshi(history);
+IEnumerable<HeikinAshiResult> results = history.GetHeikinAshi();
 
 // use results as needed
 HeikinAshiResult result = results.LastOrDefault();

--- a/indicators/Hma/Hma.cs
+++ b/indicators/Hma/Hma.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<HmaResult> GetHma<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod)
             where TQuote : IQuote
         {

--- a/indicators/Hma/README.md
+++ b/indicators/Hma/README.md
@@ -8,19 +8,20 @@ Created by Alan Hull, the [Hull Moving Average](https://alanhull.com/hull-moving
 ```csharp
 // usage
 IEnumerable<HmaResult> results =
-  Indicator.GetHma(history, lookbackPeriod);  
+  history.GetHma(lookbackPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) in the moving average.  Must be greater than 1.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N` periods of `history`.
+You must have at least `N` periods of `history`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -44,7 +45,7 @@ The first `N-(integer of SQRT(N))-1` periods will have `null` values since there
 IEnumerable<Quote> history = GetHistoryFromFeed("MSFT");
 
 // calculate 20-period HMA
-IEnumerable<HmaResult> results = Indicator.GetHma(history,20);
+IEnumerable<HmaResult> results = history.GetHma(20);
 
 // use results as needed
 HmaResult result = results.LastOrDefault();

--- a/indicators/HtTrendline/HtTrendline.cs
+++ b/indicators/HtTrendline/HtTrendline.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<HtlResult> GetHtTrendline<TQuote>(
-            IEnumerable<TQuote> history)
+            this IEnumerable<TQuote> history)
             where TQuote : IQuote
         {
 

--- a/indicators/HtTrendline/README.md
+++ b/indicators/HtTrendline/README.md
@@ -8,18 +8,14 @@ Created by John Ehlers, the Hilbert Transform Instantaneous Trendline is a 5-per
 ```csharp
 // usage
 IEnumerable<HtlResult> results =
-  Indicator.GetHtTrendline(history);
+  history.GetHtTrendline();
 ```
 
-## Parameters
+## Historical quotes requirements
 
-| name | type | notes
-| -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
+Since this indicator has a warmup period, you must have at least `100` periods of `history`.
 
-### Minimum history requirements
-
-Since this indicator has a warmup period, you must supply at least `100` periods of `history`.
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -46,7 +42,7 @@ The first `6` periods will have `null` values for `SmoothPrice` since there's no
 IEnumerable<Quote> history = GetHistoryFromFeed("MSFT");
 
 // calculate HT Trendline
-IEnumerable<HtlResult> results = Indicator.GetHtTrendline(history);
+IEnumerable<HtlResult> results = history.GetHtTrendline();
 
 // use results as needed
 HtlResult result = results.LastOrDefault();

--- a/indicators/Ichimoku/Ichimoku.cs
+++ b/indicators/Ichimoku/Ichimoku.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<IchimokuResult> GetIchimoku<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int signalPeriod = 9,
             int shortSpanPeriod = 26,
             int longSpanPeriod = 52)

--- a/indicators/Ichimoku/README.md
+++ b/indicators/Ichimoku/README.md
@@ -8,21 +8,22 @@ Created by Goichi Hosoda (細田悟一, Hosoda Goichi), [Ichimoku Cloud](https:/
 ```csharp
 // usage
 IEnumerable<IchimokuResult> results =
-  Indicator.GetIchimoku(history, signalPeriod, shortSpanPeriod, longSpanPeriod);  
+  history.GetIchimoku(signalPeriod, shortSpanPeriod, longSpanPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `signalPeriod` | int | Number of periods (`N`) in the Tenkan-sen midpoint evaluation.  Must be greater than 0.  Default is 9.
 | `shortSpanPeriod` | int | Number of periods (`S`) in the shorter Kijun-sen midpoint evaluation.  It also sets the Chikou span lag/shift.  Must be greater than 0.  Default is 26.
 | `longSpanPeriod` | int | Number of periods (`L`) in the longer Senkou leading span B midpoint evaluation.  Must be greater than `S`.  Default is 52.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least the greater of `N`,`S`, or `L` periods of `history`; though, given the leading and lagging nature, we recommend notably more.
+You must have at least the greater of `N`,`S`, or `L` periods of `history`; though, given the leading and lagging nature, we recommend notably more.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -51,7 +52,7 @@ IEnumerable<Quote> history = GetHistoryFromFeed("MSFT");
 
 // calculate ICHIMOKU(9,26,52)
 IEnumerable<IchimokuResult> results =
-  Indicator.GetIchimoku(history,9,26,52);
+  history.GetIchimoku(9,26,52);
 
 // use results as needed
 IchimokuResult result = results.LastOrDefault();

--- a/indicators/Kama/Kama.cs
+++ b/indicators/Kama/Kama.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<KamaResult> GetKama<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int erPeriod = 10,
             int fastPeriod = 2,
             int slowPeriod = 30)

--- a/indicators/Kama/README.md
+++ b/indicators/Kama/README.md
@@ -8,21 +8,22 @@ Created by Perry Kaufman, [KAMA](https://school.stockcharts.com/doku.php?id=tech
 ```csharp
 // usage
 IEnumerable<KamaResult> results =
-  Indicator.GetKama(history, erPeriod, fastPeriod, slowPeriod);  
+  history.GetKama(erPeriod, fastPeriod, slowPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `erPeriod` | int | Number of Efficiency Ratio (volatility) periods (`E`).  Must be greater than 0.  Default is 10.
 | `fastPeriod` | int | Number of Fast EMA periods.  Must be greater than 0.  Default is 2.
 | `slowPeriod` | int | Number of Slow EMA periods.  Must be greater than `fastPeriod`.  Default is 30.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `6×E` or `E+100` periods of `history`, whichever is more.  Since this uses a smoothing technique, we recommend you use at least `10×E` data points prior to the intended usage date for better precision.
+You must have at least `6×E` or `E+100` periods of `history`, whichever is more.  Since this uses a smoothing technique, we recommend you use at least `10×E` data points prior to the intended usage date for better precision.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -51,7 +52,7 @@ More about Efficiency Ratio: ER fluctuates between 0 and 1, but these extremes a
 IEnumerable<Quote> history = GetHistoryFromFeed("MSFT");
 
 // calculate KAMA(10,2,30)
-IEnumerable<KamaResult> results = Indicator.GetKama(history,10,2,30);
+IEnumerable<KamaResult> results = history.GetKama(10,2,30);
 
 // use results as needed
 KamaResult result = results.LastOrDefault();

--- a/indicators/Keltner/Keltner.cs
+++ b/indicators/Keltner/Keltner.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<KeltnerResult> GetKeltner<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int emaPeriod = 20,
             decimal multiplier = 2,
             int atrPeriod = 10)

--- a/indicators/Keltner/README.md
+++ b/indicators/Keltner/README.md
@@ -8,21 +8,22 @@ Created by Chester W. Keltner, [Keltner Channels](https://en.wikipedia.org/wiki/
 ```csharp
 // usage
 IEnumerable<KeltnerResult> results =
-  Indicator.GetKeltner(history, emaPeriod, multiplier, atrPeriod);  
+  history.GetKeltner(emaPeriod, multiplier, atrPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `emaPeriod` | int | Number of lookback periods (`E`) for the center line moving average.  Must be greater than 1 to calculate.  Default is 20.
 | `multiplier` | decimal | ATR Multiplier. Must be greater than 0.  Default is 2.
 | `atrPeriod` | int | Number of lookback periods (`A`) for the Average True Range.  Must be greater than 1 to calculate.  Default is 10.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `2×N` or `N+100` periods of `history`, whichever is more, where `N` is the greater of `E` or `A` periods.  Since this uses a smoothing technique, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.
+You must have at least `2×N` or `N+100` periods of `history`, whichever is more, where `N` is the greater of `E` or `A` periods.  Since this uses a smoothing technique, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -51,7 +52,7 @@ The first `N-1` periods will have `null` values since there's not enough data to
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate Keltner(20)
-IEnumerable<KeltnerResult> results = Indicator.GetKeltner(history,20,2.0,10);
+IEnumerable<KeltnerResult> results = history.GetKeltner(20,2.0,10);
 
 // use results as needed
 KeltnerResult result = results.LastOrDefault();

--- a/indicators/Kvo/Kvo.cs
+++ b/indicators/Kvo/Kvo.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<KvoResult> GetKvo<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int fastPeriod = 34,
             int slowPeriod = 55,
             int signalPeriod = 13)

--- a/indicators/Kvo/README.md
+++ b/indicators/Kvo/README.md
@@ -8,21 +8,22 @@ Created by Stephen Klinger, the [Klinger Volume Oscillator](https://www.investop
 ```csharp
 // usage
 IEnumerable<KvoResult> results = 
-  Indicator.GetKvo(history, shortPeriod, longPeriod, signalPeriod);  
+  history.GetKvo(shortPeriod, longPeriod, signalPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `fastPeriod` | int | Number of lookback periods (`F`) for the short-term EMA.  Must be greater than 2.  Default is 34.
 | `slowPeriod` | int | Number of lookback periods (`L`) for the long-term EMA.  Must be greater than `F`.  Default is 55.
 | `signalPeriod` | int | Number of lookback periods for the signal line.  Must be greater than 0.  Default is 13.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `L+100` periods of `history`.  Since this uses a smoothing technique, we recommend you use at least `L+150` data points prior to the intended usage date for better precision.
+You must have at least `L+100` periods of `history`.  Since this uses a smoothing technique, we recommend you use at least `L+150` data points prior to the intended usage date for better precision.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -49,7 +50,7 @@ The first `L+1` periods will have `null` values since there's not enough data to
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate Klinger(34,55,13)
-IEnumerable<KvoResult> results = Indicator.GetKvo(history,34,55,13);
+IEnumerable<KvoResult> results = history.GetKvo(34,55,13);
 
 // use results as needed
 KvoResult result = results.LastOrDefault();

--- a/indicators/MaEnvelopes/MaEnvelopes.cs
+++ b/indicators/MaEnvelopes/MaEnvelopes.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<MaEnvelopeResult> GetMaEnvelopes<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod,
             double percentOffset = 2.5,
             MaType movingAverageType = MaType.SMA)

--- a/indicators/MaEnvelopes/README.md
+++ b/indicators/MaEnvelopes/README.md
@@ -8,21 +8,22 @@
 ```csharp
 // usage
 IEnumerable<MaEnvelopeResult> results =
-  Indicator.GetSmaEnvelopes(history, lookbackPeriod, percentOffset, movingAverageType);  
+  history.GetSmaEnvelopes(lookbackPeriod, percentOffset, movingAverageType);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) in the moving average.  Must be greater than 1.
 | `percentOffset` | double | Percent offset for envelope width.  Example: 3.5% would be entered as 3.5 (not 0.035).  Must be greater than 0.  Typical values range from 2 to 10.  Default is 2.5.
 | `movingAverageType` | MaType | Type of moving average (e.g. SMA, EMA, HMA).  See [MaType options](#matype-options) below.  Default is `MaType.SMA`.
 
-### Minimum history requirements
+### Historical quotes requirements
 
 See links in the supported [MaType options](#matype-options) section below for details on the inherited requirements for `history` and `lookbackPeriod`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ### MaType options
 
@@ -70,7 +71,7 @@ IEnumerable<Quote> history = GetHistoryFromFeed("MSFT");
 
 // calculate 20-period SMA envelopes with 2.5% offset
 IEnumerable<MaEnvelopeResult> results = 
-    Indicator.GetMaEnvelopes(history,20,2.5,MaType.SMA);
+    history.GetMaEnvelopes(20,2.5,MaType.SMA);
 
 // use results as needed
 MaEnvelopeResult result = results.LastOrDefault();

--- a/indicators/Macd/Macd.cs
+++ b/indicators/Macd/Macd.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<MacdResult> GetMacd<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int fastPeriod = 12,
             int slowPeriod = 26,
             int signalPeriod = 9)

--- a/indicators/Macd/README.md
+++ b/indicators/Macd/README.md
@@ -8,21 +8,22 @@ Created by Gerald Appel, [MACD](https://en.wikipedia.org/wiki/MACD) is a simple 
 ```csharp
 // usage
 IEnumerable<MacdResult> results =
-  Indicator.GetMacd(history, fastPeriod, slowPeriod, signalPeriod);  
+  history.GetMacd(fastPeriod, slowPeriod, signalPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `fastPeriod` | int | Number of periods (`F`) for the faster moving average.  Must be greater than 0.  Default is 12.
 | `slowPeriod` | int | Number of periods (`S`) for the slower moving average.  Must be greater than `fastPeriod`.  Default is 26.
 | `signalPeriod` | int | Number of periods (`P`) for the moving average of MACD.  Must be greater than or equal to 0.  Default is 9.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `2×(S+P)` or `S+P+100` worth of `history`, whichever is more.  Since this uses a smoothing technique, we recommend you use at least `S+P+250` data points prior to the intended usage date for better precision.
+You must have at least `2×(S+P)` or `S+P+100` worth of `history`, whichever is more.  Since this uses a smoothing technique, we recommend you use at least `S+P+250` data points prior to the intended usage date for better precision.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -50,7 +51,7 @@ The first `S-1` slow periods will have `null` values since there's not enough da
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate MACD(12,26,9)
-IEnumerable<MacdResult> results = Indicator.GetMacd(history,12,26,9);
+IEnumerable<MacdResult> results = history.GetMacd(12,26,9);
 
 // use results as needed
 MacdResult result = results.LastOrDefault();

--- a/indicators/Mama/Mama.cs
+++ b/indicators/Mama/Mama.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<MamaResult> GetMama<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             decimal fastLimit = 0.5m,
             decimal slowLimit = 0.05m)
             where TQuote : IQuote

--- a/indicators/Mama/README.md
+++ b/indicators/Mama/README.md
@@ -8,20 +8,21 @@ Created by John Ehlers, the [MAMA](http://mesasoftware.com/papers/MAMA.pdf) indi
 ```csharp
 // usage
 IEnumerable<MamaResult> results =
-  Indicator.GetMama(history, fastLimit, slowLimit);  
+  history.GetMama(fastLimit, slowLimit);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `fastLimit` | decimal | Fast limit threshold.  Must be greater than `slowLimit` and less than 1.  Default is 0.5.
 | `slowLimit` | decimal | Slow limit threshold.  Must be greater than 0.  Default is 0.05.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-Since this indicator has a warmup period, you must supply at least `50` periods of `history`.
+Since this indicator has a warmup period, you must have at least `50` periods of `history`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -48,7 +49,7 @@ The first `5` periods will have `null` values for MAMA since there's not enough 
 IEnumerable<Quote> history = GetHistoryFromFeed("MSFT");
 
 // calculate Mama(0.5,0.05)
-IEnumerable<MamaResult> results = Indicator.GetMama(history,0.5,0.05);
+IEnumerable<MamaResult> results = history.GetMama(0.5,0.05);
 
 // use results as needed
 MamaResult result = results.LastOrDefault();

--- a/indicators/Mfi/Mfi.cs
+++ b/indicators/Mfi/Mfi.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<MfiResult> GetMfi<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod = 14)
             where TQuote : IQuote
         {

--- a/indicators/Mfi/README.md
+++ b/indicators/Mfi/README.md
@@ -8,19 +8,20 @@ Created by Quong and Soudack, the [Money Flow Index](https://en.wikipedia.org/wi
 ```csharp
 // usage
 IEnumerable<MfiResult> results =
-  Indicator.GetMfi(history, lookbackPeriod);
+  history.GetMfi(lookbackPeriod);
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) in the lookback period.  Must be greater than 1. Default is 14.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N+1` historical quotes.
+You must have at least `N+1` historical quotes.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -44,7 +45,7 @@ The first `N` periods will have `null` MFI values since they cannot be calculate
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate
-IEnumerable<MfiResult> results = Indicator.GetMfi(history,14);
+IEnumerable<MfiResult> results = history.GetMfi(14);
 
 // use results as needed
 MfiResult result = results.LastOrDefault();

--- a/indicators/Obv/Obv.cs
+++ b/indicators/Obv/Obv.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<ObvResult> GetObv<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int? smaPeriod = null)
             where TQuote : IQuote
         {

--- a/indicators/Obv/README.md
+++ b/indicators/Obv/README.md
@@ -8,23 +8,24 @@ Popularized by Joseph Granville, [On-balance Volume](https://en.wikipedia.org/wi
 ```csharp
 // usage
 IEnumerable<ObvResult> results =
-  Indicator.GetObv(history);
+  history.GetObv();
 
 // usage with optional overlay SMA of OBV (shown above)
 IEnumerable<ObvResult> results =
-  Indicator.GetObv(history, smaPeriod);  
+  history.GetObv(smaPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `smaPeriod` | int | Optional.  Number of periods (`N`) in the moving average of OBV.  Must be greater than 0, if specified.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least two historical quotes; however, since this is a trendline, more is recommended.
+You must have at least two historical quotes; however, since this is a trendline, more is recommended.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -51,7 +52,7 @@ The first period OBV will have `0` value since there's not enough data to calcul
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate
-IEnumerable<ObvResult> results = Indicator.GetObv(history);
+IEnumerable<ObvResult> results = history.GetObv();
 
 // use results as needed
 ObvResult result = results.LastOrDefault();

--- a/indicators/ParabolicSar/ParabolicSar.cs
+++ b/indicators/ParabolicSar/ParabolicSar.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<ParabolicSarResult> GetParabolicSar<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             decimal accelerationStep = (decimal)0.02,
             decimal maxAccelerationFactor = (decimal)0.2)
             where TQuote : IQuote

--- a/indicators/ParabolicSar/README.md
+++ b/indicators/ParabolicSar/README.md
@@ -8,20 +8,21 @@ Created by J. Welles Wilder, [Parabolic SAR](https://en.wikipedia.org/wiki/Parab
 ```csharp
 // usage
 IEnumerable<ParabolicSarResult> results =
-  Indicator.GetParabolicSar(history, accelerationStep, maxAccelerationFactor);  
+  history.GetParabolicSar(accelerationStep, maxAccelerationFactor);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `accelerationStep` | decimal | Incremental step size.  Must be greater than 0.  Default is 0.02
 | `maxAccelerationFactor` | decimal | Maximimum step limit.  Must be greater than `accelerationStep`.  Default is 0.2
 
-### Minimum history requirements
+### Historical quotes requirements
 
 At least two history records are required to calculate; however, we recommend at least 100 data points.  Initial Parabolic SAR values prior to the first reversal are not accurate and are excluded from the results.  Therefore, provide sufficient history to capture prior trend reversals, before your intended usage period.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -46,7 +47,7 @@ The first trend will have `null` values since it is not accurate and based on an
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate ParabolicSar(0.02,0.2)
-IEnumerable<ParabolicSarResult> results = Indicator.GetParabolicSar(history,0.02,0.2);
+IEnumerable<ParabolicSarResult> results = history.GetParabolicSar(0.02,0.2);
 
 // use results as needed
 ParabolicSarResult result = results.LastOrDefault();

--- a/indicators/PivotPoints/PivotPoints.cs
+++ b/indicators/PivotPoints/PivotPoints.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<PivotPointsResult> GetPivotPoints<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             PeriodSize windowSize,
             PivotPointType pointType = PivotPointType.Standard)
             where TQuote : IQuote

--- a/indicators/PivotPoints/README.md
+++ b/indicators/PivotPoints/README.md
@@ -9,20 +9,21 @@ See also the alternative [Rolling Pivot Points](../RollingPivots/README.md#conte
 ```csharp
 // usage
 IEnumerable<PivotPointResult> results =
-  Indicator.GetPivotPoints(history, windowSize, pointType);  
+  history.GetPivotPoints(windowSize, pointType);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc)
 | `windowSize` | PeriodSize | Size of the lookback window
 | `pointType` | PivotPointType | Type of Pivot Point.  Default is `PivotPointType.Standard`
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `2` windows of `history`.  For example, if you specify a `Week` window size, you need at least 14 calendar days of `history`.
+You must have at least `2` windows of `history`.  For example, if you specify a `Week` window size, you need at least 14 calendar days of `history`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ### PeriodSize options (for windowSize)
 
@@ -74,7 +75,7 @@ IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate Woodie-style month-based Pivot Points
 IEnumerable<PivotPointResult> results =
-  Indicator.GetPivotPoints(history,PeriodSize.Month,PivotPointType.Woodie);
+  history.GetPivotPoints(PeriodSize.Month,PivotPointType.Woodie);
 
 // use results as needed
 PivotPointsResult result = results.LastOrDefault();

--- a/indicators/Pmo/Pmo.cs
+++ b/indicators/Pmo/Pmo.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<PmoResult> GetPmo<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int timePeriod = 35,
             int smoothingPeriod = 20,
             int signalPeriod = 10)

--- a/indicators/Pmo/README.md
+++ b/indicators/Pmo/README.md
@@ -8,21 +8,22 @@ Created by Carl Swenlin, the DecisionPoint [Price Momentum Oscillator](https://s
 ```csharp
 // usage
 IEnumerable<PmoResult> results =
-  Indicator.GetPmo(history, timePeriod, smoothingPeriod, signalPeriod);
+  history.GetPmo(timePeriod, smoothingPeriod, signalPeriod);
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `timePeriod` | int | Number of periods (`T`) for ROC EMA smoothing.  Must be greater than 1.  Default is 35.
 | `smoothingPeriod` | int | Number of periods (`S`) for PMO EMA smoothing.  Must be greater than 0.  Default is 20.
 | `signalPeriod` | int | Number of periods (`G`) for Signal line EMA.  Must be greater than 0.  Default is 10.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N` periods of `history`, where `N` is the greater of `T+S`,`2×T`, or `T+100`.  Since this uses multiple smoothing operations, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.
+You must have at least `N` periods of `history`, where `N` is the greater of `T+S`,`2×T`, or `T+100`.  Since this uses multiple smoothing operations, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -49,7 +50,7 @@ The first `T+S-1` periods will have `null` values for PMO since there's not enou
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate 20-period PMO
-IEnumerable<PmoResult> results = Indicator.GetPmo(history,35,20,10);
+IEnumerable<PmoResult> results = history.GetPmo(35,20,10);
 
 // use results as needed
 PmoResult result = results.LastOrDefault();

--- a/indicators/Prs/Prs.cs
+++ b/indicators/Prs/Prs.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<PrsResult> GetPrs<TQuote>(
-            IEnumerable<TQuote> historyBase,
+            this IEnumerable<TQuote> historyBase,
             IEnumerable<TQuote> historyEval,
             int? lookbackPeriod = null,
             int? smaPeriod = null)

--- a/indicators/Prs/README.md
+++ b/indicators/Prs/README.md
@@ -8,25 +8,26 @@
 ```csharp
 // usage
 IEnumerable<PrsResult> results =
-  Indicator.GetPrs(historyBase, historyEval);  
+  historyBase.GetPrs(historyEval);  
 
 // usage with optional lookback period and SMA of PRS (shown above)
 IEnumerable<PrsResult> results =
-  Indicator.GetPrs(historyBase, historyEval, lookbackPeriod, smaPeriod);  
+  historyBase.GetPrs(historyEval, lookbackPeriod, smaPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `historyBase` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | This is usually market index data, but could be any baseline data that you might use for comparison.
-| `historyEval` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical quotes for evaluation.  You must supply the same number of periods as `historyBase`.
+| `historyEval` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical quotes for evaluation.  You must have the same number of periods as `historyBase`.
 | `lookbackPeriod` | int | Optional.  Number of periods (`N`) to lookback to compute % difference.  Must be greater than 0 if specified or `null`.
 | `smaPeriod` | int | Optional.  Number of periods (`S`) in the SMA lookback period for `Prs`.  Must be greater than 0.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N` periods of `historyBase` to calculate `PrsPercent` if `lookbackPeriod` is specified; otherwise, you must specify at least `S+1` periods.  More than the minimum is typically specified.  For this indicator, the elements must match (e.g. the `n`th elements must be the same date).  An `Exception` will be thrown for mismatch dates.  Historical price quotes should have a consistent frequency (day, hour, minute, etc).
+You must have at least `N` periods of `historyBase` to calculate `PrsPercent` if `lookbackPeriod` is specified; otherwise, you must specify at least `S+1` periods.  More than the minimum is typically specified.  For this indicator, the elements must match (e.g. the `n`th elements must be the same date).  An `Exception` will be thrown for mismatch dates.  Historical price quotes should have a consistent frequency (day, hour, minute, etc).
+
+`historyBase` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -53,7 +54,7 @@ IEnumerable<Quote> historySPX = GetHistoryFromFeed("SPX");
 IEnumerable<Quote> historyTSLA = GetHistoryFromFeed("TSLA");
 
 // calculate 14-period PRS
-IEnumerable<PrResult> results = Indicator.GetPrs(historySPX,historyTSLA,14);
+IEnumerable<PrResult> results = historySPX.GetPrs(historyTSLA,14);
 
 // use results as needed
 PrResult result = results.LastOrDefault();

--- a/indicators/Pvo/Pvo.cs
+++ b/indicators/Pvo/Pvo.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<PvoResult> GetPvo<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int fastPeriod = 12,
             int slowPeriod = 26,
             int signalPeriod = 9)

--- a/indicators/Pvo/README.md
+++ b/indicators/Pvo/README.md
@@ -8,21 +8,22 @@ The [Percentage Volume Oscillator](https://school.stockcharts.com/doku.php?id=te
 ```csharp
 // usage
 IEnumerable<PvoResult> results =
-  Indicator.GetPvo(history, fastPeriod, slowPeriod, signalPeriod);  
+  history.GetPvo(fastPeriod, slowPeriod, signalPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `fastPeriod` | int | Number of periods (`F`) for the faster moving average.  Must be greater than 0.  Default is 12.
 | `slowPeriod` | int | Number of periods (`S`) for the slower moving average.  Must be greater than `fastPeriod`.  Default is 26.
 | `signalPeriod` | int | Number of periods (`P`) for the moving average of PVO.  Must be greater than or equal to 0.  Default is 9.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `2×(S+P)` or `S+P+100` worth of `history`, whichever is more.  Since this uses a smoothing technique, we recommend you use at least `S+P+250` data points prior to the intended usage date for better precision.
+You must have at least `2×(S+P)` or `S+P+100` worth of `history`, whichever is more.  Since this uses a smoothing technique, we recommend you use at least `S+P+250` data points prior to the intended usage date for better precision.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -50,7 +51,7 @@ The first `S-1` slow periods will have `null` values since there's not enough da
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate Pvo(12,26,9)
-IEnumerable<PvoResult> results = Indicator.GetPvo(history,12,26,9);
+IEnumerable<PvoResult> results = history.GetPvo(12,26,9);
 
 // use results as needed
 PvoResult result = results.LastOrDefault();

--- a/indicators/Roc/README.md
+++ b/indicators/Roc/README.md
@@ -8,24 +8,25 @@
 ```csharp
 // usage
 IEnumerable<RocResult> results =
-  Indicator.GetRoc(history, lookbackPeriod);
+  history.GetRoc(lookbackPeriod);
 
 // usage with optional SMA of ROC (shown above)
 IEnumerable<RocResult> results =
-  Indicator.GetRoc(history, lookbackPeriod, smaPeriod);
+  history.GetRoc(lookbackPeriod, smaPeriod);
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) to go back.  Must be greater than 0.
 | `smaPeriod` | int | Optional.  Number of periods in the moving average of ROC.  Must be greater than 0, if specified.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N+1` periods of `history`.
+You must have at least `N+1` periods of `history`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -50,7 +51,7 @@ The first `N` periods will have `null` values for ROC since there's not enough d
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate 20-period ROC
-IEnumerable<RocResult> results = Indicator.GetRoc(history,20);
+IEnumerable<RocResult> results = history.GetRoc(20);
 
 // use results as needed
 RocResult result = results.LastOrDefault();
@@ -68,14 +69,14 @@ ROC on 12/31/2018 was -8.25%
 ```csharp
 // usage
 IEnumerable<RocWbResult> results =
-  Indicator.GetRocWb(history, lookbackPeriod, emaPeriod, stdDevPeriod);
+  history.GetRocWb(lookbackPeriod, emaPeriod, stdDevPeriod);
 ```
 
 ### Parameters with Bands
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
+
 | `lookbackPeriod` | int | Number of periods (`N`) to go back.  Must be greater than 0.  Typical values range from 10-20.
 | `emaPeriod` | int | Number of periods for the ROC EMA line.  Must be greater than 0.  Standard is 3.
 | `stdDevPeriod` | int | Number of periods the standard deviation for upper/lower band lines.  Must be greater than 0 and not more than `lookbackPeriod`.  Standard is to use same value as `lookbackPeriod`.

--- a/indicators/Roc/Roc.cs
+++ b/indicators/Roc/Roc.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicators/type[@name="Main"]/*' />
         /// 
         public static IEnumerable<RocResult> GetRoc<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod,
             int? smaPeriod = null)
             where TQuote : IQuote

--- a/indicators/Roc/RocWb.cs
+++ b/indicators/Roc/RocWb.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicators/type[@name="WithBands"]/*' />
         /// 
         public static IEnumerable<RocWbResult> GetRocWb<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod,
             int emaPeriod,
             int stdDevPeriod)

--- a/indicators/RollingPivots/README.md
+++ b/indicators/RollingPivots/README.md
@@ -8,23 +8,24 @@ Created by Dave Skender, Rolling Pivot Points is a modern update to traditional 
 ```csharp
 // usage
 IEnumerable<PivotPointResult> results = 
-  Indicator.GetRollingPivots(history, lookbackPeriod, offsetPeriod, pointType);  
+  history.GetRollingPivots(lookbackPeriod, offsetPeriod, pointType);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc)
 | `windowPeriod` | int | Number of periods (`W`) in the evaluation window.  Must be greater than 0 to calculate; but is typically specified in the 5-20 range.
 | `offsetPeriod` | int | Number of periods (`F`) to offset the window from the current period.  Must be greater than or equal to 0 and is typically less than or equal to `W`.
 | `pointType` | PivotPointType | Type of Pivot Point.  Default is `PivotPointType.Standard`
 
 For example, a window of 8 with an offset of 4 would evaluate history like: `W W W W W W W W F F  F F C`, where `W` is the window included in the Pivot Point calculation, and `F` is the distance from the current evaluation position `C`.  A `history` with daily bars using `W/F` values of `20/10` would most closely match the `month` variant of the traditional [Pivot Points](../PivotPoints/README.md#content) indicator.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `W+F` periods of `history`.
+You must have at least `W+F` periods of `history`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ### PivotPointType options
 
@@ -65,7 +66,7 @@ IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate Woodie-style 14 period Rolling Pivot Points
 IEnumerable<PivotPointResult> results = 
-  Indicator.GetRollingPivots(history,14,0,PivotPointType.Woodie);
+  history.GetRollingPivots(14,0,PivotPointType.Woodie);
 
 // use results as needed
 PivotPointsResult result = results.LastOrDefault();

--- a/indicators/RollingPivots/RollingPivots.cs
+++ b/indicators/RollingPivots/RollingPivots.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<PivotPointsResult> GetRollingPivots<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int windowPeriod,
             int offsetPeriod,
             PivotPointType pointType = PivotPointType.Standard)

--- a/indicators/Rsi/README.md
+++ b/indicators/Rsi/README.md
@@ -7,19 +7,20 @@ Created by J. Welles Wilder, the [Relative Strength Index](https://en.wikipedia.
 ```csharp
 // usage
 IEnumerable<RsiResult> results =
-  Indicator.GetRsi(history, lookbackPeriod);  
+  history.GetRsi(lookbackPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) in the lookback period.  Must be greater than 0.  Default is 14.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N+100` periods of `history`.  Since this uses a smoothing technique, we recommend you use at least `10×N` data points prior to the intended usage date for better precision.
+You must have at least `N+100` periods of `history`.  Since this uses a smoothing technique, we recommend you use at least `10×N` data points prior to the intended usage date for better precision.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -45,7 +46,7 @@ The first `N-1` periods will have `null` values since there's not enough data to
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate RSI(14)
-IEnumerable<RsiResult> results = Indicator.GetRsi(history,14);
+IEnumerable<RsiResult> results = history.GetRsi(14);
 
 // use results as needed
 RsiResult result = results.LastOrDefault();

--- a/indicators/Rsi/Rsi.cs
+++ b/indicators/Rsi/Rsi.cs
@@ -9,7 +9,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<RsiResult> GetRsi<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod = 14)
             where TQuote : IQuote
         {

--- a/indicators/Slope/README.md
+++ b/indicators/Slope/README.md
@@ -8,19 +8,20 @@
 ```csharp
 // usage
 IEnumerable<SlopeResult> results =
-  Indicator.GetSlope(history, lookbackPeriod);  
+  history.GetSlope(lookbackPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) for the linear regression.  Must be greater than 0.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N` periods of `history`.
+You must have at least `N` periods of `history`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -48,7 +49,7 @@ The first `N-1` periods will have `null` values for `Slope` since there's not en
 IEnumerable<Quote> historySPX = GetHistoryFromFeed("SPX");
 
 // calculate 20-period Slope
-IEnumerable<SlopeResult> results = Indicator.GetSlope(history,20);
+IEnumerable<SlopeResult> results = history.GetSlope(20);
 
 // use results as needed
 SlopeResult result = results.LastOrDefault();

--- a/indicators/Slope/Slope.cs
+++ b/indicators/Slope/Slope.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<SlopeResult> GetSlope<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod)
             where TQuote : IQuote
         {

--- a/indicators/Sma/README.md
+++ b/indicators/Sma/README.md
@@ -8,19 +8,20 @@
 ```csharp
 // usage
 IEnumerable<SmaResult> results =
-  Indicator.GetSma(history, lookbackPeriod);  
+  history.GetSma(lookbackPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) in the lookback window.  Must be greater than 0.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N` periods of `history`.
+You must have at least `N` periods of `history`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -44,7 +45,7 @@ The first `N-1` periods will have `null` values since there's not enough data to
 IEnumerable<Quote> history = GetHistoryFromFeed("MSFT");
 
 // calculate 20-period SMA
-IEnumerable<SmaResult> results = Indicator.GetSma(history,20);
+IEnumerable<SmaResult> results = history.GetSma(20);
 
 // use results as needed
 SmaResult result = results.LastOrDefault();
@@ -61,7 +62,8 @@ An extended variant of this indicator includes additional analysis.
 
 ```csharp
 // usage
-IEnumerable<SmaExtendedResult> results = Indicator.GetSmaExtended(history, lookbackPeriod);  
+IEnumerable<SmaExtendedResult> results =
+  history.GetSmaExtended(lookbackPeriod);  
 ```
 
 ### SmaExtendedResult

--- a/indicators/Sma/Sma.cs
+++ b/indicators/Sma/Sma.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicators/type[@name="Main"]/*' />
         /// 
         public static IEnumerable<SmaResult> GetSma<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod)
             where TQuote : IQuote
         {
@@ -57,7 +57,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicators/type[@name="Extended"]/*' />
         /// 
         public static IEnumerable<SmaExtendedResult> GetSmaExtended<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod)
             where TQuote : IQuote
         {

--- a/indicators/Smma/README.md
+++ b/indicators/Smma/README.md
@@ -8,19 +8,20 @@
 ```csharp
 // usage
 IEnumerable<SmmaResult> results =
-  Indicator.GetSmma(history, lookbackPeriod);  
+  history.GetSmma(lookbackPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) in the moving average.  Must be greater than 0.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `2×N` or `N+100` periods of `history`, whichever is more.  Since this uses a smoothing technique, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.
+You must have at least `2×N` or `N+100` periods of `history`, whichever is more.  Since this uses a smoothing technique, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -46,7 +47,7 @@ The first `N-1` periods will have `null` values since there's not enough data to
 IEnumerable<Quote> history = GetHistoryFromFeed("MSFT");
 
 // calculate 20-period SMMA
-IEnumerable<SmmaResult> results = Indicator.GetSmma(history,20);
+IEnumerable<SmmaResult> results = history.GetSmma(20);
 
 // use results as needed
 SmmaResult result = results.LastOrDefault();

--- a/indicators/Smma/Smma.cs
+++ b/indicators/Smma/Smma.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicators/type[@name="Main"]/*' />
         ///
         public static IEnumerable<SmmaResult> GetSmma<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod)
             where TQuote : IQuote
         {

--- a/indicators/StarcBands/README.md
+++ b/indicators/StarcBands/README.md
@@ -8,21 +8,22 @@ Created by Manning Stoller, [Stoller Average Range Channel (STARC) Bands](https:
 ```csharp
 // usage
 IEnumerable<StarcBandsResult> results = 
-  Indicator.GetStarcBands(history, smaPeriod, multiplier, atrPeriod);  
+  history.GetStarcBands(smaPeriod, multiplier, atrPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `smaPeriod` | int | Number of lookback periods (`S`) for the center line moving average.  Must be greater than 1 to calculate and is typically between 5 and 10.
 | `multiplier` | decimal | ATR Multiplier. Must be greater than 0.  Default is 2.
 | `atrPeriod` | int | Number of lookback periods (`A`) for the Average True Range.  Must be greater than 1 to calculate and is typically the same value as `smaPeriod`.  Default is 10.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `S` or `A+100` periods of `history`, whichever is more.  Since this uses a smoothing technique, we recommend you use at least `A+150` data points prior to the intended usage date for better precision.
+You must have at least `S` or `A+100` periods of `history`, whichever is more.  Since this uses a smoothing technique, we recommend you use at least `A+150` data points prior to the intended usage date for better precision.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -50,7 +51,7 @@ The first `N-1` periods will have `null` values since there's not enough data to
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate StarcBands(20)
-IEnumerable<StarcBandsResult> results = Indicator.GetStarcBands(history,20,2.0,10);
+IEnumerable<StarcBandsResult> results = history.GetStarcBands(20,2.0,10);
 
 // use results as needed
 StarcBandsResult result = results.LastOrDefault();

--- a/indicators/StarcBands/StarcBands.cs
+++ b/indicators/StarcBands/StarcBands.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<StarcBandsResult> GetStarcBands<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int smaPeriod = 20,
             decimal multiplier = 2,
             int atrPeriod = 10)

--- a/indicators/StdDev/README.md
+++ b/indicators/StdDev/README.md
@@ -8,24 +8,25 @@ Rolling [Standard Deviation](https://en.wikipedia.org/wiki/Standard_deviation) o
 ```csharp
 // usage
 IEnumerable<StdDevResult> results =
-  Indicator.GetStdDev(history, lookbackPeriod);  
+  history.GetStdDev(lookbackPeriod);  
 
 // usage with optional SMA of STDEV (shown above)
 IEnumerable<StdDevResult> results =
-  Indicator.GetStdDev(history, lookbackPeriod, smaPeriod);  
+  history.GetStdDev(lookbackPeriod, smaPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) in the lookback period.  Must be greater than 1 to calculate; however we suggest a larger period for statistically appropriate sample size.
 | `smaPeriod` | int | Optional.  Number of periods in the moving average of `StdDev`.  Must be greater than 0, if specified.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N` periods of `history`.
+You must have at least `N` periods of `history`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -52,7 +53,7 @@ The first `N-1` periods will have `null` values since there's not enough data to
 IEnumerable<Quote> history = GetHistoryFromFeed("SPX");
 
 // calculate 10-period Standard Deviation
-IEnumerable<StdDevResult> results = Indicator.GetStdDev(history,10);
+IEnumerable<StdDevResult> results = history.GetStdDev(10);
 
 // use results as needed
 StdDevResult result = results.LastOrDefault();

--- a/indicators/StdDev/StdDev.cs
+++ b/indicators/StdDev/StdDev.cs
@@ -9,7 +9,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<StdDevResult> GetStdDev<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod,
             int? smaPeriod = null)
             where TQuote : IQuote

--- a/indicators/StdDevChannels/README.md
+++ b/indicators/StdDevChannels/README.md
@@ -8,20 +8,21 @@ Standard Deviation Channels are based on an linear regression centerline and sta
 ```csharp
 // usage
 IEnumerable<StdDevChannelsResult> results =
-  Indicator.GetStdDevChannels(history, lookbackPeriod, standardDeviations);  
+  history.GetStdDevChannels(lookbackPeriod, standardDeviations);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Size (`N`) of the evaluation window.  Must be `null` or greater than 1 to calculate.  A `null` value will produce a full `history` evaluation window ([see below](#alternative-depiction-for-full-history-variant)).  Default is 20.
 | `standardDeviations` | int | Width of bands.  Standard deviations (`D`) from the regression line.  Must be greater than 0.  Default is 2.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N` periods of `history`.
+You must have at least `N` periods of `history`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -51,7 +52,7 @@ IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate StdDevChannels(20,2)
 IEnumerable<StdDevChannelsResult> results =
-  Indicator.GetStdDevChannels(history,20,2);
+  history.GetStdDevChannels(20,2);
 
 // use results as needed
 StdDevChannelsResult result = results.LastOrDefault();

--- a/indicators/StdDevChannels/StdDevChannels.cs
+++ b/indicators/StdDevChannels/StdDevChannels.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<StdDevChannelsResult> GetStdDevChannels<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int? lookbackPeriod = 20,
             decimal standardDeviations = 2)
             where TQuote : IQuote

--- a/indicators/Stoch/README.md
+++ b/indicators/Stoch/README.md
@@ -8,21 +8,22 @@ Created by George Lane, the [Stochastic Oscillator](https://en.wikipedia.org/wik
 ```csharp
 // usage
 IEnumerable<StochResult> results =
-  Indicator.GetStoch(history, lookbackPeriod, signalPeriod, smoothingPeriod);  
+  history.GetStoch(lookbackPeriod, signalPeriod, smoothingPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Lookback period (`N`) for the oscillator (%K).  Must be greater than 0.  Default is 14.
 | `signalPeriod` | int | Smoothing period for the signal (%D).  Must be greater than 0.  Default is 3.
 | `smoothingPeriod` | int | Smoothing period (`S`) for the Oscillator (%K).  "Slow" stochastic uses 3, "Fast" stochastic uses 1.  Must be greater than 0.  Default is 3.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N+S` periods of `history`.
+You must have at least `N+S` periods of `history`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -48,7 +49,7 @@ The first `N+S-1` periods will have `null` Oscillator values since there's not e
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate STO %K(14),%D(3) (slow)
-IEnumerable<StochResult> results = Indicator.GetStoch(history,14,3,3);
+IEnumerable<StochResult> results = history.GetStoch(14,3,3);
 
 // use results as needed
 StochResult result = results.LastOrDefault();

--- a/indicators/Stoch/Stoch.cs
+++ b/indicators/Stoch/Stoch.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<StochResult> GetStoch<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod = 14,
             int signalPeriod = 3,
             int smoothPeriod = 3)

--- a/indicators/StochRsi/README.md
+++ b/indicators/StochRsi/README.md
@@ -8,14 +8,13 @@ Created by by Tushar Chande and Stanley Kroll, [Stochastic RSI](https://school.s
 ```csharp
 // usage
 IEnumerable<StochRsiResult> results =
-  Indicator.GetStochRsi(history, rsiPeriod, stochPeriod, signalPeriod, smoothPeriod);
+  history.GetStochRsi(rsiPeriod, stochPeriod, signalPeriod, smoothPeriod);
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `rsiPeriod` | int | Number of periods (`R`) in the lookback period.  Must be greater than 0.  Standard is 14.
 | `stochPeriod` | int | Number of periods (`S`) in the lookback period.  Must be greater than 0.  Typically the same value as `rsiPeriod`.
 | `signalPeriod` | int | Number of periods (`G`) in the signal line (SMA of the StochRSI).  Must be greater than 0.  Typically 3-5.
@@ -23,9 +22,11 @@ IEnumerable<StochRsiResult> results =
 
 The original Stochasic RSI formula uses a the Fast variant of the Stochastic calculation (`smoothPeriod=1`).  For a standard period of 14, the original formula would be `GetStochRSI(history,14,14,3,1)`; though, the "3" here is just for the Signal, which is not present in the original formula, but useful for additional smoothing of the Stochastic RSI.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N` periods of `history`, where `N` is the greater of `R+S` and `R+100`.  Since this uses a smoothing technique in the underlying RSI value, we recommend you use at least `10×R` periods prior to the intended usage date for better precision.
+You must have at least `N` periods of `history`, where `N` is the greater of `R+S` and `R+100`.  Since this uses a smoothing technique in the underlying RSI value, we recommend you use at least `10×R` periods prior to the intended usage date for better precision.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -52,7 +53,7 @@ The first `R+S-1` periods will have `null` values for `StochRsi` since there's n
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate StochRSI(14)
-IEnumerable<StochRsiResult> results = Indicator.GetStochRsi(history,14,14,1,1);
+IEnumerable<StochRsiResult> results = history.GetStochRsi(14,14,1,1);
 
 // use results as needed
 StochRsiResult result = results.LastOrDefault();

--- a/indicators/StochRsi/StochRsi.cs
+++ b/indicators/StochRsi/StochRsi.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<StochRsiResult> GetStochRsi<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int rsiPeriod,
             int stochPeriod,
             int signalPeriod,

--- a/indicators/SuperTrend/README.md
+++ b/indicators/SuperTrend/README.md
@@ -9,20 +9,21 @@ It can indicate a buy/sell signal or a trailing stop when the trend changes.
 ```csharp
 // usage
 IEnumerable<SuperTrendResult> results =
-  Indicator.GetSuperTrend(history, lookbackPeriod, multiplier);  
+  history.GetSuperTrend(lookbackPeriod, multiplier);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) for the ATR evaluation.  Must be greater than 1 and is usually set between 7 and 14.  Default is 10.
 | `multiplier` | decimal | Multiplier sets the ATR band width.  Must be greater than 0 and is usually set around 2 to 3.  Default is 3.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N+100` periods of `history`.  Since this uses a smoothing technique, we recommend you use at least `N+250` periods prior to the intended usage date for optimal precision.
+You must have at least `N+100` periods of `history`.  Since this uses a smoothing technique, we recommend you use at least `N+250` periods prior to the intended usage date for optimal precision.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -54,7 +55,7 @@ IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate SuperTrend(14,3)
 IEnumerable<SuperTrendResult> results
-  = Indicator.GetSuperTrend(history,14,3);
+  = history.GetSuperTrend(14,3);
 
 // use results as needed
 SuperTrendResult r = results.LastOrDefault();

--- a/indicators/SuperTrend/SuperTrend.cs
+++ b/indicators/SuperTrend/SuperTrend.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<SuperTrendResult> GetSuperTrend<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod = 10,
             decimal multiplier = 3)
             where TQuote : IQuote

--- a/indicators/T3/README.md
+++ b/indicators/T3/README.md
@@ -8,20 +8,21 @@ Created by Tim Tillson, the [T3](https://www.forexfactory.com/attachment.php/845
 ```csharp
 // usage
 IEnumerable<T3Result> results = 
-  Indicator.GetT3(history, lookbackPeriod, volumeFactor);  
+  history.GetT3(lookbackPeriod, volumeFactor);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) for the EMA smoothing.  Must be greater than 0 and is usually less than 63.  Default is 5.
 | `volumeFactor` | double | Size of the Volume Factor.  Must be greater than 0 and is usually less than 2.  Default is 0.7
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `6×(N-1)+100` periods of `history`.  Since this uses a smoothing technique, we recommend you use at least `6×(N-1)+250` data points prior to the intended usage date for better precision.
+You must have at least `6×(N-1)+100` periods of `history`.  Since this uses a smoothing technique, we recommend you use at least `6×(N-1)+250` data points prior to the intended usage date for better precision.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -47,7 +48,7 @@ The first `6×(N-1)` periods will have `null` values since there's not enough da
 IEnumerable<Quote> history = GetHistoryFromFeed("MSFT");
 
 // calculate 5-period T3
-IEnumerable<T3Result> results = Indicator.GetT3(history,5,0.7);
+IEnumerable<T3Result> results = history.GetT3(5,0.7);
 
 // use results as needed
 T3Result result = results.LastOrDefault();

--- a/indicators/T3/T3.cs
+++ b/indicators/T3/T3.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<T3Result> GetT3<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod = 5,
             double volumeFactor = 0.7)
             where TQuote : IQuote

--- a/indicators/Trix/README.md
+++ b/indicators/Trix/README.md
@@ -8,24 +8,25 @@ Created by Jack Hutson, [TRIX](https://en.wikipedia.org/wiki/Trix_(technical_ana
 ```csharp
 // usage for Trix
 IEnumerable<TrixResult> results =
-  Indicator.GetTrix(history, lookbackPeriod);
+  history.GetTrix(lookbackPeriod);
 
 // usage for Trix with Signal Line (shown above)
 IEnumerable<TrixResult> results =
-  Indicator.GetTrix(history, lookbackPeriod, signalPeriod);
+  history.GetTrix(lookbackPeriod, signalPeriod);
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) in each of the the exponential moving averages.  Must be greater than 0.
 | `signalPeriod` | int | Optional.  Number of periods in the moving average of TRIX.  Must be greater than 0, if specified.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `4×N` or `3×N+100` periods of `history`, whichever is more.  Since this uses a smoothing technique, we recommend you use at least `3×N+250` data points prior to the intended usage date for better precision.
+You must have at least `4×N` or `3×N+100` periods of `history`, whichever is more.  Since this uses a smoothing technique, we recommend you use at least `3×N+250` data points prior to the intended usage date for better precision.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -53,7 +54,7 @@ We always return the same number of elements as there are in the historical quot
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate 20-period Trix
-IEnumerable<TrixResult> results = Indicator.GetTrix(history,14);
+IEnumerable<TrixResult> results = history.GetTrix(14);
 
 // use results as needed
 TrixResult result = results.LastOrDefault();

--- a/indicators/Trix/Trix.cs
+++ b/indicators/Trix/Trix.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<TrixResult> GetTrix<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod,
             int? signalPeriod = null)
             where TQuote : IQuote

--- a/indicators/Tsi/README.md
+++ b/indicators/Tsi/README.md
@@ -8,21 +8,22 @@ Created by William Blau, the [True Strength Index](https://en.wikipedia.org/wiki
 ```csharp
 // usage
 IEnumerable<TsiResult> results = 
-  Indicator.GetTsi(history, lookbackPeriod, smoothPeriod, signalPeriod);  
+  history.GetTsi(lookbackPeriod, smoothPeriod, signalPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) for the first EMA.  Must be greater than 0.  Default is 25.
 | `smoothPeriod` | int | Number of periods (`M`) for the second smoothing.  Must be greater than 0.  Default is 13.
 | `signalPeriod` | int | Number of periods (`S`) in the TSI moving average.  Must be greater than or equal to 0.  Default is 7.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N+M+100` periods of `history`.  Since this uses a two EMA smoothing techniques, we recommend you use at least `N+M+250` data points prior to the intended usage date for better precision.
+You must have at least `N+M+100` periods of `history`.  Since this uses a two EMA smoothing techniques, we recommend you use at least `N+M+250` data points prior to the intended usage date for better precision.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -49,7 +50,7 @@ The first `N+M-1` periods will have `null` values since there's not enough data 
 IEnumerable<Quote> history = GetHistoryFromFeed("MSFT");
 
 // calculate 20-period TSI
-IEnumerable<TsiResult> results = Indicator.GetTsi(history,25,13,7);
+IEnumerable<TsiResult> results = history.GetTsi(25,13,7);
 
 // use results as needed
 TsiResult result = results.LastOrDefault();

--- a/indicators/Tsi/Tsi.cs
+++ b/indicators/Tsi/Tsi.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<TsiResult> GetTsi<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod = 25,
             int smoothPeriod = 13,
             int signalPeriod = 7)

--- a/indicators/UlcerIndex/README.md
+++ b/indicators/UlcerIndex/README.md
@@ -8,19 +8,20 @@ Created by Peter Martin, the [Ulcer Index](https://en.wikipedia.org/wiki/Ulcer_i
 ```csharp
 // usage
 IEnumerable<UlcerIndexResult> results =
-  Indicator.GetUlcerIndex(history, lookbackPeriod);  
+  history.GetUlcerIndex(lookbackPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) for review.  Must be greater than 0.  Default is 14.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N` periods of `history`.
+You must have at least `N` periods of `history`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -44,7 +45,7 @@ The first `N-1` slow periods + signal period will have `null` values since there
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate UI(14)
-IEnumerable<UlcerIndexResult> results = Indicator.GetUlcerIndex(history,14);
+IEnumerable<UlcerIndexResult> results = history.GetUlcerIndex(14);
 
 // use results as needed
 UlcerIndexResult result = results.LastOrDefault();

--- a/indicators/UlcerIndex/Ulcer.cs
+++ b/indicators/UlcerIndex/Ulcer.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<UlcerIndexResult> GetUlcerIndex<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod = 14)
             where TQuote : IQuote
         {

--- a/indicators/Ultimate/README.md
+++ b/indicators/Ultimate/README.md
@@ -8,21 +8,22 @@ Created by Larry Williams, the [Ultimate Oscillator](https://en.wikipedia.org/wi
 ```csharp
 // usage
 IEnumerable<UltimateResult> results =
-  Indicator.GetUltimate(history, shortPeriod, middlePeriod, longPeriod);  
+  history.GetUltimate(shortPeriod, middlePeriod, longPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `shortPeriod` | int | Number of periods (`S`) in the short lookback.  Must be greater than 0.  Default is 7.
 | `middlePeriod` | int | Number of periods (`M`) in the middle lookback.  Must be greater than `S`.  Default is 14.
 | `longPeriod` | int | Number of periods (`L`) in the long lookback.  Must be greater than `M`.  Default is 28.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `L+1` periods of `history`.
+You must have at least `L+1` periods of `history`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -46,7 +47,7 @@ The first `L-1` periods will have `null` Ultimate values since there's not enoug
 IEnumerable<Quote> history = GetHistoryFromFeed("MSFT");
 
 // calculate 20-period Ultimate
-IEnumerable<UltimateResult> results = Indicator.GetUltimate(history,7,14,28);
+IEnumerable<UltimateResult> results = history.GetUltimate(7,14,28);
 
 // use results as needed
 UltimateResult result = results.LastOrDefault();

--- a/indicators/Ultimate/Ultimate.cs
+++ b/indicators/Ultimate/Ultimate.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<UltimateResult> GetUltimate<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int shortPeriod = 7,
             int middlePeriod = 14,
             int longPeriod = 28)

--- a/indicators/VolSma/README.md
+++ b/indicators/VolSma/README.md
@@ -8,19 +8,20 @@ The Volume Simple Moving Average is the average volume over a lookback window.  
 ```csharp
 // usage
 IEnumerable<VolSmaResult> results =
-  Indicator.GetVolSma(history, lookbackPeriod);  
+  history.GetVolSma(lookbackPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) in the moving average.  Must be greater than 0.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N` periods of `history`.
+You must have at least `N` periods of `history`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -45,7 +46,7 @@ The first `N-1` periods will have `null` values for `VolSma` since there's not e
 IEnumerable<Quote> history = GetHistoryFromFeed("MSFT");
 
 // calculate 20-period SMA of Volume
-IEnumerable<VolSmaResult> results = Indicator.GetVolSma(history,20);
+IEnumerable<VolSmaResult> results = history.GetVolSma(20);
 
 // use results as needed
 VolSmaResult result = results.LastOrDefault();

--- a/indicators/VolSma/VolSma.cs
+++ b/indicators/VolSma/VolSma.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<VolSmaResult> GetVolSma<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod)
             where TQuote : IQuote
         {

--- a/indicators/Vortex/README.md
+++ b/indicators/Vortex/README.md
@@ -8,19 +8,20 @@ Created by Etienne Botes and Douglas Siepman, the [Vortex Indicator](https://en.
 ```csharp
 // usage
 IEnumerable<VortexResult> results =
-  Indicator.GetVortex(history, lookbackPeriod);  
+  history.GetVortex(lookbackPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) to consider.  Must be greater than 1 and is usually between 14 and 30.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N+1` periods of `history`.
+You must have at least `N+1` periods of `history`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -45,7 +46,7 @@ The first `N` periods will have `null` values for VI since there's not enough da
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate 14-period VI
-IEnumerable<VortexResult> results = Indicator.GetVortex(history,14);
+IEnumerable<VortexResult> results = history.GetVortex(14);
 
 // use results as needed
 VortexResult result = results.LastOrDefault();

--- a/indicators/Vortex/Vortex.cs
+++ b/indicators/Vortex/Vortex.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<VortexResult> GetVortex<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod)
             where TQuote : IQuote
         {

--- a/indicators/Vwap/README.md
+++ b/indicators/Vwap/README.md
@@ -8,23 +8,24 @@ The [Volume Weighted Average Price](https://en.wikipedia.org/wiki/Volume-weighte
 ```csharp
 // usage
 IEnumerable<VwapResult> results =
-  Indicator.GetVwap(history);
+  history.GetVwap();
 
 // usage with optional anchored start date
 IEnumerable<VwapResult> results =
-  Indicator.GetVwap(history, startDate);  
+  history.GetVwap(startDate);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `startDate` | DateTime | Optional.  The anchor date used to start the VWAP accumulation.  The earliest date in `history` is used when not provided.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least one historical quote to calculate; however, more is often needed to be useful.  History is typically provided for a single day using minute-based intraday periods.  Since this is an accumulated weighted average price, different start dates will produce different results.  The accumulation starts at the first period in the provided `history`, unless it is specified in the optional `startDate` parameter.
+You must have at least one historical quote to calculate; however, more is often needed to be useful.  History is typically provided for a single day using minute-based intraday periods.  Since this is an accumulated weighted average price, different start dates will produce different results.  The accumulation starts at the first period in the provided `history`, unless it is specified in the optional `startDate` parameter.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -48,7 +49,7 @@ The first period or the `startDate` will have a `Vwap = Close` value since it is
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate
-IEnumerable<VwapResult> results = Indicator.GetVwap(history);
+IEnumerable<VwapResult> results = history.GetVwap();
 
 // use results as needed
 VwapResult result = results.LastOrDefault();

--- a/indicators/Vwap/Vwap.cs
+++ b/indicators/Vwap/Vwap.cs
@@ -9,7 +9,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<VwapResult> GetVwap<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             DateTime? startDate = null)
             where TQuote : IQuote
         {

--- a/indicators/WilliamsR/README.md
+++ b/indicators/WilliamsR/README.md
@@ -8,19 +8,20 @@ Created by Larry Williams, the [Williams %R](https://en.wikipedia.org/wiki/Willi
 ```csharp
 // usage
 IEnumerable<WilliamsResult> results =
-  Indicator.GetWilliamsR(history, lookbackPeriod);  
+  history.GetWilliamsR(lookbackPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) in the lookback period.  Must be greater than 0.  Default is 14.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N` periods of `history`.
+You must have at least `N` periods of `history`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -44,7 +45,7 @@ The first `N-1` periods will have `null` Oscillator values since there's not eno
 IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate WilliamsR(14)
-IEnumerable<WilliamsResult> results = Indicator.GetWilliamsR(history,14);
+IEnumerable<WilliamsResult> results = history.GetWilliamsR(14);
 
 // use results as needed
 WilliamsResult result = results.LastOrDefault();

--- a/indicators/WilliamsR/WilliamsR.cs
+++ b/indicators/WilliamsR/WilliamsR.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<WilliamsResult> GetWilliamsR<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod = 14)
             where TQuote : IQuote
         {

--- a/indicators/Wma/README.md
+++ b/indicators/Wma/README.md
@@ -8,19 +8,20 @@
 ```csharp
 // usage
 IEnumerable<WmaResult> results =
-  Indicator.GetWma(history, lookbackPeriod);  
+  history.GetWma(lookbackPeriod);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `lookbackPeriod` | int | Number of periods (`N`) in the moving average.  Must be greater than 0.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least `N` periods of `history`.
+You must have at least `N` periods of `history`.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ## Response
 
@@ -44,7 +45,7 @@ The first `N-1` periods will have `null` values since there's not enough data to
 IEnumerable<Quote> history = GetHistoryFromFeed("MSFT");
 
 // calculate 20-period WMA
-IEnumerable<WmaResult> results = Indicator.GetWma(history,20);
+IEnumerable<WmaResult> results = history.GetWma(20);
 
 // use results as needed
 WmaResult result = results.LastOrDefault();

--- a/indicators/Wma/Wma.cs
+++ b/indicators/Wma/Wma.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<WmaResult> GetWma<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             int lookbackPeriod)
             where TQuote : IQuote
         {

--- a/indicators/ZigZag/README.md
+++ b/indicators/ZigZag/README.md
@@ -8,20 +8,21 @@
 ```csharp
 // usage
 IEnumerable<ZigZagResult> results =
-  Indicator.GetZigZag(history, type, percentChange);  
+  history.GetZigZag(type, percentChange);  
 ```
 
 ## Parameters
 
 | name | type | notes
 | -- |-- |--
-| `history` | IEnumerable\<[TQuote](../../docs/GUIDE.md#historical-quotes)\> | Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 | `type` | ZigZagType | Determines whether `Close` or `High/Low` are used to measure percent change.  See [ZigZagType options](#zigzagtype-options) below.  Default is `ZigZagType.Close`.
 | `percentChange` | decimal | Percent change required to establish a line endpoint.  Example: 3.5% would be entered as 3.5 (not 0.035).  Must be greater than 0.  Typical values range from 3 to 10.  Default is 5.
 
-### Minimum history requirements
+### Historical quotes requirements
 
-You must supply at least two periods of `history` to calculate, but notably more is needed to be useful.
+You must have at least two periods of `history` to calculate, but notably more is needed to be useful.
+
+`history` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide](../../docs/GUIDE.md) for more information.
 
 ### ZigZagType options
 
@@ -58,7 +59,7 @@ IEnumerable<Quote> history = GetHistoryFromFeed("SPY");
 
 // calculate 3% change ZIGZAG
 IEnumerable<ZigZagResult> results =
-  Indicator.GetZigZag(history,ZigZagType.Close,3);
+  history.GetZigZag(ZigZagType.Close,3);
 
 // use results as needed
 ZigZagResult result = results.LastOrDefault();

--- a/indicators/ZigZag/ZigZag.cs
+++ b/indicators/ZigZag/ZigZag.cs
@@ -10,7 +10,7 @@ namespace Skender.Stock.Indicators
         /// <include file='./info.xml' path='indicator/*' />
         /// 
         public static IEnumerable<ZigZagResult> GetZigZag<TQuote>(
-            IEnumerable<TQuote> history,
+            this IEnumerable<TQuote> history,
             ZigZagType type = ZigZagType.Close,
             decimal percentChange = 5)
             where TQuote : IQuote

--- a/tests/external/Test.Convergence.cs
+++ b/tests/external/Test.Convergence.cs
@@ -19,7 +19,7 @@ namespace External.Other
             foreach (int qty in convergeQuantities)
             {
                 IEnumerable<Quote> h = HistoryTestData.GetLong(128 + qty);
-                IEnumerable<AdxResult> r = Indicator.GetAdx(h);
+                IEnumerable<AdxResult> r = h.GetAdx();
 
                 AdxResult l = r.LastOrDefault();
                 Console.WriteLine("ADX on {0:d} with {1,4} periods: {2:N8}",

--- a/tests/external/Test.PublicClass.cs
+++ b/tests/external/Test.PublicClass.cs
@@ -50,6 +50,7 @@ namespace External.Other
             IEnumerable<Quote> history = HistoryTestData.Get();
             history.Validate();
 
+            history.GetSma(6);
             Indicator.GetSma(history, 5);
         }
 
@@ -111,7 +112,7 @@ namespace External.Other
                 })
                 .ToList();
 
-            List<EmaResult> results = Indicator.GetEma(myGenericHistory, 20)
+            List<EmaResult> results = myGenericHistory.GetEma(20)
                 .ToList();
 
             // assertions
@@ -182,7 +183,7 @@ namespace External.Other
         public void DerivedIndicatorClassLinq()
         {
             IEnumerable<Quote> history = HistoryTestData.Get();
-            IEnumerable<EmaResult> emaResults = Indicator.GetEma(history, 14);
+            IEnumerable<EmaResult> emaResults = history.GetEma(14);
 
             // can use a derive Indicator class using Linq
 

--- a/tests/indicators/Test.Adl.cs
+++ b/tests/indicators/Test.Adl.cs
@@ -14,7 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
 
-            List<AdlResult> results = Indicator.GetAdl(history).ToList();
+            List<AdlResult> results = history.GetAdl().ToList();
 
             // assertions
 

--- a/tests/indicators/Test.Adx.cs
+++ b/tests/indicators/Test.Adx.cs
@@ -14,7 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
             int lookbackPeriod = 14;
-            List<AdxResult> results = Indicator.GetAdx(history, lookbackPeriod).ToList();
+            List<AdxResult> results = history.GetAdx(lookbackPeriod).ToList();
 
             // assertions
 

--- a/tests/indicators/Test.Alligator.cs
+++ b/tests/indicators/Test.Alligator.cs
@@ -12,8 +12,7 @@ namespace Internal.Tests
         [TestMethod]
         public void Standard()
         {
-            List<AlligatorResult> results = Indicator.GetAlligator(history)
-                .ToList();
+            List<AlligatorResult> results = history.GetAlligator().ToList();
 
             // assertions
 

--- a/tests/indicators/Test.Alma.cs
+++ b/tests/indicators/Test.Alma.cs
@@ -17,7 +17,7 @@ namespace Internal.Tests
             double offset = 0.85;
             double sigma = 6;
 
-            List<AlmaResult> results = Indicator.GetAlma(history, lookbackPeriod, offset, sigma)
+            List<AlmaResult> results = history.GetAlma(lookbackPeriod, offset, sigma)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.Aroon.cs
+++ b/tests/indicators/Test.Aroon.cs
@@ -14,7 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
             int lookbackPeriod = 25;
-            List<AroonResult> results = Indicator.GetAroon(history, lookbackPeriod).ToList();
+            List<AroonResult> results = history.GetAroon(lookbackPeriod).ToList();
 
             // assertions
 

--- a/tests/indicators/Test.Atr.cs
+++ b/tests/indicators/Test.Atr.cs
@@ -14,7 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
             int lookbackPeriod = 14;
-            List<AtrResult> results = Indicator.GetAtr(history, lookbackPeriod).ToList();
+            List<AtrResult> results = history.GetAtr(lookbackPeriod).ToList();
 
             // assertions
 

--- a/tests/indicators/Test.Awesome.cs
+++ b/tests/indicators/Test.Awesome.cs
@@ -14,7 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
 
-            List<AwesomeResult> results = Indicator.GetAwesome(history, 5, 34)
+            List<AwesomeResult> results = history.GetAwesome(5, 34)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.BollingerBands.cs
+++ b/tests/indicators/Test.BollingerBands.cs
@@ -15,7 +15,7 @@ namespace Internal.Tests
         {
 
             List<BollingerBandsResult> results =
-                Indicator.GetBollingerBands(history, 20, 2)
+                history.GetBollingerBands(20, 2)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.Bop.cs
+++ b/tests/indicators/Test.Bop.cs
@@ -14,8 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
 
-            List<BopResult> results = Indicator.GetBop(history, 14)
-                .ToList();
+            List<BopResult> results = history.GetBop(14).ToList();
 
             // assertions
 

--- a/tests/indicators/Test.Cci.cs
+++ b/tests/indicators/Test.Cci.cs
@@ -14,8 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
 
-            List<CciResult> results = Indicator.GetCci(history, 20)
-                .ToList();
+            List<CciResult> results = history.GetCci(20).ToList();
 
             // assertions
 

--- a/tests/indicators/Test.ChaikinOsc.cs
+++ b/tests/indicators/Test.ChaikinOsc.cs
@@ -16,7 +16,7 @@ namespace Internal.Tests
             int fastPeriod = 3;
             int slowPeriod = 10;
 
-            List<ChaikinOscResult> results = Indicator.GetChaikinOsc(history, fastPeriod, slowPeriod)
+            List<ChaikinOscResult> results = history.GetChaikinOsc(fastPeriod, slowPeriod)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.Chandelier.cs
+++ b/tests/indicators/Test.Chandelier.cs
@@ -16,7 +16,7 @@ namespace Internal.Tests
             int lookbackPeriod = 22;
 
             List<ChandelierResult> longResult =
-                Indicator.GetChandelier(history, lookbackPeriod, 3.0m)
+                history.GetChandelier(lookbackPeriod, 3.0m)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.Chop.cs
+++ b/tests/indicators/Test.Chop.cs
@@ -13,8 +13,7 @@ namespace Internal.Tests
         public void Standard()
         {
             int lookbackPeriod = 14;
-
-            List<ChopResult> results = Indicator.GetChop(history, lookbackPeriod)
+            List<ChopResult> results = history.GetChop(lookbackPeriod)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.Cmf.cs
+++ b/tests/indicators/Test.Cmf.cs
@@ -14,9 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
             int lookbackPeriod = 20;
-
-            List<CmfResult> results = Indicator.GetCmf(history, lookbackPeriod)
-                .ToList();
+            List<CmfResult> results = history.GetCmf(lookbackPeriod).ToList();
 
             // assertions
 

--- a/tests/indicators/Test.ConnorsRsi.cs
+++ b/tests/indicators/Test.ConnorsRsi.cs
@@ -19,7 +19,7 @@ namespace Internal.Tests
             int startPeriod = Math.Max(rsiPeriod, Math.Max(streakPeriod, rankPeriod)) + 2;
 
             List<ConnorsRsiResult> results1 =
-                Indicator.GetConnorsRsi(history, rsiPeriod, streakPeriod, rankPeriod)
+                history.GetConnorsRsi(rsiPeriod, streakPeriod, rankPeriod)
                 .ToList();
 
             // assertions
@@ -37,7 +37,7 @@ namespace Internal.Tests
             Assert.AreEqual(74.7662m, Math.Round((decimal)r1.ConnorsRsi, 4));
 
             // different parameters
-            List<ConnorsRsiResult> results2 = Indicator.GetConnorsRsi(history, 14, 20, 10).ToList();
+            List<ConnorsRsiResult> results2 = history.GetConnorsRsi(14, 20, 10).ToList();
             ConnorsRsiResult r2 = results2[501];
             Assert.AreEqual(42.0773m, Math.Round((decimal)r2.RsiClose, 4));
             Assert.AreEqual(52.7386m, Math.Round((decimal)r2.RsiStreak, 4));

--- a/tests/indicators/Test.Correlation.cs
+++ b/tests/indicators/Test.Correlation.cs
@@ -14,9 +14,8 @@ namespace Internal.Tests
         public void Standard()
         {
             int lookbackPeriod = 20;
-
             List<CorrResult> results =
-                Indicator.GetCorrelation(history, historyOther, lookbackPeriod)
+                history.GetCorrelation(historyOther, lookbackPeriod)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.Donchian.cs
+++ b/tests/indicators/Test.Donchian.cs
@@ -14,8 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
             int lookbackPeriod = 20;
-
-            List<DonchianResult> results = Indicator.GetDonchian(history, lookbackPeriod)
+            List<DonchianResult> results = history.GetDonchian(lookbackPeriod)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.DoubleEma.cs
+++ b/tests/indicators/Test.DoubleEma.cs
@@ -14,8 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
             int lookbackPeriod = 20;
-
-            List<EmaResult> results = Indicator.GetDoubleEma(history, lookbackPeriod)
+            List<EmaResult> results = history.GetDoubleEma(lookbackPeriod)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.ElderRay.cs
+++ b/tests/indicators/Test.ElderRay.cs
@@ -14,8 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
 
-            List<ElderRayResult> results = Indicator.GetElderRay(history, 13)
-                .ToList();
+            List<ElderRayResult> results = history.GetElderRay(13).ToList();
 
             // assertions
 

--- a/tests/indicators/Test.Ema.cs
+++ b/tests/indicators/Test.Ema.cs
@@ -14,9 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
             int lookbackPeriod = 20;
-
-            List<EmaResult> results = Indicator.GetEma(history, lookbackPeriod)
-                .ToList();
+            List<EmaResult> results = history.GetEma(lookbackPeriod).ToList();
 
             // assertions
 

--- a/tests/indicators/Test.Epma.cs
+++ b/tests/indicators/Test.Epma.cs
@@ -14,9 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
             int lookbackPeriod = 20;
-
-            List<EpmaResult> results = Indicator.GetEpma(history, lookbackPeriod)
-                .ToList();
+            List<EpmaResult> results = history.GetEpma(lookbackPeriod).ToList();
 
             // assertions
 

--- a/tests/indicators/Test.Fcb.cs
+++ b/tests/indicators/Test.Fcb.cs
@@ -14,9 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
 
-            List<FcbResult> results =
-                Indicator.GetFcb(history, 2)
-                .ToList();
+            List<FcbResult> results = history.GetFcb(2).ToList();
 
             // assertions
 

--- a/tests/indicators/Test.FisherTransform.cs
+++ b/tests/indicators/Test.FisherTransform.cs
@@ -14,7 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
 
-            List<FisherTransformResult> results = Indicator.GetFisherTransform(history, 10)
+            List<FisherTransformResult> results = history.GetFisherTransform(10)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.ForceIndex.cs
+++ b/tests/indicators/Test.ForceIndex.cs
@@ -14,9 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
 
-            List<ForceIndexResult> r =
-                Indicator.GetForceIndex(history, 13)
-                .ToList();
+            List<ForceIndexResult> r = history.GetForceIndex(13).ToList();
 
             // assertions
 

--- a/tests/indicators/Test.Fractal.cs
+++ b/tests/indicators/Test.Fractal.cs
@@ -14,8 +14,7 @@ namespace Internal.Tests
         public void Standard2()
         {
 
-            List<FractalResult> results = Indicator.GetFractal(history, 2)
-                .ToList();
+            List<FractalResult> results = history.GetFractal(2).ToList();
 
             // assertions
 
@@ -55,8 +54,7 @@ namespace Internal.Tests
         public void Standard4()
         {
 
-            List<FractalResult> results = Indicator.GetFractal(history, 4)
-                .ToList();
+            List<FractalResult> results = history.GetFractal(4).ToList();
 
             // assertions
 

--- a/tests/indicators/Test.Gator.cs
+++ b/tests/indicators/Test.Gator.cs
@@ -12,8 +12,7 @@ namespace Internal.Tests
         [TestMethod]
         public void Standard()
         {
-            List<GatorResult> results = Indicator.GetGator(history)
-                .ToList();
+            List<GatorResult> results = history.GetGator().ToList();
 
             // assertions
 

--- a/tests/indicators/Test.HeikinAshi.cs
+++ b/tests/indicators/Test.HeikinAshi.cs
@@ -14,8 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
 
-            List<HeikinAshiResult> results = Indicator.GetHeikinAshi(history)
-                .ToList();
+            List<HeikinAshiResult> results = history.GetHeikinAshi().ToList();
 
             // assertions
 

--- a/tests/indicators/Test.Hma.cs
+++ b/tests/indicators/Test.Hma.cs
@@ -14,9 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
             int lookbackPeriod = 20;
-
-            List<HmaResult> results = Indicator.GetHma(history, lookbackPeriod)
-                .ToList();
+            List<HmaResult> results = history.GetHma(lookbackPeriod).ToList();
 
             // assertions
 

--- a/tests/indicators/Test.HtTrendline.cs
+++ b/tests/indicators/Test.HtTrendline.cs
@@ -14,8 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
 
-            List<HtlResult> results = Indicator.GetHtTrendline(history)
-                .ToList();
+            List<HtlResult> results = history.GetHtTrendline().ToList();
 
             // assertions
 

--- a/tests/indicators/Test.Ichimoku.cs
+++ b/tests/indicators/Test.Ichimoku.cs
@@ -17,8 +17,8 @@ namespace Internal.Tests
             int shortSpanPeriod = 26;
             int longSpanPeriod = 52;
 
-            List<IchimokuResult> results = Indicator.GetIchimoku(
-                history, signalPeriod, shortSpanPeriod, longSpanPeriod)
+            List<IchimokuResult> results = history.GetIchimoku(
+                signalPeriod, shortSpanPeriod, longSpanPeriod)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.Kama.cs
+++ b/tests/indicators/Test.Kama.cs
@@ -17,7 +17,7 @@ namespace Internal.Tests
             int fastPeriod = 2;
             int slowPeriod = 30;
 
-            List<KamaResult> results = Indicator.GetKama(history, erPeriod, fastPeriod, slowPeriod)
+            List<KamaResult> results = history.GetKama(erPeriod, fastPeriod, slowPeriod)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.Keltner.cs
+++ b/tests/indicators/Test.Keltner.cs
@@ -18,7 +18,7 @@ namespace Internal.Tests
             int atrPeriod = 10;
 
             List<KeltnerResult> results =
-                Indicator.GetKeltner(history, emaPeriod, multiplier, atrPeriod)
+                history.GetKeltner(emaPeriod, multiplier, atrPeriod)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.Klinger.cs
+++ b/tests/indicators/Test.Klinger.cs
@@ -15,7 +15,7 @@ namespace Internal.Tests
         {
 
             List<KvoResult> results =
-                Indicator.GetKvo(history, 34, 55, 13)
+                history.GetKvo(34, 55, 13)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.MaEnvelopes.cs
+++ b/tests/indicators/Test.MaEnvelopes.cs
@@ -15,7 +15,7 @@ namespace Internal.Tests
         {
 
             List<MaEnvelopeResult> results =
-                Indicator.GetMaEnvelopes(history, 10, 2.5, MaType.ALMA)
+                history.GetMaEnvelopes(10, 2.5, MaType.ALMA)
                 .ToList();
 
             // assertions
@@ -47,7 +47,7 @@ namespace Internal.Tests
         {
 
             List<MaEnvelopeResult> results =
-                Indicator.GetMaEnvelopes(history, 20, 2.5, MaType.DEMA)
+                history.GetMaEnvelopes(20, 2.5, MaType.DEMA)
                 .ToList();
 
             // assertions
@@ -79,7 +79,7 @@ namespace Internal.Tests
         {
 
             List<MaEnvelopeResult> results =
-                Indicator.GetMaEnvelopes(history, 20, 2.5, MaType.EPMA)
+                history.GetMaEnvelopes(20, 2.5, MaType.EPMA)
                 .ToList();
 
             // assertions
@@ -111,7 +111,7 @@ namespace Internal.Tests
         {
 
             List<MaEnvelopeResult> results =
-                Indicator.GetMaEnvelopes(history, 20, 2.5, MaType.EMA)
+                history.GetMaEnvelopes(20, 2.5, MaType.EMA)
                 .ToList();
 
             // assertions
@@ -143,7 +143,7 @@ namespace Internal.Tests
         {
 
             List<MaEnvelopeResult> results =
-                Indicator.GetMaEnvelopes(history, 20, 2.5, MaType.HMA)
+                history.GetMaEnvelopes(20, 2.5, MaType.HMA)
                 .ToList();
 
             // assertions
@@ -170,7 +170,7 @@ namespace Internal.Tests
         {
 
             List<MaEnvelopeResult> results =
-                Indicator.GetMaEnvelopes(history, 20, 2.5, MaType.SMA)
+                history.GetMaEnvelopes(20, 2.5, MaType.SMA)
                 .ToList();
 
             // assertions
@@ -202,7 +202,7 @@ namespace Internal.Tests
         {
 
             List<MaEnvelopeResult> results =
-                Indicator.GetMaEnvelopes(history, 20, 2.5, MaType.TEMA)
+                history.GetMaEnvelopes(20, 2.5, MaType.TEMA)
                 .ToList();
 
             // assertions
@@ -234,7 +234,7 @@ namespace Internal.Tests
         {
 
             List<MaEnvelopeResult> results =
-                Indicator.GetMaEnvelopes(history, 20, 2.5, MaType.WMA)
+                history.GetMaEnvelopes(20, 2.5, MaType.WMA)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.Macd.cs
+++ b/tests/indicators/Test.Macd.cs
@@ -18,7 +18,7 @@ namespace Internal.Tests
             int signalPeriod = 9;
 
             List<MacdResult> results =
-                Indicator.GetMacd(history, fastPeriod, slowPeriod, signalPeriod)
+                history.GetMacd(fastPeriod, slowPeriod, signalPeriod)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.Mama.cs
+++ b/tests/indicators/Test.Mama.cs
@@ -16,7 +16,7 @@ namespace Internal.Tests
             decimal fastLimit = 0.5m;
             decimal slowLimit = 0.05m;
 
-            List<MamaResult> results = Indicator.GetMama(history, fastLimit, slowLimit)
+            List<MamaResult> results = history.GetMama(fastLimit, slowLimit)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.Mfi.cs
+++ b/tests/indicators/Test.Mfi.cs
@@ -14,9 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
             int lookbackPeriod = 14;
-
-            List<MfiResult> results = Indicator.GetMfi(history, lookbackPeriod)
-                .ToList();
+            List<MfiResult> results = history.GetMfi(lookbackPeriod).ToList();
 
             // assertions
 

--- a/tests/indicators/Test.Obv.cs
+++ b/tests/indicators/Test.Obv.cs
@@ -14,8 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
 
-            List<ObvResult> results = Indicator.GetObv(history)
-                .ToList();
+            List<ObvResult> results = history.GetObv().ToList();
 
             // assertions
 

--- a/tests/indicators/Test.ParabolicSar.cs
+++ b/tests/indicators/Test.ParabolicSar.cs
@@ -17,7 +17,7 @@ namespace Internal.Tests
             decimal maxAccelerationFactor = 0.2m;
 
             List<ParabolicSarResult> results =
-                Indicator.GetParabolicSar(history, acclerationStep, maxAccelerationFactor)
+                history.GetParabolicSar(acclerationStep, maxAccelerationFactor)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.PivotPoints.cs
+++ b/tests/indicators/Test.PivotPoints.cs
@@ -16,7 +16,7 @@ namespace Internal.Tests
             PeriodSize periodSize = PeriodSize.Month;
             PivotPointType pointType = PivotPointType.Standard;
 
-            List<PivotPointsResult> results = Indicator.GetPivotPoints(history, periodSize, pointType)
+            List<PivotPointsResult> results = history.GetPivotPoints(periodSize, pointType)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.Pmo.cs
+++ b/tests/indicators/Test.Pmo.cs
@@ -14,8 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
 
-            List<PmoResult> results = Indicator.GetPmo(history, 35, 20, 10)
-                .ToList();
+            List<PmoResult> results = history.GetPmo(35, 20, 10).ToList();
 
             // assertions
 

--- a/tests/indicators/Test.Prs.cs
+++ b/tests/indicators/Test.Prs.cs
@@ -17,7 +17,7 @@ namespace Internal.Tests
             int smaPeriod = 10;
 
             List<PrsResult> results =
-                Indicator.GetPrs(history, historyOther, lookbackPeriod, smaPeriod)
+                history.GetPrs(historyOther, lookbackPeriod, smaPeriod)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.Pvo.cs
+++ b/tests/indicators/Test.Pvo.cs
@@ -18,7 +18,7 @@ namespace Internal.Tests
             int signalPeriod = 9;
 
             List<PvoResult> results =
-                Indicator.GetPvo(history, fastPeriod, slowPeriod, signalPeriod)
+                history.GetPvo(fastPeriod, slowPeriod, signalPeriod)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.Roc.cs
+++ b/tests/indicators/Test.Roc.cs
@@ -14,9 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
             int lookbackPeriod = 20;
-
-            List<RocResult> results = Indicator.GetRoc(history, lookbackPeriod)
-                .ToList();
+            List<RocResult> results = history.GetRoc(lookbackPeriod).ToList();
 
             // assertions
 

--- a/tests/indicators/Test.RocWb.cs
+++ b/tests/indicators/Test.RocWb.cs
@@ -13,8 +13,7 @@ namespace Internal.Tests
         [TestMethod]
         public void Standard()
         {
-            List<RocWbResult> results = Indicator.GetRocWb(history, 20, 3, 20)
-                .ToList();
+            List<RocWbResult> results = history.GetRocWb(20, 3, 20).ToList();
 
             // assertions
 

--- a/tests/indicators/Test.RollingPivots.cs
+++ b/tests/indicators/Test.RollingPivots.cs
@@ -18,7 +18,7 @@ namespace Internal.Tests
             PivotPointType pointType = PivotPointType.Standard;
 
             List<PivotPointsResult> results =
-                Indicator.GetRollingPivots(history, windowPeriod, offsetPeriod, pointType)
+                history.GetRollingPivots(windowPeriod, offsetPeriod, pointType)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.Rsi.cs
+++ b/tests/indicators/Test.Rsi.cs
@@ -14,9 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
             int lookbackPeriod = 14;
-
-            List<RsiResult> results = Indicator.GetRsi(history, lookbackPeriod)
-                .ToList();
+            List<RsiResult> results = history.GetRsi(lookbackPeriod).ToList();
 
             // assertions
 

--- a/tests/indicators/Test.Slope.cs
+++ b/tests/indicators/Test.Slope.cs
@@ -14,9 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
             int lookbackPeriod = 20;
-
-            List<SlopeResult> results = Indicator.GetSlope(history, lookbackPeriod)
-                .ToList();
+            List<SlopeResult> results = history.GetSlope(lookbackPeriod).ToList();
 
             // assertions
 

--- a/tests/indicators/Test.Sma.cs
+++ b/tests/indicators/Test.Sma.cs
@@ -14,8 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
 
-            List<SmaResult> results = Indicator.GetSma(history, 20)
-                .ToList();
+            List<SmaResult> results = history.GetSma(20).ToList();
 
             // assertions
 
@@ -37,8 +36,7 @@ namespace Internal.Tests
         public void Extended()
         {
 
-            List<SmaExtendedResult> results = Indicator.GetSmaExtended(history, 20)
-                .ToList();
+            List<SmaExtendedResult> results = history.GetSmaExtended(20).ToList();
 
             // assertions
 

--- a/tests/indicators/Test.Smma.cs
+++ b/tests/indicators/Test.Smma.cs
@@ -13,9 +13,7 @@ namespace Internal.Tests
         public void Standard()
         {
             int lookbackPeriod = 20;
-
-            List<SmmaResult> results = Indicator.GetSmma(history, lookbackPeriod)
-                .ToList();
+            List<SmmaResult> results = history.GetSmma(lookbackPeriod).ToList();
 
             // assertions
 

--- a/tests/indicators/Test.StarcBands.cs
+++ b/tests/indicators/Test.StarcBands.cs
@@ -19,7 +19,7 @@ namespace Internal.Tests
             int lookbackPeriod = Math.Max(smaPeriod, atrPeriod);
 
             List<StarcBandsResult> results =
-                Indicator.GetStarcBands(history, smaPeriod, multiplier, atrPeriod)
+                history.GetStarcBands(smaPeriod, multiplier, atrPeriod)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.StdDev.cs
+++ b/tests/indicators/Test.StdDev.cs
@@ -14,9 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
             int lookbackPeriod = 10;
-
-            List<StdDevResult> results = Indicator.GetStdDev(history, lookbackPeriod)
-                .ToList();
+            List<StdDevResult> results = history.GetStdDev(lookbackPeriod).ToList();
 
             // assertions
 

--- a/tests/indicators/Test.StdDevChannels.cs
+++ b/tests/indicators/Test.StdDevChannels.cs
@@ -17,7 +17,7 @@ namespace Internal.Tests
             decimal standardDeviations = 2;
 
             List<StdDevChannelsResult> results =
-                Indicator.GetStdDevChannels(history, lookbackPeriod, standardDeviations)
+                history.GetStdDevChannels(lookbackPeriod, standardDeviations)
                 .ToList();
 
             // assertions
@@ -79,7 +79,7 @@ namespace Internal.Tests
             // null provided for lookback period
 
             List<StdDevChannelsResult> results =
-                Indicator.GetStdDevChannels(history, null, 2)
+                history.GetStdDevChannels(null, 2)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.Stoch.cs
+++ b/tests/indicators/Test.Stoch.cs
@@ -18,7 +18,7 @@ namespace Internal.Tests
             int smoothPeriod = 3;
 
             List<StochResult> results =
-                Indicator.GetStoch(history, lookbackPeriod, signalPeriod, smoothPeriod)
+                history.GetStoch(lookbackPeriod, signalPeriod, smoothPeriod)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.StochRsi.cs
+++ b/tests/indicators/Test.StochRsi.cs
@@ -19,7 +19,7 @@ namespace Internal.Tests
             int smoothPeriod = 1;
 
             List<StochRsiResult> results =
-                Indicator.GetStochRsi(history, rsiPeriod, stochPeriod, signalPeriod, smoothPeriod)
+                history.GetStochRsi(rsiPeriod, stochPeriod, signalPeriod, smoothPeriod)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.SuperTrend.cs
+++ b/tests/indicators/Test.SuperTrend.cs
@@ -16,7 +16,7 @@ namespace Internal.Tests
             int lookbackPeriod = 14;
             decimal multiplier = 3;
 
-            List<SuperTrendResult> results = Indicator.GetSuperTrend(history, lookbackPeriod, multiplier)
+            List<SuperTrendResult> results = history.GetSuperTrend(lookbackPeriod, multiplier)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.T3.cs
+++ b/tests/indicators/Test.T3.cs
@@ -14,8 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
 
-            List<T3Result> results = Indicator.GetT3(history, 5, 0.7)
-                .ToList();
+            List<T3Result> results = history.GetT3(5, 0.7).ToList();
 
             // assertions
 

--- a/tests/indicators/Test.TripleEma.cs
+++ b/tests/indicators/Test.TripleEma.cs
@@ -14,9 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
             int lookbackPeriod = 20;
-
-            List<EmaResult> results = Indicator.GetTripleEma(history, lookbackPeriod)
-                .ToList();
+            List<EmaResult> results = history.GetTripleEma(lookbackPeriod).ToList();
 
             // assertions
 

--- a/tests/indicators/Test.Trix.cs
+++ b/tests/indicators/Test.Trix.cs
@@ -14,8 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
 
-            List<TrixResult> results = Indicator.GetTrix(history, 20, 5)
-                .ToList();
+            List<TrixResult> results = history.GetTrix(20, 5).ToList();
 
             // assertions
 

--- a/tests/indicators/Test.Tsi.cs
+++ b/tests/indicators/Test.Tsi.cs
@@ -14,8 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
 
-            List<TsiResult> results = Indicator.GetTsi(history, 25, 13, 7)
-                .ToList();
+            List<TsiResult> results = history.GetTsi(25, 13, 7).ToList();
 
             // assertions
 

--- a/tests/indicators/Test.UlcerIndex.cs
+++ b/tests/indicators/Test.UlcerIndex.cs
@@ -14,8 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
             int lookbackPeriod = 14;
-
-            List<UlcerIndexResult> results = Indicator.GetUlcerIndex(history, lookbackPeriod)
+            List<UlcerIndexResult> results = history.GetUlcerIndex(lookbackPeriod)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.Ultimate.cs
+++ b/tests/indicators/Test.Ultimate.cs
@@ -14,7 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
 
-            List<UltimateResult> results = Indicator.GetUltimate(history, 7, 14, 28)
+            List<UltimateResult> results = history.GetUltimate(7, 14, 28)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.VolSma.cs
+++ b/tests/indicators/Test.VolSma.cs
@@ -14,8 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
             int lookbackPeriod = 20;
-
-            List<VolSmaResult> results = Indicator.GetVolSma(history, lookbackPeriod)
+            List<VolSmaResult> results = history.GetVolSma(lookbackPeriod)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.Vortex.cs
+++ b/tests/indicators/Test.Vortex.cs
@@ -14,8 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
             int lookbackPeriod = 14;
-            List<VortexResult> results
-                = Indicator.GetVortex(history, lookbackPeriod).ToList();
+            List<VortexResult> results = history.GetVortex(lookbackPeriod).ToList();
 
             // assertions
 

--- a/tests/indicators/Test.Vwap.cs
+++ b/tests/indicators/Test.Vwap.cs
@@ -17,7 +17,7 @@ namespace Internal.Tests
         public void Standard()
         {
 
-            List<VwapResult> results = Indicator.GetVwap(intraday)
+            List<VwapResult> results = intraday.GetVwap()
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.WilliamsR.cs
+++ b/tests/indicators/Test.WilliamsR.cs
@@ -14,8 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
             int lookbackPeriod = 14;
-
-            List<WilliamsResult> results = Indicator.GetWilliamsR(history, lookbackPeriod)
+            List<WilliamsResult> results = history.GetWilliamsR(lookbackPeriod)
                 .ToList();
 
             // assertions

--- a/tests/indicators/Test.Wma.cs
+++ b/tests/indicators/Test.Wma.cs
@@ -14,9 +14,7 @@ namespace Internal.Tests
         public void Standard()
         {
             int lookbackPeriod = 20;
-
-            List<WmaResult> results = Indicator.GetWma(history, lookbackPeriod)
-                .ToList();
+            List<WmaResult> results = history.GetWma(lookbackPeriod).ToList();
 
             // assertions
 

--- a/tests/indicators/Test.ZigZag.cs
+++ b/tests/indicators/Test.ZigZag.cs
@@ -13,10 +13,9 @@ namespace Internal.Tests
         [TestMethod]
         public void StandardClose()
         {
-            decimal percentChange = 3;
 
             List<ZigZagResult> results =
-                Indicator.GetZigZag(history, ZigZagType.Close, percentChange)
+                history.GetZigZag(ZigZagType.Close, 3)
                 .ToList();
 
             // assertions
@@ -70,10 +69,9 @@ namespace Internal.Tests
         [TestMethod]
         public void StandardHighLow()
         {
-            decimal percentChange = 3;
 
             List<ZigZagResult> results =
-                Indicator.GetZigZag(history, ZigZagType.HighLow, percentChange)
+                history.GetZigZag(ZigZagType.HighLow, 3)
                 .ToList();
 
             // assertions

--- a/tests/performance/Perf.Indicators.cs
+++ b/tests/performance/Perf.Indicators.cs
@@ -15,49 +15,49 @@ namespace Tests.Performance
         [Benchmark]
         public object GetAdl()
         {
-            return Indicator.GetAdl(h);
+            return h.GetAdl();
         }
 
         [Benchmark]
         public object GetAdlWithSma()
         {
-            return Indicator.GetAdl(h, 14);
+            return h.GetAdl(14);
         }
 
         [Benchmark]
         public object GetAdx()
         {
-            return Indicator.GetAdx(h);
+            return h.GetAdx();
         }
 
         [Benchmark]
         public object GetAlligator()
         {
-            return Indicator.GetAlligator(h);
+            return h.GetAlligator();
         }
 
         [Benchmark]
         public object GetAlma()
         {
-            return Indicator.GetAlma(h);
+            return h.GetAlma();
         }
 
         [Benchmark]
         public object GetAroon()
         {
-            return Indicator.GetAroon(h);
+            return h.GetAroon();
         }
 
         [Benchmark]
         public object GetAtr()
         {
-            return Indicator.GetAtr(h);
+            return h.GetAtr();
         }
 
         [Benchmark]
         public object GetAwesome()
         {
-            return Indicator.GetAwesome(h);
+            return h.GetAwesome();
         }
 
         [Benchmark]
@@ -69,397 +69,397 @@ namespace Tests.Performance
         [Benchmark]
         public object GetBollingerBands()
         {
-            return Indicator.GetBollingerBands(h);
+            return h.GetBollingerBands();
         }
 
         [Benchmark]
         public object GetBop()
         {
-            return Indicator.GetBop(h);
+            return h.GetBop();
         }
 
         [Benchmark]
         public object GetCci()
         {
-            return Indicator.GetCci(h);
+            return h.GetCci();
         }
 
         [Benchmark]
         public object GetChaikinOsc()
         {
-            return Indicator.GetChaikinOsc(h);
+            return h.GetChaikinOsc();
         }
 
         [Benchmark]
         public object GetChandelier()
         {
-            return Indicator.GetChandelier(h);
+            return h.GetChandelier();
         }
 
         [Benchmark]
         public object GetChop()
         {
-            return Indicator.GetChop(h);
+            return h.GetChop();
         }
 
         [Benchmark]
         public object GetCmf()
         {
-            return Indicator.GetCmf(h);
+            return h.GetCmf();
         }
 
         [Benchmark]
         public object GetConnorsRsi()
         {
-            return Indicator.GetConnorsRsi(h);
+            return h.GetConnorsRsi();
         }
 
         [Benchmark]
         public object GetCorrelation()
         {
-            return Indicator.GetCorrelation(h, ho, 20);
+            return h.GetCorrelation(ho, 20);
         }
 
         [Benchmark]
         public object GetDonchian()
         {
-            return Indicator.GetDonchian(h);
+            return h.GetDonchian();
         }
 
         [Benchmark]
         public object GetDoubleEma()
         {
-            return Indicator.GetDoubleEma(h, 14);
+            return h.GetDoubleEma(14);
         }
 
         [Benchmark]
         public object GetElderRay()
         {
-            return Indicator.GetElderRay(h);
+            return h.GetElderRay();
         }
 
         [Benchmark]
         public object GetEma()
         {
-            return Indicator.GetEma(h, 14);
+            return h.GetEma(14);
         }
 
         [Benchmark]
         public object GetEpma()
         {
-            return Indicator.GetEpma(h, 14);
+            return h.GetEpma(14);
         }
 
         [Benchmark]
         public object GetFcb()
         {
-            return Indicator.GetFcb(h, 14);
+            return h.GetFcb(14);
         }
 
         [Benchmark]
         public object GetFisherTransform()
         {
-            return Indicator.GetFisherTransform(h, 10);
+            return h.GetFisherTransform(10);
         }
 
         [Benchmark]
         public object GetForceIndex()
         {
-            return Indicator.GetForceIndex(h, 13);
+            return h.GetForceIndex(13);
         }
 
         [Benchmark]
         public object GetFractal()
         {
-            return Indicator.GetFractal(h);
+            return h.GetFractal();
         }
 
         [Benchmark]
         public object GetGator()
         {
-            return Indicator.GetGator(h);
+            return h.GetGator();
         }
 
         [Benchmark]
         public object GetHeikinAshi()
         {
-            return Indicator.GetHeikinAshi(h);
+            return h.GetHeikinAshi();
         }
 
         [Benchmark]
         public object GetHma()
         {
-            return Indicator.GetHma(h, 14);
+            return h.GetHma(14);
         }
 
         [Benchmark]
         public object GetHtTrendline()
         {
-            return Indicator.GetHtTrendline(h);
+            return h.GetHtTrendline();
         }
 
         [Benchmark]
         public object GetIchimoku()
         {
-            return Indicator.GetIchimoku(h);
+            return h.GetIchimoku();
         }
 
         [Benchmark]
         public object GetKama()
         {
-            return Indicator.GetKama(h);
+            return h.GetKama();
         }
 
         [Benchmark]
         public object GetKlinger()
         {
-            return Indicator.GetKvo(h);
+            return h.GetKvo();
         }
 
         [Benchmark]
         public object GetKeltner()
         {
-            return Indicator.GetKeltner(h);
+            return h.GetKeltner();
         }
 
         [Benchmark]
         public object GetMacd()
         {
-            return Indicator.GetMacd(h);
+            return h.GetMacd();
         }
 
         [Benchmark]
         public object GetMaEnvelopes()
         {
-            return Indicator.GetMaEnvelopes(h, 20, 2.5, MaType.SMA);
+            return h.GetMaEnvelopes(20, 2.5, MaType.SMA);
         }
 
         [Benchmark]
         public object GetMama()
         {
-            return Indicator.GetMama(h);
+            return h.GetMama();
         }
 
         [Benchmark]
         public object GetMfi()
         {
-            return Indicator.GetMfi(h);
+            return h.GetMfi();
         }
 
         [Benchmark]
         public object GetObv()
         {
-            return Indicator.GetObv(h);
+            return h.GetObv();
         }
 
         [Benchmark]
         public object GetObvWithSma()
         {
-            return Indicator.GetObv(h, 14);
+            return h.GetObv(14);
         }
 
         [Benchmark]
         public object GetParabolicSar()
         {
-            return Indicator.GetParabolicSar(h);
+            return h.GetParabolicSar();
         }
 
         [Benchmark]
         public object GetPivotPoints()
         {
-            return Indicator.GetPivotPoints(h, PeriodSize.Month, PivotPointType.Standard);
+            return h.GetPivotPoints(PeriodSize.Month, PivotPointType.Standard);
         }
 
         [Benchmark]
         public object GetPmo()
         {
-            return Indicator.GetPmo(h);
+            return h.GetPmo();
         }
 
         [Benchmark]
         public object GetPrs()
         {
-            return Indicator.GetPrs(h, ho);
+            return h.GetPrs(ho);
         }
 
         [Benchmark]
         public object GetPrsWithSma()
         {
-            return Indicator.GetPrs(h, ho, null, 5);
+            return h.GetPrs(ho, null, 5);
         }
 
         [Benchmark]
         public object GetPvo()
         {
-            return Indicator.GetPvo(h);
+            return h.GetPvo();
         }
 
         [Benchmark]
         public object GetRoc()
         {
-            return Indicator.GetRoc(h, 20);
+            return h.GetRoc(20);
         }
 
         [Benchmark]
         public object GetRocWb()
         {
-            return Indicator.GetRocWb(h, 12, 3, 12);
+            return h.GetRocWb(12, 3, 12);
         }
 
         [Benchmark]
         public object GetRocWithSma()
         {
-            return Indicator.GetRoc(h, 20, 14);
+            return h.GetRoc(20, 14);
         }
 
         [Benchmark]
         public object GetRsi()
         {
-            return Indicator.GetRsi(h);
+            return h.GetRsi();
         }
 
         [Benchmark]
         public object GetSlope()
         {
-            return Indicator.GetSlope(h, 20);
+            return h.GetSlope(20);
         }
 
         [Benchmark]
         public object GetSma()
         {
-            return Indicator.GetSma(h, 10);
+            return h.GetSma(10);
         }
 
         [Benchmark]
         public object GetSmaExtended()
         {
-            return Indicator.GetSmaExtended(h, 10);
+            return h.GetSmaExtended(10);
         }
 
         [Benchmark]
         public object GetSmma()
         {
-            return Indicator.GetSmma(h, 10);
+            return h.GetSmma(10);
         }
 
         [Benchmark]
         public object GetStarcBands()
         {
-            return Indicator.GetStarcBands(h);
+            return h.GetStarcBands();
         }
 
         [Benchmark]
         public object GetStdDev()
         {
-            return Indicator.GetStdDev(h, 20);
+            return h.GetStdDev(20);
         }
 
         [Benchmark]
         public object GetStdDevWithSma()
         {
-            return Indicator.GetStdDev(h, 20, 14);
+            return h.GetStdDev(20, 14);
         }
 
         [Benchmark]
         public object GetStdDevChannels()
         {
-            return Indicator.GetStdDevChannels(h);
+            return h.GetStdDevChannels();
         }
 
         [Benchmark]
         public object GetStoch()
         {
-            return Indicator.GetStoch(h);
+            return h.GetStoch();
         }
 
         [Benchmark]
         public object GetStochRsi()
         {
-            return Indicator.GetStochRsi(h, 14, 14, 3);
+            return h.GetStochRsi(14, 14, 3);
         }
 
         [Benchmark]
         public object GetSuperTrend()
         {
-            return Indicator.GetSuperTrend(h);
+            return h.GetSuperTrend();
         }
 
         [Benchmark]
         public object GetTripleEma()
         {
-            return Indicator.GetTripleEma(h, 14);
+            return h.GetTripleEma(14);
         }
 
         [Benchmark]
         public object GetTrix()
         {
-            return Indicator.GetTrix(h, 14);
+            return h.GetTrix(14);
         }
 
         [Benchmark]
         public object GetTrixWithSma()
         {
-            return Indicator.GetTrix(h, 14, 5);
+            return h.GetTrix(14, 5);
         }
 
         [Benchmark]
         public object GetTsi()
         {
-            return Indicator.GetTsi(h);
+            return h.GetTsi();
         }
 
         [Benchmark]
         public object GetT3()
         {
-            return Indicator.GetT3(h);
+            return h.GetT3();
         }
 
         [Benchmark]
         public object GetUlcerIndex()
         {
-            return Indicator.GetUlcerIndex(h);
+            return h.GetUlcerIndex();
         }
 
         [Benchmark]
         public object GetUltimate()
         {
-            return Indicator.GetUltimate(h);
+            return h.GetUltimate();
         }
 
         [Benchmark]
         public object GetVolSma()
         {
-            return Indicator.GetVolSma(h, 14);
+            return h.GetVolSma(14);
         }
 
         [Benchmark]
         public object GetVortex()
         {
-            return Indicator.GetVortex(h, 14);
+            return h.GetVortex(14);
         }
 
         [Benchmark]
         public object GetVwap()
         {
-            return Indicator.GetVwap(hday);
+            return hday.GetVwap();
         }
 
         [Benchmark]
         public object GetWilliamsR()
         {
-            return Indicator.GetWilliamsR(h);
+            return h.GetWilliamsR();
         }
 
         [Benchmark]
         public object GetWma()
         {
-            return Indicator.GetWma(h, 14);
+            return h.GetWma(14);
         }
 
         [Benchmark]
         public object GetZigZag()
         {
-            return Indicator.GetZigZag(h);
+            return h.GetZigZag();
         }
     }
 }

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -1,93 +1,94 @@
-# Performance benchmarks for v1.11.1
+# Performance benchmarks for v1.13.0
 
 These are the execution times for the current indicators using two years of historical daily stock quotes (502 periods) with default or typical parameters.
 
 ``` bash
-BenchmarkDotNet=v0.13.0, OS=Windows 10.0.19042.985 (20H2/October2020Update)
+BenchmarkDotNet=v0.13.0, OS=Windows 10.0.19043.1055 (21H1/May2021Update)
 Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
-.NET SDK=5.0.203
-  [Host]     : .NET 5.0.6 (5.0.621.22011), X64 RyuJIT
-  DefaultJob : .NET 5.0.6 (5.0.621.22011), X64 RyuJIT
+.NET SDK=5.0.301
+  [Host]     : .NET 5.0.7 (5.0.721.25508), X64 RyuJIT
+  DefaultJob : .NET 5.0.7 (5.0.721.25508), X64 RyuJIT
 ```
 
 ## indicators
 
-|             Method |        Mean |    Error |   StdDev |
-|------------------- |------------:|---------:|---------:|
-|             GetAdl |   144.93 μs | 0.426 μs | 0.356 μs |
-|      GetAdlWithSma |   379.24 μs | 0.999 μs | 0.935 μs |
-|             GetAdx |   752.20 μs | 2.060 μs | 1.927 μs |
-|       GetAlligator |   235.47 μs | 0.843 μs | 0.789 μs |
-|            GetAlma |   217.43 μs | 0.538 μs | 0.503 μs |
-|           GetAroon |   337.66 μs | 0.732 μs | 0.684 μs |
-|             GetAtr |   159.75 μs | 0.731 μs | 0.648 μs |
-|         GetAwesome |   331.46 μs | 1.751 μs | 1.367 μs |
-|            GetBeta |   979.92 μs | 3.162 μs | 2.803 μs |
-|  GetBollingerBands |   462.40 μs | 2.117 μs | 1.877 μs |
-|             GetBop |   283.49 μs | 2.585 μs | 2.158 μs |
-|             GetCci |   845.06 μs | 1.262 μs | 1.119 μs |
-|      GetChaikinOsc |   266.55 μs | 0.563 μs | 0.499 μs |
-|      GetChandelier |   355.75 μs | 1.098 μs | 0.974 μs |
-|            GetChop |   306.13 μs | 1.367 μs | 1.212 μs |
-|             GetCmf |   666.08 μs | 1.856 μs | 1.550 μs |
-|      GetConnorsRsi | 1,181.32 μs | 3.130 μs | 2.614 μs |
-|     GetCorrelation |   873.22 μs | 1.914 μs | 1.697 μs |
-|        GetDonchian |   345.41 μs | 0.955 μs | 0.798 μs |
-|       GetDoubleEma |   184.03 μs | 0.930 μs | 0.824 μs |
-|        GetElderRay |   166.58 μs | 0.700 μs | 0.655 μs |
-|             GetEma |    99.82 μs | 0.296 μs | 0.276 μs |
-|            GetEpma | 1,388.29 μs | 3.948 μs | 3.500 μs |
-|             GetFcb |   392.89 μs | 1.242 μs | 1.162 μs |
-| GetFisherTransform |   283.96 μs | 1.102 μs | 0.977 μs |
-|      GetForceIndex |   128.03 μs | 0.580 μs | 0.514 μs |
-|         GetFractal |   108.10 μs | 0.624 μs | 0.584 μs |
-|           GetGator |   288.83 μs | 0.830 μs | 0.735 μs |
-|      GetHeikinAshi |   176.00 μs | 0.486 μs | 0.431 μs |
-|             GetHma | 1,368.52 μs | 4.075 μs | 3.403 μs |
-|     GetHtTrendline |   175.90 μs | 1.924 μs | 1.799 μs |
-|        GetIchimoku | 1,003.14 μs | 2.958 μs | 2.622 μs |
-|            GetKama |   326.21 μs | 0.830 μs | 0.777 μs |
-|         GetKeltner |   468.85 μs | 0.792 μs | 0.702 μs |
-|            GetMacd |   216.78 μs | 0.625 μs | 0.522 μs |
-|     GetMaEnvelopes |   151.92 μs | 0.416 μs | 0.347 μs |
-|            GetMama |   286.52 μs | 0.627 μs | 0.555 μs |
-|             GetMfi |   484.78 μs | 0.973 μs | 0.910 μs |
-|             GetObv |    62.79 μs | 0.218 μs | 0.204 μs |
-|      GetObvWithSma |   138.33 μs | 0.326 μs | 0.289 μs |
-|    GetParabolicSar |    93.76 μs | 0.325 μs | 0.304 μs |
-|     GetPivotPoints |    97.71 μs | 0.351 μs | 0.311 μs |
-|             GetPmo |   261.43 μs | 0.672 μs | 0.596 μs |
-|             GetPrs |   132.97 μs | 0.573 μs | 0.508 μs |
-|      GetPrsWithSma |   204.46 μs | 0.308 μs | 0.273 μs |
-|             GetPvo |   341.19 μs | 0.906 μs | 0.804 μs |
-|             GetRoc |    96.64 μs | 0.401 μs | 0.375 μs |
-|           GetRocWb |   201.06 μs | 0.341 μs | 0.302 μs |
-|      GetRocWithSma |   353.39 μs | 0.411 μs | 0.364 μs |
-|             GetRsi |   340.56 μs | 0.782 μs | 0.653 μs |
-|           GetSlope |   880.20 μs | 0.799 μs | 0.668 μs |
-|             GetSma |   105.35 μs | 0.244 μs | 0.190 μs |
-|     GetSmaExtended |   945.91 μs | 1.511 μs | 1.261 μs |
-|            GetSmma |    97.21 μs | 0.467 μs | 0.437 μs |
-|      GetStarcBands |   420.69 μs | 0.779 μs | 0.728 μs |
-|          GetStdDev |   295.64 μs | 0.688 μs | 0.538 μs |
-|   GetStdDevWithSma |   436.54 μs | 4.411 μs | 3.911 μs |
-|  GetStdDevChannels |   945.04 μs | 1.729 μs | 1.444 μs |
-|           GetStoch |   403.55 μs | 1.305 μs | 1.221 μs |
-|        GetStochRsi |   704.54 μs | 1.785 μs | 1.670 μs |
-|      GetSuperTrend |   303.18 μs | 0.804 μs | 0.752 μs |
-|       GetTripleEma |   263.62 μs | 1.432 μs | 1.339 μs |
-|            GetTrix |   325.12 μs | 2.111 μs | 1.871 μs |
-|     GetTrixWithSma |   378.41 μs | 0.966 μs | 0.903 μs |
-|             GetTsi |   369.60 μs | 0.457 μs | 0.357 μs |
-|              GetT3 |   465.37 μs | 0.731 μs | 0.648 μs |
-|      GetUlcerIndex | 1,531.77 μs | 1.826 μs | 1.618 μs |
-|        GetUltimate |   556.71 μs | 1.488 μs | 1.243 μs |
-|          GetVolSma |   121.32 μs | 0.487 μs | 0.456 μs |
-|          GetVortex |   279.29 μs | 0.519 μs | 0.405 μs |
-|            GetVwap |    98.09 μs | 0.297 μs | 0.248 μs |
-|       GetWilliamsR |   291.26 μs | 1.229 μs | 1.149 μs |
-|             GetWma |   735.78 μs | 1.319 μs | 1.101 μs |
-|          GetZigZag |   148.00 μs | 0.369 μs | 0.345 μs |
+|             Method |        Mean |     Error |    StdDev |
+|------------------- |------------:|----------:|----------:|
+|             GetAdl |   143.99 μs |  0.385 μs |  0.322 μs |
+|      GetAdlWithSma |   378.45 μs |  1.024 μs |  0.958 μs |
+|             GetAdx |   752.21 μs |  1.662 μs |  1.554 μs |
+|       GetAlligator |   234.75 μs |  0.360 μs |  0.300 μs |
+|            GetAlma |   219.23 μs |  2.133 μs |  1.665 μs |
+|           GetAroon |   348.09 μs |  1.176 μs |  0.982 μs |
+|             GetAtr |   159.34 μs |  0.266 μs |  0.236 μs |
+|         GetAwesome |   329.91 μs |  1.614 μs |  1.431 μs |
+|            GetBeta |   971.69 μs |  2.306 μs |  2.045 μs |
+|  GetBollingerBands |   457.50 μs |  0.854 μs |  0.757 μs |
+|             GetBop |   278.49 μs |  0.716 μs |  0.598 μs |
+|             GetCci |   846.06 μs |  2.232 μs |  2.088 μs |
+|      GetChaikinOsc |   268.37 μs |  0.774 μs |  0.724 μs |
+|      GetChandelier |   361.67 μs |  0.939 μs |  0.833 μs |
+|            GetChop |   305.60 μs |  0.906 μs |  0.847 μs |
+|             GetCmf |   666.58 μs |  0.739 μs |  0.617 μs |
+|      GetConnorsRsi | 1,175.92 μs |  4.322 μs |  4.043 μs |
+|     GetCorrelation |   879.02 μs |  1.301 μs |  1.086 μs |
+|        GetDonchian |   341.23 μs |  0.745 μs |  0.622 μs |
+|       GetDoubleEma |   182.35 μs |  0.515 μs |  0.482 μs |
+|        GetElderRay |   167.89 μs |  0.524 μs |  0.465 μs |
+|             GetEma |    98.38 μs |  0.190 μs |  0.158 μs |
+|            GetEpma | 1,377.38 μs |  3.667 μs |  3.062 μs |
+|             GetFcb |   384.00 μs |  0.875 μs |  0.730 μs |
+| GetFisherTransform |   285.59 μs |  0.974 μs |  0.911 μs |
+|      GetForceIndex |   127.83 μs |  0.273 μs |  0.228 μs |
+|         GetFractal |   105.90 μs |  0.237 μs |  0.210 μs |
+|           GetGator |   285.49 μs |  0.722 μs |  0.675 μs |
+|      GetHeikinAshi |   173.11 μs |  0.442 μs |  0.413 μs |
+|             GetHma | 1,364.67 μs |  2.549 μs |  2.259 μs |
+|     GetHtTrendline |   173.95 μs |  0.424 μs |  0.376 μs |
+|        GetIchimoku |   990.62 μs |  3.245 μs |  2.877 μs |
+|            GetKama |   328.36 μs |  0.513 μs |  0.401 μs |
+|         GetKlinger |   495.51 μs |  1.240 μs |  1.099 μs |
+|         GetKeltner |   479.02 μs |  0.630 μs |  0.526 μs |
+|            GetMacd |   216.36 μs |  0.402 μs |  0.376 μs |
+|     GetMaEnvelopes |   151.98 μs |  0.170 μs |  0.142 μs |
+|            GetMama |   287.67 μs |  0.852 μs |  0.665 μs |
+|             GetMfi |   486.01 μs |  1.798 μs |  1.681 μs |
+|             GetObv |    62.47 μs |  0.394 μs |  0.369 μs |
+|      GetObvWithSma |   138.48 μs |  0.961 μs |  0.944 μs |
+|    GetParabolicSar |    94.35 μs |  0.359 μs |  0.318 μs |
+|     GetPivotPoints |    95.21 μs |  0.335 μs |  0.313 μs |
+|             GetPmo |   260.83 μs |  0.752 μs |  0.587 μs |
+|             GetPrs |   132.90 μs |  0.854 μs |  0.798 μs |
+|      GetPrsWithSma |   206.29 μs |  0.505 μs |  0.472 μs |
+|             GetPvo |   341.99 μs |  4.889 μs |  8.563 μs |
+|             GetRoc |    96.66 μs |  1.051 μs |  0.878 μs |
+|           GetRocWb |   201.52 μs |  0.394 μs |  0.308 μs |
+|      GetRocWithSma |   355.29 μs |  1.056 μs |  0.824 μs |
+|             GetRsi |   342.66 μs |  1.079 μs |  0.956 μs |
+|           GetSlope |   897.78 μs |  5.472 μs |  4.851 μs |
+|             GetSma |   107.45 μs |  0.751 μs |  0.627 μs |
+|     GetSmaExtended |   947.36 μs |  4.993 μs |  4.426 μs |
+|            GetSmma |    98.28 μs |  0.514 μs |  0.455 μs |
+|      GetStarcBands |   418.86 μs |  1.821 μs |  1.703 μs |
+|          GetStdDev |   291.32 μs |  1.029 μs |  0.913 μs |
+|   GetStdDevWithSma |   381.76 μs |  2.349 μs |  2.198 μs |
+|  GetStdDevChannels |   988.70 μs |  3.511 μs |  2.932 μs |
+|           GetStoch |   402.00 μs |  1.573 μs |  1.394 μs |
+|        GetStochRsi |   709.01 μs |  5.271 μs |  4.673 μs |
+|      GetSuperTrend |   304.45 μs |  1.213 μs |  1.075 μs |
+|       GetTripleEma |   262.92 μs |  1.150 μs |  0.960 μs |
+|            GetTrix |   322.77 μs |  0.740 μs |  0.618 μs |
+|     GetTrixWithSma |   378.55 μs |  0.654 μs |  0.510 μs |
+|             GetTsi |   368.83 μs |  0.921 μs |  0.769 μs |
+|              GetT3 |   465.86 μs |  0.936 μs |  0.781 μs |
+|      GetUlcerIndex | 1,508.19 μs |  5.792 μs |  5.134 μs |
+|        GetUltimate |   557.18 μs |  3.958 μs |  3.702 μs |
+|          GetVolSma |   122.34 μs |  0.649 μs |  0.542 μs |
+|          GetVortex |   284.85 μs |  1.313 μs |  1.097 μs |
+|            GetVwap |    99.16 μs |  0.344 μs |  0.305 μs |
+|       GetWilliamsR |   284.47 μs |  1.061 μs |  0.828 μs |
+|             GetWma |   749.35 μs | 13.237 μs | 16.741 μs |
+|          GetZigZag |   146.51 μs |  0.453 μs |  0.378 μs |
 
 ## history functions (mostly internal)
 
@@ -101,7 +102,7 @@ Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical co
 
 | Method | Periods |        Mean |    Error |   StdDev |
 |------- |-------- |------------:|---------:|---------:|
-| StdDev |      20 |    36.89 ns | 0.109 ns | 0.091 ns |
-| StdDev |      50 |    95.57 ns | 0.269 ns | 0.224 ns |
-| StdDev |     250 |   530.10 ns | 1.183 ns | 0.988 ns |
-| StdDev |    1000 | 2,142.99 ns | 4.975 ns | 4.653 ns |
+| StdDev |      20 |    36.59 ns | 0.139 ns | 0.130 ns |
+| StdDev |      50 |    95.29 ns | 0.192 ns | 0.170 ns |
+| StdDev |     250 |   530.01 ns | 1.333 ns | 1.181 ns |
+| StdDev |    1000 | 2,142.70 ns | 4.781 ns | 4.239 ns |


### PR DESCRIPTION
## Description

Adding indicators as extensions of `history`.  Please note this is not a breaking change as the original syntax still works as previously specified.

``` csharp
// existing original syntax
var results = Indicator.GetEma(history,lookbackperiod);

// newly added extension syntax
var results = history.GetEma(lookbackPeriod);
```
- documentation now shows the new extension approach syntax only; however, we provide a mention of the old syntax in the guide for reference.

## Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, including `INDICATORS.md`, `README.md`, `info.xml`, etc
- [ ] I have made corresponding changes to the `wraps` interoperability files
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage
- [x] I have added or run the performance tests that depict optimal execution times
- [x] New and existing unit tests pass locally and in the build (below) with my changes

## Acknowledgements

- [x] I have read and understand [the Apache 2.0 license](https://opensource.org/licenses/Apache-2.0)
- [x] I agree to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)
