### PR TITLE
add ConvertToQuotes

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -249,6 +249,18 @@ If you want to compute an indicator of indicators, such as an SMA of an ADX or a
 // fetch historical quotes from your feed (your method)
 IEnumerable<Quote> quotes = GetHistoryFromFeed("SPY");
 
+// calculate RSI of OBV
+IEnumerable<RsiResult> results 
+  = quotes.GetObv()
+    .ConvertToQuotes()
+    .GetRsi(14);
+```
+
+See [.ConvertToQuotes()](UTILITIES.md#convert-to-quotes) for more information.
+
+When `.ConvertToQuotes()` is not available for an indicator, a workaround is to convert yourself.
+
+```csharp
 // calculate OBV
 IEnumerable<ObvResult> obvResults = quotes.GetObv();
 
@@ -263,8 +275,7 @@ List<Quote> obvQuotes = obvResults
   .ToList();
 
 // calculate RSI of OBV
-int lookbackPeriods = 14;
-IEnumerable<RsiResult> results = obvQuotes.GetRsi(lookbackPeriods);
+IEnumerable<RsiResult> results = obvQuotes.GetRsi(14);
 ```
 
 ## Utilities

--- a/docs/UTILITIES.md
+++ b/docs/UTILITIES.md
@@ -36,6 +36,39 @@ IEnumerable<Quote> dayBarQuotes =
 
 ## Utilities for indicator results
 
+### Convert to quotes
+
+`results.ConvertToQuotes()` will transform indicator results back into an `IEnumerable<Quote>` so it can be re-used to generate an [indicator of indicators](GUIDE.md#generating-indicator-of-indicators).
+
+```csharp
+// example: an RSI of Renko bricks
+IEnumerable<RsiResult> results 
+  = quotes.GetRenko(..)
+    .ConvertToQuotes()
+    .GetRsi(14);
+```
+
+Currently, `.ConvertToQuotes` is only available on a select few indicators.  If you find an indicator that is a good candidate for this utility, please [submit an Issue](https://github.com/DaveSkender/Stock.Indicators/issues).
+
+:warning: WARNING! In many cases, `.ConvertToQuotes` will remove any `null` results -- this will produce fewer historical `quotes` than were originally provided.
+
+
+### Find indicator result by date
+
+`results.Find(lookupDate)` is a simple lookup for your indicator results collection.  Just specify the date you want returned.
+
+```csharp
+// fetch historical quotes from your favorite feed
+IEnumerable<Quote> quotes = GetHistoryFromFeed("MSFT");
+
+// calculate indicator series
+IEnumerable<SmaResult> results = quotes.GetSma(20);
+
+// find result on a specific date
+DateTime lookupDate = [..] // the date you want to find
+SmaResult result = results.Find(lookupDate);
+```
+
 ### Remove warmup periods
 
 `results.RemoveWarmupPeriods()` will remove the recommended initial warmup periods from indicator results.
@@ -58,19 +91,3 @@ See [individual indicator pages](INDICATORS.md) for information on recommended p
 :warning: Note: `.RemoveWarmupPeriods()` is not available on indicators that do not have any recommended pruning; however, you can still do a custom pruning by using the customizable `.RemoveWarmupPeriods(removePeriods)`.
 
 :warning: WARNING! `.RemoveWarmupPeriods()` will reverse-engineer some parameters in determing the recommended pruning amount.  Consequently, on rare occassions when there are unusual results, there can be an erroneous increase in the amount of pruning.  If you want more certainty, use the `.RemoveWarmupPeriods(removePeriods)` with a specific number of `removePeriods`.
-
-### Find indicator result by date
-
-`results.Find(lookupDate)` is a simple lookup for your indicator results collection.  Just specify the date you want returned.
-
-```csharp
-// fetch historical quotes from your favorite feed
-IEnumerable<Quote> quotes = GetHistoryFromFeed("MSFT");
-
-// calculate indicator series
-IEnumerable<SmaResult> results = quotes.GetSma(20);
-
-// find result on a specific date
-DateTime lookupDate = [..] // the date you want to find
-SmaResult result = results.Find(lookupDate);
-```

--- a/indicators/Adl/Adl.cs
+++ b/indicators/Adl/Adl.cs
@@ -63,6 +63,24 @@ namespace Skender.Stock.Indicators
         }
 
 
+        // convert to quotes
+        public static IEnumerable<Quote> ConvertToQuotes(
+            this IEnumerable<AdlResult> results)
+        {
+            return results
+              .Select(x => new Quote
+              {
+                  Date = x.Date,
+                  Open = x.Adl,
+                  High = x.Adl,
+                  Low = x.Adl,
+                  Close = x.Adl,
+                  Volume = x.Adl
+              })
+              .ToList();
+        }
+
+
         // parameter validation
         private static void ValidateAdl<TQuote>(
             IEnumerable<TQuote> quotes,

--- a/indicators/Adl/README.md
+++ b/indicators/Adl/README.md
@@ -1,4 +1,4 @@
-﻿# Accumulation/Distribution Line (ADL)
+# Accumulation/Distribution Line (ADL)
 
 Created by Marc Chaikin, the [Accumulation/Distribution Line/Index](https://en.wikipedia.org/wiki/Accumulation/distribution_index) is a rolling accumulation of Chaikin Money Flow Volume.
 [[Discuss] :speech_balloon:](https://github.com/DaveSkender/Stock.Indicators/discussions/271 "Community discussion about this indicator")
@@ -49,6 +49,7 @@ We always return the same number of elements as there are in the historical quot
 
 ### Utilities
 
+- [.ConvertToQuotes()](../../docs/UTILITIES.md#convert-to-quotes)
 - [.Find(lookupDate)](../../docs/UTILITIES.md#find-indicator-result-by-date)
 - [.RemoveWarmupPeriods(qty)](../../docs/UTILITIES.md#remove-warmup-periods)
 

--- a/indicators/HeikinAshi/HeikinAshi.Models.cs
+++ b/indicators/HeikinAshi/HeikinAshi.Models.cs
@@ -9,5 +9,6 @@ namespace Skender.Stock.Indicators
         public decimal High { get; set; }
         public decimal Low { get; set; }
         public decimal Close { get; set; }
+        public decimal Volume { get; set; }
     }
 }

--- a/indicators/HeikinAshi/HeikinAshi.cs
+++ b/indicators/HeikinAshi/HeikinAshi.cs
@@ -14,45 +14,46 @@ namespace Skender.Stock.Indicators
         {
 
             // sort quotes
-            List<TQuote> historyList = quotes.Sort();
+            List<TQuote> quotesList = quotes.Sort();
 
             // check parameter arguments
             ValidateHeikinAshi(quotes);
 
             // initialize
-            List<HeikinAshiResult> results = new(historyList.Count);
+            List<HeikinAshiResult> results = new(quotesList.Count);
 
             decimal? prevOpen = null;
             decimal? prevClose = null;
 
             // roll through quotes
-            for (int i = 0; i < historyList.Count; i++)
+            for (int i = 0; i < quotesList.Count; i++)
             {
-                TQuote h = historyList[i];
+                TQuote q = quotesList[i];
 
                 // close
-                decimal close = (h.Open + h.High + h.Low + h.Close) / 4;
+                decimal close = (q.Open + q.High + q.Low + q.Close) / 4;
 
                 // open
-                decimal open = (prevOpen == null) ? (h.Open + h.Close) / 2
+                decimal open = (prevOpen == null) ? (q.Open + q.Close) / 2
                     : (decimal)(prevOpen + prevClose) / 2;
 
                 // high
-                decimal[] arrH = { h.High, open, close };
+                decimal[] arrH = { q.High, open, close };
                 decimal high = arrH.Max();
 
                 // low
-                decimal[] arrL = { h.Low, open, close };
+                decimal[] arrL = { q.Low, open, close };
                 decimal low = arrL.Min();
 
 
                 HeikinAshiResult result = new()
                 {
-                    Date = h.Date,
+                    Date = q.Date,
                     Open = open,
                     High = high,
                     Low = low,
-                    Close = close
+                    Close = close,
+                    Volume = q.Volume
                 };
                 results.Add(result);
 
@@ -65,6 +66,25 @@ namespace Skender.Stock.Indicators
         }
 
 
+        // convert to quotes
+        public static IEnumerable<Quote> ConvertToQuotes(
+            this IEnumerable<HeikinAshiResult> results)
+        {
+            return results
+              .Select(x => new Quote
+              {
+                  Date = x.Date,
+                  Open = x.Open,
+                  High = x.High,
+                  Low = x.Low,
+                  Close = x.Close,
+                  Volume = x.Volume
+              })
+              .ToList();
+        }
+
+
+        // parameter validation
         private static void ValidateHeikinAshi<TQuote>(
             IEnumerable<TQuote> quotes)
             where TQuote : IQuote

--- a/indicators/HeikinAshi/README.md
+++ b/indicators/HeikinAshi/README.md
@@ -1,4 +1,4 @@
-﻿# Heikin-Ashi
+# Heikin-Ashi
 
 Created by Munehisa Homma, [Heikin-Ashi](https://en.wikipedia.org/wiki/Candlestick_chart#Heikin-Ashi_candlesticks) is a modified candlestick pattern that uses prior day for smoothing.
 [[Discuss] :speech_balloon:](https://github.com/DaveSkender/Stock.Indicators/discussions/254 "Community discussion about this indicator")
@@ -34,9 +34,11 @@ The first period will have `null` values since there's not enough data to calcul
 | `High` | decimal | Modified high price
 | `Low` | decimal | Modified low price
 | `Close` | decimal | Modified close price
+| `Volume` | decimal | Volume (same as `quotes`)
 
 ### Utilities
 
+- [.ConvertToQuotes()](../../docs/UTILITIES.md#convert-to-quotes)
 - [.Find(lookupDate)](../../docs/UTILITIES.md#find-indicator-result-by-date)
 - [.RemoveWarmupPeriods(qty)](../../docs/UTILITIES.md#remove-warmup-periods)
 

--- a/indicators/Obv/Obv.cs
+++ b/indicators/Obv/Obv.cs
@@ -72,6 +72,24 @@ namespace Skender.Stock.Indicators
         }
 
 
+        // convert to quotes
+        public static IEnumerable<Quote> ConvertToQuotes(
+            this IEnumerable<ObvResult> results)
+        {
+            return results
+              .Select(x => new Quote
+              {
+                  Date = x.Date,
+                  Open = x.Obv,
+                  High = x.Obv,
+                  Low = x.Obv,
+                  Close = x.Obv,
+                  Volume = x.Obv
+              })
+              .ToList();
+        }
+
+
         // parameter validation
         private static void ValidateObv<TQuote>(
             IEnumerable<TQuote> quotes,

--- a/indicators/Obv/README.md
+++ b/indicators/Obv/README.md
@@ -47,6 +47,7 @@ The first period OBV will have `0` value since there's not enough data to calcul
 
 ### Utilities
 
+- [.ConvertToQuotes()](../../docs/UTILITIES.md#convert-to-quotes)
 - [.Find(lookupDate)](../../docs/UTILITIES.md#find-indicator-result-by-date)
 - [.RemoveWarmupPeriods(qty)](../../docs/UTILITIES.md#remove-warmup-periods)
 

--- a/tests/indicators/Test.Adl.cs
+++ b/tests/indicators/Test.Adl.cs
@@ -37,6 +37,22 @@ namespace Internal.Tests
         }
 
         [TestMethod]
+        public void ConvertToQuotes()
+        {
+            List<Quote> newQuotes = quotes.GetAdl()
+                .ConvertToQuotes()
+                .ToList();
+
+            Assert.AreEqual(502, newQuotes.Count);
+
+            Quote q1 = newQuotes[249];
+            Assert.AreEqual(3266400865.74m, Math.Round(q1.Close, 2));
+
+            Quote q2 = newQuotes[501];
+            Assert.AreEqual(3439986548.42m, Math.Round(q2.Close, 2));
+        }
+
+        [TestMethod]
         public void BadData()
         {
             IEnumerable<AdlResult> r = Indicator.GetAdl(historyBad);

--- a/tests/indicators/Test.HeikinAshi.cs
+++ b/tests/indicators/Test.HeikinAshi.cs
@@ -27,6 +27,26 @@ namespace Internal.Tests
             Assert.AreEqual(245.54m, Math.Round(r.High, 4));
             Assert.AreEqual(241.3018m, Math.Round(r.Low, 4));
             Assert.AreEqual(244.6525m, Math.Round(r.Close, 4));
+            Assert.AreEqual(147031456m, r.Volume);
+        }
+
+        [TestMethod]
+        public void ConvertToQuotes()
+        {
+            List<Quote> newQuotes = quotes.GetHeikinAshi()
+                .ConvertToQuotes()
+                .ToList();
+
+            // assertions
+
+            Assert.AreEqual(502, newQuotes.Count);
+
+            Quote q = newQuotes[501];
+            Assert.AreEqual(241.3018m, Math.Round(q.Open, 4));
+            Assert.AreEqual(245.54m, Math.Round(q.High, 4));
+            Assert.AreEqual(241.3018m, Math.Round(q.Low, 4));
+            Assert.AreEqual(244.6525m, Math.Round(q.Close, 4));
+            Assert.AreEqual(147031456m, q.Volume);
         }
 
         [TestMethod]

--- a/tests/indicators/Test.Obv.cs
+++ b/tests/indicators/Test.Obv.cs
@@ -51,6 +51,23 @@ namespace Internal.Tests
         }
 
         [TestMethod]
+        public void ConvertToQuotes()
+        {
+            List<Quote> newQuotes = quotes.GetObv()
+                .ConvertToQuotes()
+                .ToList();
+
+            // assertions
+            Assert.AreEqual(502, newQuotes.Count);
+
+            Quote r1 = newQuotes[249];
+            Assert.AreEqual(1780918888m, r1.Close);
+
+            Quote r2 = newQuotes[501];
+            Assert.AreEqual(539843504m, r2.Close);
+        }
+
+        [TestMethod]
         public void BadData()
         {
             IEnumerable<ObvResult> r = Indicator.GetObv(historyBad);

--- a/tests/indicators/Test.Obv.cs
+++ b/tests/indicators/Test.Obv.cs
@@ -60,11 +60,11 @@ namespace Internal.Tests
             // assertions
             Assert.AreEqual(502, newQuotes.Count);
 
-            Quote r1 = newQuotes[249];
-            Assert.AreEqual(1780918888m, r1.Close);
+            Quote q1 = newQuotes[249];
+            Assert.AreEqual(1780918888m, q1.Close);
 
-            Quote r2 = newQuotes[501];
-            Assert.AreEqual(539843504m, r2.Close);
+            Quote q2 = newQuotes[501];
+            Assert.AreEqual(539843504m, q2.Close);
         }
 
         [TestMethod]

--- a/tests/indicators/common/Test.Results.cs
+++ b/tests/indicators/common/Test.Results.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Skender.Stock.Indicators;
 
@@ -20,6 +21,29 @@ namespace Internal.Tests
 
             EmaResult r = emaResults.Find(findDate);
             Assert.AreEqual(249.3519m, Math.Round((decimal)r.Ema, 4));
+        }
+
+
+        [TestMethod]
+        public void Remove()
+        {
+            // specific periods
+            IEnumerable<HeikinAshiResult> results =
+                quotes.GetHeikinAshi()
+                  .RemoveWarmupPeriods(102);
+
+            Assert.AreEqual(400, results.Count());
+        }
+
+        [TestMethod]
+        public void RemoveTooMany()
+        {
+            // more than available
+            IEnumerable<HeikinAshiResult> results =
+                quotes.GetHeikinAshi()
+                  .RemoveWarmupPeriods(600);
+
+            Assert.AreEqual(0, results.Count());
         }
 
         [TestMethod]


### PR DESCRIPTION
## Description

Add `.ConvertToQuotes()` utility method to simplify indicator of indicator calculations.  This is currently only available on a select few indicators.  Submit an issue to request more.

```csharp
// calculate RSI of OBV
IEnumerable<RsiResult> results 
  = quotes.GetObv()
    .ConvertToQuotes()
    .GetRsi(14);
```

## Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, including `INDICATORS.md`, `README.md`, `info.xml`, etc
- [ ] I have made corresponding changes to the `wraps` interoperability files
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage
- [ ] I have added or run the performance tests that depict optimal execution times
- [x] New and existing unit tests pass locally and in the build (below) with my changes

## Acknowledgements

- [x] I have read and understand [the Apache 2.0 license](https://opensource.org/licenses/Apache-2.0)
- [x] I agree to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)
