### PR TITLE
refactor: internal lists

### DIFF
--- a/indicators/Adl/Adl.cs
+++ b/indicators/Adl/Adl.cs
@@ -64,6 +64,8 @@ namespace Skender.Stock.Indicators
 
 
         // convert to quotes
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        /// 
         public static IEnumerable<Quote> ConvertToQuotes(
             this IEnumerable<AdlResult> results)
         {

--- a/indicators/Adl/Adl.cs
+++ b/indicators/Adl/Adl.cs
@@ -64,7 +64,7 @@ namespace Skender.Stock.Indicators
 
 
         // convert to quotes
-        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Convert"]/*' />
         /// 
         public static IEnumerable<Quote> ConvertToQuotes(
             this IEnumerable<AdlResult> results)

--- a/indicators/Adx/Adx.cs
+++ b/indicators/Adx/Adx.cs
@@ -154,7 +154,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        /// 
         public static IEnumerable<AdxResult> RemoveWarmupPeriods(
             this IEnumerable<AdxResult> results)
         {

--- a/indicators/Alligator/Alligator.cs
+++ b/indicators/Alligator/Alligator.cs
@@ -125,7 +125,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<AlligatorResult> RemoveWarmupPeriods(
             this IEnumerable<AlligatorResult> results)
         {

--- a/indicators/Alma/Alma.cs
+++ b/indicators/Alma/Alma.cs
@@ -73,7 +73,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<AlmaResult> RemoveWarmupPeriods(
             this IEnumerable<AlmaResult> results)
         {

--- a/indicators/Aroon/Aroon.cs
+++ b/indicators/Aroon/Aroon.cs
@@ -72,7 +72,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<AroonResult> RemoveWarmupPeriods(
             this IEnumerable<AroonResult> results)
         {

--- a/indicators/Atr/Atr.cs
+++ b/indicators/Atr/Atr.cs
@@ -78,7 +78,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<AtrResult> RemoveWarmupPeriods(
             this IEnumerable<AtrResult> results)
         {

--- a/indicators/Awesome/Awesome.cs
+++ b/indicators/Awesome/Awesome.cs
@@ -65,7 +65,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<AwesomeResult> RemoveWarmupPeriods(
             this IEnumerable<AwesomeResult> results)
         {

--- a/indicators/Beta/Beta.cs
+++ b/indicators/Beta/Beta.cs
@@ -51,7 +51,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<BetaResult> RemoveWarmupPeriods(
             this IEnumerable<BetaResult> results)
         {

--- a/indicators/BollingerBands/BollingerBands.cs
+++ b/indicators/BollingerBands/BollingerBands.cs
@@ -71,7 +71,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<BollingerBandsResult> RemoveWarmupPeriods(
             this IEnumerable<BollingerBandsResult> results)
         {

--- a/indicators/Bop/Bop.cs
+++ b/indicators/Bop/Bop.cs
@@ -55,7 +55,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<BopResult> RemoveWarmupPeriods(
             this IEnumerable<BopResult> results)
         {

--- a/indicators/Cci/Cci.cs
+++ b/indicators/Cci/Cci.cs
@@ -66,7 +66,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<CciResult> RemoveWarmupPeriods(
             this IEnumerable<CciResult> results)
         {

--- a/indicators/ChaikinOsc/ChaikinOsc.cs
+++ b/indicators/ChaikinOsc/ChaikinOsc.cs
@@ -35,8 +35,8 @@ namespace Skender.Stock.Indicators
                 .Select(x => new BasicData { Date = x.Date, Value = x.Adl })
                 .ToList();
 
-            List<EmaResult> adlEmaSlow = CalcEma(adlBasicData, slowPeriods).ToList();
-            List<EmaResult> adlEmaFast = CalcEma(adlBasicData, fastPeriods).ToList();
+            List<EmaResult> adlEmaSlow = CalcEma(adlBasicData, slowPeriods);
+            List<EmaResult> adlEmaFast = CalcEma(adlBasicData, fastPeriods);
 
             // add Oscillator
             for (int i = slowPeriods - 1; i < results.Count; i++)

--- a/indicators/ChaikinOsc/ChaikinOsc.cs
+++ b/indicators/ChaikinOsc/ChaikinOsc.cs
@@ -53,7 +53,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<ChaikinOscResult> RemoveWarmupPeriods(
             this IEnumerable<ChaikinOscResult> results)
         {

--- a/indicators/Chandelier/Chandelier.cs
+++ b/indicators/Chandelier/Chandelier.cs
@@ -88,7 +88,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<ChandelierResult> RemoveWarmupPeriods(
             this IEnumerable<ChandelierResult> results)
         {

--- a/indicators/Chop/Chop.cs
+++ b/indicators/Chop/Chop.cs
@@ -79,7 +79,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<ChopResult> RemoveWarmupPeriods(
             this IEnumerable<ChopResult> results)
         {

--- a/indicators/Cmf/Cmf.cs
+++ b/indicators/Cmf/Cmf.cs
@@ -68,7 +68,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<CmfResult> RemoveWarmupPeriods(
             this IEnumerable<CmfResult> results)
         {

--- a/indicators/ConnorsRsi/ConnorsRsi.cs
+++ b/indicators/ConnorsRsi/ConnorsRsi.cs
@@ -53,7 +53,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<ConnorsRsiResult> RemoveWarmupPeriods(
             this IEnumerable<ConnorsRsiResult> results)
         {

--- a/indicators/ConnorsRsi/ConnorsRsi.cs
+++ b/indicators/ConnorsRsi/ConnorsRsi.cs
@@ -33,7 +33,7 @@ namespace Skender.Stock.Indicators
                 .Select(x => new BasicData { Date = x.Date, Value = (decimal)x.Streak })
                 .ToList();
 
-            List<RsiResult> rsiStreakResults = CalcRsi(bdStreak, streakPeriods).ToList();
+            List<RsiResult> rsiStreakResults = CalcRsi(bdStreak, streakPeriods);
 
             // compose final results
             for (int p = streakPeriods + 2; p < results.Count; p++)
@@ -70,7 +70,7 @@ namespace Skender.Stock.Indicators
             List<BasicData> bdList, int rsiPeriods, int rankPeriods)
         {
             // initialize
-            List<RsiResult> rsiResults = CalcRsi(bdList, rsiPeriods).ToList();
+            List<RsiResult> rsiResults = CalcRsi(bdList, rsiPeriods);
 
             int size = bdList.Count;
             List<ConnorsRsiResult> results = new(size);

--- a/indicators/Correlation/Correlation.cs
+++ b/indicators/Correlation/Correlation.cs
@@ -89,7 +89,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<CorrResult> RemoveWarmupPeriods(
             this IEnumerable<CorrResult> results)
         {

--- a/indicators/Donchian/Donchian.cs
+++ b/indicators/Donchian/Donchian.cs
@@ -69,7 +69,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<DonchianResult> RemoveWarmupPeriods(
             this IEnumerable<DonchianResult> results)
         {

--- a/indicators/ElderRay/ElderRay.cs
+++ b/indicators/ElderRay/ElderRay.cs
@@ -44,7 +44,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<ElderRayResult> RemoveWarmupPeriods(
             this IEnumerable<ElderRayResult> results)
         {

--- a/indicators/Ema/DoubleEma.cs
+++ b/indicators/Ema/DoubleEma.cs
@@ -56,7 +56,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<DemaResult> RemoveWarmupPeriods(
             this IEnumerable<DemaResult> results)
         {

--- a/indicators/Ema/DoubleEma.cs
+++ b/indicators/Ema/DoubleEma.cs
@@ -23,14 +23,14 @@ namespace Skender.Stock.Indicators
 
             // initialize
             List<DemaResult> results = new(bdList.Count);
-            List<EmaResult> emaN = CalcEma(bdList, lookbackPeriods).ToList();
+            List<EmaResult> emaN = CalcEma(bdList, lookbackPeriods);
 
             List<BasicData> bd2 = emaN
                 .Where(x => x.Ema != null)
                 .Select(x => new BasicData { Date = x.Date, Value = (decimal)x.Ema })
                 .ToList();  // note: ToList seems to be required when changing data
 
-            List<EmaResult> emaN2 = CalcEma(bd2, lookbackPeriods).ToList();
+            List<EmaResult> emaN2 = CalcEma(bd2, lookbackPeriods);
 
             // compose final results
             for (int i = 0; i < emaN.Count; i++)

--- a/indicators/Ema/Ema.cs
+++ b/indicators/Ema/Ema.cs
@@ -23,7 +23,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<EmaResult> RemoveWarmupPeriods(
             this IEnumerable<EmaResult> results)
         {

--- a/indicators/Ema/Ema.cs
+++ b/indicators/Ema/Ema.cs
@@ -36,7 +36,7 @@ namespace Skender.Stock.Indicators
 
 
         // standard calculation
-        private static IEnumerable<EmaResult> CalcEma(
+        private static List<EmaResult> CalcEma(
             List<BasicData> bdList, int lookbackPeriods)
         {
 

--- a/indicators/Ema/TripleEma.cs
+++ b/indicators/Ema/TripleEma.cs
@@ -65,7 +65,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<TemaResult> RemoveWarmupPeriods(
             this IEnumerable<TemaResult> results)
         {

--- a/indicators/Ema/TripleEma.cs
+++ b/indicators/Ema/TripleEma.cs
@@ -23,21 +23,21 @@ namespace Skender.Stock.Indicators
 
             // initialize
             List<TemaResult> results = new(bdList.Count);
-            List<EmaResult> emaN1 = CalcEma(bdList, lookbackPeriods).ToList();
+            List<EmaResult> emaN1 = CalcEma(bdList, lookbackPeriods);
 
             List<BasicData> bd2 = emaN1
                 .Where(x => x.Ema != null)
                 .Select(x => new BasicData { Date = x.Date, Value = (decimal)x.Ema })
                 .ToList();
 
-            List<EmaResult> emaN2 = CalcEma(bd2, lookbackPeriods).ToList();
+            List<EmaResult> emaN2 = CalcEma(bd2, lookbackPeriods);
 
             List<BasicData> bd3 = emaN2
                 .Where(x => x.Ema != null)
                 .Select(x => new BasicData { Date = x.Date, Value = (decimal)x.Ema })
                 .ToList();
 
-            List<EmaResult> emaN3 = CalcEma(bd3, lookbackPeriods).ToList();
+            List<EmaResult> emaN3 = CalcEma(bd3, lookbackPeriods);
 
             // compose final results
             for (int i = 0; i < emaN1.Count; i++)

--- a/indicators/Epma/Epma.cs
+++ b/indicators/Epma/Epma.cs
@@ -43,7 +43,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<EpmaResult> RemoveWarmupPeriods(
             this IEnumerable<EpmaResult> results)
         {

--- a/indicators/Fcb/Fcb.cs
+++ b/indicators/Fcb/Fcb.cs
@@ -53,7 +53,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<FcbResult> RemoveWarmupPeriods(
             this IEnumerable<FcbResult> results)
         {

--- a/indicators/ForceIndex/ForceIndex.cs
+++ b/indicators/ForceIndex/ForceIndex.cs
@@ -75,7 +75,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<ForceIndexResult> RemoveWarmupPeriods(
             this IEnumerable<ForceIndexResult> results)
         {

--- a/indicators/Gator/Gator.cs
+++ b/indicators/Gator/Gator.cs
@@ -46,7 +46,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<GatorResult> RemoveWarmupPeriods(
             this IEnumerable<GatorResult> results)
         {

--- a/indicators/HeikinAshi/HeikinAshi.cs
+++ b/indicators/HeikinAshi/HeikinAshi.cs
@@ -67,6 +67,8 @@ namespace Skender.Stock.Indicators
 
 
         // convert to quotes
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<Quote> ConvertToQuotes(
             this IEnumerable<HeikinAshiResult> results)
         {

--- a/indicators/HeikinAshi/HeikinAshi.cs
+++ b/indicators/HeikinAshi/HeikinAshi.cs
@@ -67,7 +67,7 @@ namespace Skender.Stock.Indicators
 
 
         // convert to quotes
-        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Convert"]/*' />
         ///
         public static IEnumerable<Quote> ConvertToQuotes(
             this IEnumerable<HeikinAshiResult> results)

--- a/indicators/Hma/Hma.cs
+++ b/indicators/Hma/Hma.cs
@@ -76,7 +76,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<HmaResult> RemoveWarmupPeriods(
             this IEnumerable<HmaResult> results)
         {

--- a/indicators/HtTrendline/HtTrendline.cs
+++ b/indicators/HtTrendline/HtTrendline.cs
@@ -156,7 +156,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<HtlResult> RemoveWarmupPeriods(
             this IEnumerable<HtlResult> results)
         {

--- a/indicators/Kama/Kama.cs
+++ b/indicators/Kama/Kama.cs
@@ -86,7 +86,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<KamaResult> RemoveWarmupPeriods(
             this IEnumerable<KamaResult> results)
         {

--- a/indicators/Keltner/Keltner.cs
+++ b/indicators/Keltner/Keltner.cs
@@ -59,7 +59,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<KeltnerResult> RemoveWarmupPeriods(
             this IEnumerable<KeltnerResult> results)
         {

--- a/indicators/Kvo/Kvo.cs
+++ b/indicators/Kvo/Kvo.cs
@@ -139,7 +139,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<KvoResult> RemoveWarmupPeriods(
             this IEnumerable<KvoResult> results)
         {

--- a/indicators/Macd/Macd.cs
+++ b/indicators/Macd/Macd.cs
@@ -24,8 +24,8 @@ namespace Skender.Stock.Indicators
             ValidateMacd(quotes, fastPeriods, slowPeriods, signalPeriods);
 
             // initialize
-            List<EmaResult> emaFast = CalcEma(bdList, fastPeriods).ToList();
-            List<EmaResult> emaSlow = CalcEma(bdList, slowPeriods).ToList();
+            List<EmaResult> emaFast = CalcEma(bdList, fastPeriods);
+            List<EmaResult> emaSlow = CalcEma(bdList, slowPeriods);
 
             int size = bdList.Count;
             List<BasicData> emaDiff = new();
@@ -63,7 +63,7 @@ namespace Skender.Stock.Indicators
             }
 
             // add signal and histogram to result
-            List<EmaResult> emaSignal = CalcEma(emaDiff, signalPeriods).ToList();
+            List<EmaResult> emaSignal = CalcEma(emaDiff, signalPeriods);
 
             for (int d = slowPeriods - 1; d < size; d++)
             {

--- a/indicators/Macd/Macd.cs
+++ b/indicators/Macd/Macd.cs
@@ -78,7 +78,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<MacdResult> RemoveWarmupPeriods(
             this IEnumerable<MacdResult> results)
         {

--- a/indicators/Mama/Mama.cs
+++ b/indicators/Mama/Mama.cs
@@ -150,7 +150,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<MamaResult> RemoveWarmupPeriods(
             this IEnumerable<MamaResult> results)
         {

--- a/indicators/Mfi/Mfi.cs
+++ b/indicators/Mfi/Mfi.cs
@@ -103,7 +103,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<MfiResult> RemoveWarmupPeriods(
             this IEnumerable<MfiResult> results)
         {

--- a/indicators/Obv/Obv.cs
+++ b/indicators/Obv/Obv.cs
@@ -73,7 +73,7 @@ namespace Skender.Stock.Indicators
 
 
         // convert to quotes
-        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Convert"]/*' />
         ///
         public static IEnumerable<Quote> ConvertToQuotes(
             this IEnumerable<ObvResult> results)

--- a/indicators/Obv/Obv.cs
+++ b/indicators/Obv/Obv.cs
@@ -73,6 +73,8 @@ namespace Skender.Stock.Indicators
 
 
         // convert to quotes
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<Quote> ConvertToQuotes(
             this IEnumerable<ObvResult> results)
         {

--- a/indicators/ParabolicSar/ParabolicSar.cs
+++ b/indicators/ParabolicSar/ParabolicSar.cs
@@ -161,7 +161,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<ParabolicSarResult> RemoveWarmupPeriods(
             this IEnumerable<ParabolicSarResult> results)
         {

--- a/indicators/PivotPoints/PivotPoints.cs
+++ b/indicators/PivotPoints/PivotPoints.cs
@@ -100,7 +100,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<PivotPointsResult> RemoveWarmupPeriods(
             this IEnumerable<PivotPointsResult> results)
         {

--- a/indicators/Pmo/Pmo.cs
+++ b/indicators/Pmo/Pmo.cs
@@ -58,7 +58,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<PmoResult> RemoveWarmupPeriods(
             this IEnumerable<PmoResult> results)
         {

--- a/indicators/Pvo/Pvo.cs
+++ b/indicators/Pvo/Pvo.cs
@@ -80,7 +80,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<PvoResult> RemoveWarmupPeriods(
             this IEnumerable<PvoResult> results)
         {

--- a/indicators/Pvo/Pvo.cs
+++ b/indicators/Pvo/Pvo.cs
@@ -24,8 +24,8 @@ namespace Skender.Stock.Indicators
             ValidatePvo(quotes, fastPeriods, slowPeriods, signalPeriods);
 
             // initialize
-            List<EmaResult> emaFast = CalcEma(bdList, fastPeriods).ToList();
-            List<EmaResult> emaSlow = CalcEma(bdList, slowPeriods).ToList();
+            List<EmaResult> emaFast = CalcEma(bdList, fastPeriods);
+            List<EmaResult> emaSlow = CalcEma(bdList, slowPeriods);
 
             int size = bdList.Count;
             List<BasicData> emaDiff = new();
@@ -65,7 +65,7 @@ namespace Skender.Stock.Indicators
             }
 
             // add signal and histogram to result
-            List<EmaResult> emaSignal = CalcEma(emaDiff, signalPeriods).ToList();
+            List<EmaResult> emaSignal = CalcEma(emaDiff, signalPeriods);
 
             for (int d = slowPeriods - 1; d < size; d++)
             {

--- a/indicators/Renko/Renko.cs
+++ b/indicators/Renko/Renko.cs
@@ -92,7 +92,7 @@ namespace Skender.Stock.Indicators
         }
 
         // convert to quotes
-        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Convert"]/*' />
         ///
         public static IEnumerable<Quote> ConvertToQuotes(
             this IEnumerable<RenkoResult> results)

--- a/indicators/Renko/Renko.cs
+++ b/indicators/Renko/Renko.cs
@@ -92,6 +92,8 @@ namespace Skender.Stock.Indicators
         }
 
         // convert to quotes
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<Quote> ConvertToQuotes(
             this IEnumerable<RenkoResult> results)
         {

--- a/indicators/Roc/Roc.cs
+++ b/indicators/Roc/Roc.cs
@@ -63,7 +63,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<RocResult> RemoveWarmupPeriods(
             this IEnumerable<RocResult> results)
         {

--- a/indicators/Roc/RocWb.cs
+++ b/indicators/Roc/RocWb.cs
@@ -82,7 +82,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<RocWbResult> RemoveWarmupPeriods(
             this IEnumerable<RocWbResult> results)
         {

--- a/indicators/RollingPivots/RollingPivots.cs
+++ b/indicators/RollingPivots/RollingPivots.cs
@@ -75,7 +75,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<RollingPivotsResult> RemoveWarmupPeriods(
             this IEnumerable<RollingPivotsResult> results)
         {

--- a/indicators/Rsi/Rsi.cs
+++ b/indicators/Rsi/Rsi.cs
@@ -23,7 +23,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<RsiResult> RemoveWarmupPeriods(
             this IEnumerable<RsiResult> results)
         {

--- a/indicators/Rsi/Rsi.cs
+++ b/indicators/Rsi/Rsi.cs
@@ -36,7 +36,7 @@ namespace Skender.Stock.Indicators
 
 
         // internals
-        private static IEnumerable<RsiResult> CalcRsi(List<BasicData> bdList, int lookbackPeriods)
+        private static List<RsiResult> CalcRsi(List<BasicData> bdList, int lookbackPeriods)
         {
 
             // check parameter arguments

--- a/indicators/Slope/Slope.cs
+++ b/indicators/Slope/Slope.cs
@@ -103,7 +103,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<SlopeResult> RemoveWarmupPeriods(
             this IEnumerable<SlopeResult> results)
         {

--- a/indicators/Sma/Sma.cs
+++ b/indicators/Sma/Sma.cs
@@ -54,7 +54,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions (standard)
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        /// 
         public static IEnumerable<SmaResult> RemoveWarmupPeriods(
             this IEnumerable<SmaResult> results)
         {

--- a/indicators/Sma/SmaExtended.cs
+++ b/indicators/Sma/SmaExtended.cs
@@ -57,7 +57,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions (extended)
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<SmaExtendedResult> RemoveWarmupPeriods(
             this IEnumerable<SmaExtendedResult> results)
         {

--- a/indicators/Smma/Smma.cs
+++ b/indicators/Smma/Smma.cs
@@ -62,7 +62,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<SmmaResult> RemoveWarmupPeriods(
             this IEnumerable<SmmaResult> results)
         {

--- a/indicators/StarcBands/StarcBands.cs
+++ b/indicators/StarcBands/StarcBands.cs
@@ -57,7 +57,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<StarcBandsResult> RemoveWarmupPeriods(
             this IEnumerable<StarcBandsResult> results)
         {

--- a/indicators/StdDev/StdDev.cs
+++ b/indicators/StdDev/StdDev.cs
@@ -37,7 +37,7 @@ namespace Skender.Stock.Indicators
 
 
         // internals
-        private static IEnumerable<StdDevResult> CalcStdDev(
+        private static List<StdDevResult> CalcStdDev(
             List<BasicData> bdList, int lookbackPeriods, int? smaPeriods = null)
         {
 

--- a/indicators/StdDev/StdDev.cs
+++ b/indicators/StdDev/StdDev.cs
@@ -24,7 +24,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<StdDevResult> RemoveWarmupPeriods(
             this IEnumerable<StdDevResult> results)
         {

--- a/indicators/StdDevChannels/StdDevChannels.cs
+++ b/indicators/StdDevChannels/StdDevChannels.cs
@@ -59,7 +59,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<StdDevChannelsResult> RemoveWarmupPeriods(
             this IEnumerable<StdDevChannelsResult> results)
         {

--- a/indicators/Stoch/Stoch.cs
+++ b/indicators/Stoch/Stoch.cs
@@ -106,7 +106,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<StochResult> RemoveWarmupPeriods(
             this IEnumerable<StochResult> results)
         {

--- a/indicators/StochRsi/StochRsi.cs
+++ b/indicators/StochRsi/StochRsi.cs
@@ -66,7 +66,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<StochRsiResult> RemoveWarmupPeriods(
             this IEnumerable<StochRsiResult> results)
         {

--- a/indicators/SuperTrend/SuperTrend.cs
+++ b/indicators/SuperTrend/SuperTrend.cs
@@ -94,7 +94,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<SuperTrendResult> RemoveWarmupPeriods(
             this IEnumerable<SuperTrendResult> results)
         {

--- a/indicators/T3/T3.cs
+++ b/indicators/T3/T3.cs
@@ -160,7 +160,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<T3Result> RemoveWarmupPeriods(
             this IEnumerable<T3Result> results)
         {

--- a/indicators/Trix/Trix.cs
+++ b/indicators/Trix/Trix.cs
@@ -26,21 +26,21 @@ namespace Skender.Stock.Indicators
             List<TrixResult> results = new(bdList.Count);
             decimal? lastEma = null;
 
-            List<EmaResult> emaN1 = CalcEma(bdList, lookbackPeriods).ToList();
+            List<EmaResult> emaN1 = CalcEma(bdList, lookbackPeriods);
 
             List<BasicData> bd2 = emaN1
                 .Where(x => x.Ema != null)
                 .Select(x => new BasicData { Date = x.Date, Value = (decimal)x.Ema })
                 .ToList();
 
-            List<EmaResult> emaN2 = CalcEma(bd2, lookbackPeriods).ToList();
+            List<EmaResult> emaN2 = CalcEma(bd2, lookbackPeriods);
 
             List<BasicData> bd3 = emaN2
                 .Where(x => x.Ema != null)
                 .Select(x => new BasicData { Date = x.Date, Value = (decimal)x.Ema })
                 .ToList();
 
-            List<EmaResult> emaN3 = CalcEma(bd3, lookbackPeriods).ToList();
+            List<EmaResult> emaN3 = CalcEma(bd3, lookbackPeriods);
 
             // compose final results
             for (int i = 0; i < emaN1.Count; i++)

--- a/indicators/Trix/Trix.cs
+++ b/indicators/Trix/Trix.cs
@@ -78,7 +78,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<TrixResult> RemoveWarmupPeriods(
             this IEnumerable<TrixResult> results)
         {

--- a/indicators/Tsi/Tsi.cs
+++ b/indicators/Tsi/Tsi.cs
@@ -142,7 +142,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<TsiResult> RemoveWarmupPeriods(
             this IEnumerable<TsiResult> results)
         {

--- a/indicators/UlcerIndex/Ulcer.cs
+++ b/indicators/UlcerIndex/Ulcer.cs
@@ -70,7 +70,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<UlcerIndexResult> RemoveWarmupPeriods(
             this IEnumerable<UlcerIndexResult> results)
         {

--- a/indicators/Ultimate/Ultimate.cs
+++ b/indicators/Ultimate/Ultimate.cs
@@ -96,7 +96,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<UltimateResult> RemoveWarmupPeriods(
             this IEnumerable<UltimateResult> results)
         {

--- a/indicators/VolSma/VolSma.cs
+++ b/indicators/VolSma/VolSma.cs
@@ -47,7 +47,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<VolSmaResult> RemoveWarmupPeriods(
             this IEnumerable<VolSmaResult> results)
         {

--- a/indicators/Vortex/Vortex.cs
+++ b/indicators/Vortex/Vortex.cs
@@ -95,7 +95,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<VortexResult> RemoveWarmupPeriods(
             this IEnumerable<VortexResult> results)
         {

--- a/indicators/Vwap/Vwap.cs
+++ b/indicators/Vwap/Vwap.cs
@@ -54,7 +54,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<VwapResult> RemoveWarmupPeriods(
             this IEnumerable<VwapResult> results)
         {

--- a/indicators/WilliamsR/WilliamsR.cs
+++ b/indicators/WilliamsR/WilliamsR.cs
@@ -29,7 +29,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<WilliamsResult> RemoveWarmupPeriods(
             this IEnumerable<WilliamsResult> results)
         {

--- a/indicators/Wma/Wma.cs
+++ b/indicators/Wma/Wma.cs
@@ -55,7 +55,9 @@ namespace Skender.Stock.Indicators
         }
 
 
-        // remove recommended periods extensions
+        // remove recommended periods
+        /// <include file='../_Common/Results/info.xml' path='info/type[@name="Prune"]/*' />
+        ///
         public static IEnumerable<WmaResult> RemoveWarmupPeriods(
             this IEnumerable<WmaResult> results)
         {

--- a/indicators/_Common/Quotes/History.Functions.cs
+++ b/indicators/_Common/Quotes/History.Functions.cs
@@ -13,6 +13,8 @@ namespace Skender.Stock.Indicators
         private static readonly CultureInfo NativeCulture = Thread.CurrentThread.CurrentUICulture;
 
         // validation
+        /// <include file='./info.xml' path='info/type[@name="Validate"]/*' />
+        /// 
         public static IEnumerable<TQuote> Validate<TQuote>(this IEnumerable<TQuote> quotes)
             where TQuote : IQuote
         {
@@ -39,6 +41,8 @@ namespace Skender.Stock.Indicators
         }
 
         // aggregation (quantization)
+        /// <include file='./info.xml' path='info/type[@name="Aggregate"]/*' />
+        /// 
         public static IEnumerable<Quote> Aggregate<TQuote>(
             this IEnumerable<TQuote> quotes,
             PeriodSize newSize)

--- a/indicators/_Common/Quotes/info.xml
+++ b/indicators/_Common/Quotes/info.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<info>
+  <type name="Validate">
+    <summary>
+      Validate historical quotes.
+      See
+      <see href="https://daveskender.github.io/Stock.Indicators/docs/UTILITIES.html#validate-quote-history">documentation</see>
+      for more information.
+    </summary>
+    <typeparam name="TQuote">Configurable Quote type.  See Guide for more information.</typeparam>
+    <param name="quotes">Historical price quotes.</param>
+    <returns>Time series of historical quote values.</returns>
+    <exception cref="BadQuotesException">Insufficient quotes provided.</exception>
+  </type>
+  <type name="Aggregate">
+    <summary>
+      Converts historical quotes into larger bar sizes.
+      See
+      <see href="https://daveskender.github.io/Stock.Indicators/docs/UTILITIES.html#resize-quote-history">documentation</see>
+      for more information.
+    </summary>
+    <typeparam name="TQuote">Configurable Quote type.  See Guide for more information.</typeparam>
+    <param name="quotes">Historical price quotes.</param>
+    <param name="newSize">PeriodSize enum representing the new bar size.</param>
+    <returns>Time series of historical quote values.</returns>
+    <exception cref="ArgumentOutOfRangeException">Invalid parameter value provided.</exception>
+  </type>
+</info>

--- a/indicators/_Common/Results.cs
+++ b/indicators/_Common/Results.cs
@@ -47,7 +47,7 @@ namespace Skender.Stock.Indicators
 
 
         // REMOVE RESULTS
-        internal static IEnumerable<TResult> Remove<TResult>(
+        private static List<TResult> Remove<TResult>(
             this IEnumerable<TResult> results,
             int removePeriods)
             where TResult : IResult

--- a/indicators/_Common/Results/Results.cs
+++ b/indicators/_Common/Results/Results.cs
@@ -24,6 +24,8 @@ namespace Skender.Stock.Indicators
     {
 
         // FIND by DATE
+        /// <include file='./info.xml' path='info/type[@name="Find"]/*' />
+        /// 
         public static TResult Find<TResult>(
             this IEnumerable<TResult> results,
             DateTime lookupDate)
@@ -34,6 +36,8 @@ namespace Skender.Stock.Indicators
 
 
         // REMOVE SPECIFIC PERIODS extension
+        /// <include file='./info.xml' path='info/type[@name="PruneSpecific"]/*' />
+        /// 
         public static IEnumerable<TResult> RemoveWarmupPeriods<TResult>(
             this IEnumerable<TResult> results,
             int removePeriods)

--- a/indicators/_Common/Results/info.xml
+++ b/indicators/_Common/Results/info.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<info>
+  <type name="Convert">
+    <summary>
+      Convert indicator results to historical quotes.
+      See
+      <see href="https://daveskender.github.io/Stock.Indicators/docs/UTILITIES.html#convert-to-quotes">documentation</see>
+      for more information.
+    </summary>
+    <typeparam name="TResult">Any result type.</typeparam>
+    <param name="results">Indicator results to evaluate.</param>
+    <returns>Time series of historical quote values.</returns>
+    <exception cref="BadQuotesException">Insufficient quotes provided.</exception>
+  </type>
+  <type name="Find">
+    <summary>
+      Finds indicator values on a specific date.
+      See
+      <see href="https://daveskender.github.io/Stock.Indicators/docs/UTILITIES.html#resize-quote-history">documentation</see>
+      for more information.
+    </summary>
+    <typeparam name="TResult">Any result type.</typeparam>
+    <param name="results">Indicator results to evaluate.</param>
+    <param name="lookupDate">Exact date to lookup</param>
+    <returns>First indicator result on the date specified.</returns>
+  </type>
+  <type name="Prune">
+    <summary>
+      Removes the recommended quantity of results from the beginning of the results list.
+    </summary>
+    <param name="results">Indicator results to evaluate.</param>
+    <returns>Time series of indicator results, pruned.</returns>
+  </type>
+  <type name="PruneSpecific">
+    <summary>
+      Removes a specific quantity of results from the beginning of the results list.
+    </summary>
+    <typeparam name="TResult">Any result type.</typeparam>
+    <param name="results">Indicator results to evaluate.</param>
+    <param name="removePeriods">Exact quantity to remove.</param>
+    <returns>Time series of indicator results, pruned.</returns>
+    <exception cref="ArgumentOutOfRangeException">Invalid parameter value provided.</exception>
+  </type>
+</info>

--- a/indicators/_Common/Results/info.xml
+++ b/indicators/_Common/Results/info.xml
@@ -3,12 +3,11 @@
 <info>
   <type name="Convert">
     <summary>
-      Convert indicator results to historical quotes.
+      Convert indicator results into historical quotes.
       See
       <see href="https://daveskender.github.io/Stock.Indicators/docs/UTILITIES.html#convert-to-quotes">documentation</see>
       for more information.
     </summary>
-    <typeparam name="TResult">Any result type.</typeparam>
     <param name="results">Indicator results to evaluate.</param>
     <returns>Time series of historical quote values.</returns>
     <exception cref="BadQuotesException">Insufficient quotes provided.</exception>


### PR DESCRIPTION
## Description

Implements return of `List` instead of `IEnumerable` for internal methods to avoid recasting.
See #489 for more information.

## Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage
- [x] I have added or run the performance tests that depict optimal execution times
- [x] New and existing unit tests pass locally and in the build (below) with my changes

## Acknowledgements

- [x] I have read and understand [the Apache 2.0 license](https://opensource.org/licenses/Apache-2.0)
- [x] I agree to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)
