### PR TITLE
refactor: internal lists

### DIFF
--- a/indicators/ChaikinOsc/ChaikinOsc.cs
+++ b/indicators/ChaikinOsc/ChaikinOsc.cs
@@ -35,8 +35,8 @@ namespace Skender.Stock.Indicators
                 .Select(x => new BasicData { Date = x.Date, Value = x.Adl })
                 .ToList();
 
-            List<EmaResult> adlEmaSlow = CalcEma(adlBasicData, slowPeriods).ToList();
-            List<EmaResult> adlEmaFast = CalcEma(adlBasicData, fastPeriods).ToList();
+            List<EmaResult> adlEmaSlow = CalcEma(adlBasicData, slowPeriods);
+            List<EmaResult> adlEmaFast = CalcEma(adlBasicData, fastPeriods);
 
             // add Oscillator
             for (int i = slowPeriods - 1; i < results.Count; i++)

--- a/indicators/ConnorsRsi/ConnorsRsi.cs
+++ b/indicators/ConnorsRsi/ConnorsRsi.cs
@@ -33,7 +33,7 @@ namespace Skender.Stock.Indicators
                 .Select(x => new BasicData { Date = x.Date, Value = (decimal)x.Streak })
                 .ToList();
 
-            List<RsiResult> rsiStreakResults = CalcRsi(bdStreak, streakPeriods).ToList();
+            List<RsiResult> rsiStreakResults = CalcRsi(bdStreak, streakPeriods);
 
             // compose final results
             for (int p = streakPeriods + 2; p < results.Count; p++)
@@ -70,7 +70,7 @@ namespace Skender.Stock.Indicators
             List<BasicData> bdList, int rsiPeriods, int rankPeriods)
         {
             // initialize
-            List<RsiResult> rsiResults = CalcRsi(bdList, rsiPeriods).ToList();
+            List<RsiResult> rsiResults = CalcRsi(bdList, rsiPeriods);
 
             int size = bdList.Count;
             List<ConnorsRsiResult> results = new(size);

--- a/indicators/Ema/DoubleEma.cs
+++ b/indicators/Ema/DoubleEma.cs
@@ -23,14 +23,14 @@ namespace Skender.Stock.Indicators
 
             // initialize
             List<DemaResult> results = new(bdList.Count);
-            List<EmaResult> emaN = CalcEma(bdList, lookbackPeriods).ToList();
+            List<EmaResult> emaN = CalcEma(bdList, lookbackPeriods);
 
             List<BasicData> bd2 = emaN
                 .Where(x => x.Ema != null)
                 .Select(x => new BasicData { Date = x.Date, Value = (decimal)x.Ema })
                 .ToList();  // note: ToList seems to be required when changing data
 
-            List<EmaResult> emaN2 = CalcEma(bd2, lookbackPeriods).ToList();
+            List<EmaResult> emaN2 = CalcEma(bd2, lookbackPeriods);
 
             // compose final results
             for (int i = 0; i < emaN.Count; i++)

--- a/indicators/Ema/Ema.cs
+++ b/indicators/Ema/Ema.cs
@@ -36,7 +36,7 @@ namespace Skender.Stock.Indicators
 
 
         // standard calculation
-        private static IEnumerable<EmaResult> CalcEma(
+        private static List<EmaResult> CalcEma(
             List<BasicData> bdList, int lookbackPeriods)
         {
 

--- a/indicators/Ema/TripleEma.cs
+++ b/indicators/Ema/TripleEma.cs
@@ -23,21 +23,21 @@ namespace Skender.Stock.Indicators
 
             // initialize
             List<TemaResult> results = new(bdList.Count);
-            List<EmaResult> emaN1 = CalcEma(bdList, lookbackPeriods).ToList();
+            List<EmaResult> emaN1 = CalcEma(bdList, lookbackPeriods);
 
             List<BasicData> bd2 = emaN1
                 .Where(x => x.Ema != null)
                 .Select(x => new BasicData { Date = x.Date, Value = (decimal)x.Ema })
                 .ToList();
 
-            List<EmaResult> emaN2 = CalcEma(bd2, lookbackPeriods).ToList();
+            List<EmaResult> emaN2 = CalcEma(bd2, lookbackPeriods);
 
             List<BasicData> bd3 = emaN2
                 .Where(x => x.Ema != null)
                 .Select(x => new BasicData { Date = x.Date, Value = (decimal)x.Ema })
                 .ToList();
 
-            List<EmaResult> emaN3 = CalcEma(bd3, lookbackPeriods).ToList();
+            List<EmaResult> emaN3 = CalcEma(bd3, lookbackPeriods);
 
             // compose final results
             for (int i = 0; i < emaN1.Count; i++)

--- a/indicators/Macd/Macd.cs
+++ b/indicators/Macd/Macd.cs
@@ -24,8 +24,8 @@ namespace Skender.Stock.Indicators
             ValidateMacd(quotes, fastPeriods, slowPeriods, signalPeriods);
 
             // initialize
-            List<EmaResult> emaFast = CalcEma(bdList, fastPeriods).ToList();
-            List<EmaResult> emaSlow = CalcEma(bdList, slowPeriods).ToList();
+            List<EmaResult> emaFast = CalcEma(bdList, fastPeriods);
+            List<EmaResult> emaSlow = CalcEma(bdList, slowPeriods);
 
             int size = bdList.Count;
             List<BasicData> emaDiff = new();
@@ -63,7 +63,7 @@ namespace Skender.Stock.Indicators
             }
 
             // add signal and histogram to result
-            List<EmaResult> emaSignal = CalcEma(emaDiff, signalPeriods).ToList();
+            List<EmaResult> emaSignal = CalcEma(emaDiff, signalPeriods);
 
             for (int d = slowPeriods - 1; d < size; d++)
             {

--- a/indicators/Pvo/Pvo.cs
+++ b/indicators/Pvo/Pvo.cs
@@ -24,8 +24,8 @@ namespace Skender.Stock.Indicators
             ValidatePvo(quotes, fastPeriods, slowPeriods, signalPeriods);
 
             // initialize
-            List<EmaResult> emaFast = CalcEma(bdList, fastPeriods).ToList();
-            List<EmaResult> emaSlow = CalcEma(bdList, slowPeriods).ToList();
+            List<EmaResult> emaFast = CalcEma(bdList, fastPeriods);
+            List<EmaResult> emaSlow = CalcEma(bdList, slowPeriods);
 
             int size = bdList.Count;
             List<BasicData> emaDiff = new();
@@ -65,7 +65,7 @@ namespace Skender.Stock.Indicators
             }
 
             // add signal and histogram to result
-            List<EmaResult> emaSignal = CalcEma(emaDiff, signalPeriods).ToList();
+            List<EmaResult> emaSignal = CalcEma(emaDiff, signalPeriods);
 
             for (int d = slowPeriods - 1; d < size; d++)
             {

--- a/indicators/Rsi/Rsi.cs
+++ b/indicators/Rsi/Rsi.cs
@@ -36,7 +36,7 @@ namespace Skender.Stock.Indicators
 
 
         // internals
-        private static IEnumerable<RsiResult> CalcRsi(List<BasicData> bdList, int lookbackPeriods)
+        private static List<RsiResult> CalcRsi(List<BasicData> bdList, int lookbackPeriods)
         {
 
             // check parameter arguments

--- a/indicators/StdDev/StdDev.cs
+++ b/indicators/StdDev/StdDev.cs
@@ -37,7 +37,7 @@ namespace Skender.Stock.Indicators
 
 
         // internals
-        private static IEnumerable<StdDevResult> CalcStdDev(
+        private static List<StdDevResult> CalcStdDev(
             List<BasicData> bdList, int lookbackPeriods, int? smaPeriods = null)
         {
 

--- a/indicators/Trix/Trix.cs
+++ b/indicators/Trix/Trix.cs
@@ -26,21 +26,21 @@ namespace Skender.Stock.Indicators
             List<TrixResult> results = new(bdList.Count);
             decimal? lastEma = null;
 
-            List<EmaResult> emaN1 = CalcEma(bdList, lookbackPeriods).ToList();
+            List<EmaResult> emaN1 = CalcEma(bdList, lookbackPeriods);
 
             List<BasicData> bd2 = emaN1
                 .Where(x => x.Ema != null)
                 .Select(x => new BasicData { Date = x.Date, Value = (decimal)x.Ema })
                 .ToList();
 
-            List<EmaResult> emaN2 = CalcEma(bd2, lookbackPeriods).ToList();
+            List<EmaResult> emaN2 = CalcEma(bd2, lookbackPeriods);
 
             List<BasicData> bd3 = emaN2
                 .Where(x => x.Ema != null)
                 .Select(x => new BasicData { Date = x.Date, Value = (decimal)x.Ema })
                 .ToList();
 
-            List<EmaResult> emaN3 = CalcEma(bd3, lookbackPeriods).ToList();
+            List<EmaResult> emaN3 = CalcEma(bd3, lookbackPeriods);
 
             // compose final results
             for (int i = 0; i < emaN1.Count; i++)

--- a/indicators/_Common/Results.cs
+++ b/indicators/_Common/Results.cs
@@ -47,7 +47,7 @@ namespace Skender.Stock.Indicators
 
 
         // REMOVE RESULTS
-        internal static IEnumerable<TResult> Remove<TResult>(
+        private static List<TResult> Remove<TResult>(
             this IEnumerable<TResult> results,
             int removePeriods)
             where TResult : IResult


### PR DESCRIPTION
## Description

Implements return of `List` instead of `IEnumerable` for internal methods to avoid recasting.
See #489 for more information.

## Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage
- [x] I have added or run the performance tests that depict optimal execution times
- [x] New and existing unit tests pass locally and in the build (below) with my changes

## Acknowledgements

- [x] I have read and understand [the Apache 2.0 license](https://opensource.org/licenses/Apache-2.0)
- [x] I agree to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)