### PR TITLE
fix: github-pages version

### DIFF
--- a/GemFile
+++ b/GemFile
@@ -1,8 +1,10 @@
 source 'https://rubygems.org'
 
+gem 'wdm', '>= 0.1.0' if Gem.win_platform?
+
 # jekyll plugins
 group :jekyll_plugins do
-  gem 'github-pages'
+  gem 'github-pages', "~>215"
   gem 'jemoji'
   gem 'jekyll-sitemap'
   gem "jekyll-last-modified-at" # used in sitemap

--- a/GemFile.lock
+++ b/GemFile.lock
@@ -26,7 +26,7 @@ GEM
       ffi (>= 1.15.0)
     eventmachine (1.2.7-x64-mingw32)
     execjs (2.8.1)
-    faraday (1.5.0)
+    faraday (1.5.1)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -41,7 +41,7 @@ GEM
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
     faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.1.0)
+    faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     ffi (1.15.3-x64-mingw32)
     forwardable-extended (2.6.0)
@@ -216,7 +216,7 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.3)
-    listen (3.5.1)
+    listen (3.6.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
@@ -243,7 +243,7 @@ GEM
     rouge (3.26.0)
     ruby-enum (0.9.0)
       i18n
-    ruby2_keywords (0.0.4)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     safe_yaml (1.0.5)
     sass (3.7.4)
@@ -267,16 +267,18 @@ GEM
       unf_ext
     unf_ext (0.0.7.7-x64-mingw32)
     unicode-display_width (1.7.0)
+    wdm (0.1.1)
     zeitwerk (2.4.2)
 
 PLATFORMS
   x64-mingw32
 
 DEPENDENCIES
-  github-pages
+  github-pages (~> 215)
   jekyll-last-modified-at
   jekyll-sitemap
   jemoji
+  wdm (>= 0.1.0)
 
 BUNDLED WITH
-   2.2.15
+   2.2.24

--- a/_config.yml
+++ b/_config.yml
@@ -26,9 +26,4 @@ exclude:
 
 include: ["docs", "LICENSE"]
 
-plugins:
-  - jemoji
-  - jekyll-sitemap
-  - jekyll-last-modified-at
-
 google_analytics: G-7602GXEZ0R


### PR DESCRIPTION
A recent update to Gem `github-pages` to version 216 breaks the documentation site build.  This fix will force it to use version 215, avoiding the breaking change.  We'll have to revisit this after GitHub updates guidance on this issue.