### PR TITLE
suppress: Roslyn bug

### DIFF
--- a/indicators/GlobalSuppressions.cs
+++ b/indicators/GlobalSuppressions.cs
@@ -18,3 +18,10 @@ using System.Diagnostics.CodeAnalysis;
     Justification = "Making an exception",
     Scope = "member",
     Target = "~P:Skender.Stock.Indicators.IResult.Date")]
+
+// this can be removed after Microsoft publishes fix,
+// see https://github.com/dotnet/roslyn/issues/55014
+[assembly: SuppressMessage(
+    "Style",
+    "IDE0130:Namespace does not match folder structure",
+    Justification = "Microsoft bug, not real")]

--- a/tests/external/GlobalSuppressions.cs
+++ b/tests/external/GlobalSuppressions.cs
@@ -19,3 +19,10 @@ using System.Diagnostics.CodeAnalysis;
     "StyleCop.CSharp.DocumentationRules",
     "SA1600:Elements should be documented",
     Justification = "Not documenting unit test projects.")]
+
+// this can be removed after Microsoft publishes fix,
+// see https://github.com/dotnet/roslyn/issues/55014
+[assembly: SuppressMessage(
+    "Style",
+    "IDE0130:Namespace does not match folder structure",
+    Justification = "Microsoft bug, not real")]

--- a/tests/indicators/GlobalSuppressions.cs
+++ b/tests/indicators/GlobalSuppressions.cs
@@ -19,3 +19,10 @@ using System.Diagnostics.CodeAnalysis;
     "StyleCop.CSharp.DocumentationRules",
     "SA1600:Elements should be documented",
     Justification = "Not documenting unit test projects.")]
+
+// this can be removed after Microsoft publishes fix,
+// see https://github.com/dotnet/roslyn/issues/55014
+[assembly: SuppressMessage(
+    "Style",
+    "IDE0130:Namespace does not match folder structure",
+    Justification = "Microsoft bug, not real")]

--- a/tests/performance/GlobalSuppressions.cs
+++ b/tests/performance/GlobalSuppressions.cs
@@ -24,3 +24,10 @@ using System.Diagnostics.CodeAnalysis;
     "Performance",
     "CA1822:Mark members as static",
     Justification = "Tests are excluded when static, for some reason")]
+
+// this can be removed after Microsoft publishes fix,
+// see https://github.com/dotnet/roslyn/issues/55014
+[assembly: SuppressMessage(
+    "Style",
+    "IDE0130:Namespace does not match folder structure",
+    Justification = "Microsoft bug, not real")]


### PR DESCRIPTION
## Description

A recent update to Microsoft Roslyn analyzers is producing a buggy Warning; this temporary fix supresses it.

## Acknowledgements

- [x] I have read and understand [the Apache 2.0 license](https://opensource.org/licenses/Apache-2.0)
- [x] I agree to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)
