### PR TITLE
add Marubozu constraints

### DIFF
--- a/indicators/Patterns/Marubozu/Marubozu.cs
+++ b/indicators/Patterns/Marubozu/Marubozu.cs
@@ -56,10 +56,16 @@ namespace Skender.Stock.Indicators
         {
 
             // check parameter arguments
-            if (minBodyPercent <= 0)
+            if (minBodyPercent > 1)
             {
                 throw new ArgumentOutOfRangeException(nameof(minBodyPercent), minBodyPercent,
-                    "Minimum Body Percent must be greater than 0 for Marubozu and is usually above 90%.");
+                    "Minimum Body Percent must be less than 1 for Marubozu (<=100%).");
+            }
+
+            if (minBodyPercent < 0.8)
+            {
+                throw new ArgumentOutOfRangeException(nameof(minBodyPercent), minBodyPercent,
+                    "Minimum Body Percent must at least 0.8 (80%) for Marubozu and is usually greater than 0.9 (90%).");
             }
 
             // check quotes

--- a/indicators/Patterns/Marubozu/README.md
+++ b/indicators/Patterns/Marubozu/README.md
@@ -15,7 +15,7 @@ IEnumerable<MarubozuResult> results =
 
 | name | type | notes
 | -- |-- |--
-| `minBodyPercent` | double | Optional.  Minimum body size as a decimalized percent of total candle size.  Must be greater than 0, if specified.  Default is 0.95 (e.g. 95%).
+| `minBodyPercent` | double | Optional.  Minimum body size as a decimalized percent of total candle size.  Must be between 0.8 and 1, if specified.  Default is 0.95 (95%).
 
 ### Historical quotes requirements
 

--- a/tests/external/Tests.Other.csproj
+++ b/tests/external/Tests.Other.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/tests/indicators/Patterns/Test.Marubozu.cs
+++ b/tests/indicators/Patterns/Test.Marubozu.cs
@@ -45,9 +45,12 @@ namespace Internal.Tests
         [TestMethod]
         public void Exceptions()
         {
-            // bad SMA period
+            // bad minimum body percent values
             Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
-                Indicator.GetMarubozu(quotes, 0));
+                Indicator.GetMarubozu(quotes, 0.799));
+
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
+                Indicator.GetMarubozu(quotes, 1.001));
 
             // insufficient quotes
             Assert.ThrowsException<BadQuotesException>(() =>

--- a/tests/indicators/Tests.Indicators.csproj
+++ b/tests/indicators/Tests.Indicators.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
     <PackageReference Include="coverlet.collector" Version="3.1.0">

--- a/tests/performance/Tests.Performance.csproj
+++ b/tests/performance/Tests.Performance.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Description

- add top `minBodyPercent` constraint to 100%.  any more would produce zero results
- add bottom constraint of 80% (opinionated) as any less would obviate the core definition

Fixes #521 

## Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage
- [x] I have added or run the performance tests that depict optimal execution times
- [x] New and existing unit tests pass locally and in the build (below) with my changes

## Acknowledgements

- [x] I have read and understand [the Apache 2.0 license](https://opensource.org/licenses/Apache-2.0)
- [x] I agree to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)
