### PR TITLE
update build test task

### DIFF
--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -48,14 +48,14 @@ steps:
     displayName: build
     inputs:
       projects: "**/*.csproj"
-      arguments: --configuration $(BuildConfiguration) /p:Version=$(GitVersion.NuGetVersion)
+      arguments: "--configuration $(BuildConfiguration) /p:Version=$(GitVersion.NuGetVersion)"
 
   - task: DotNetCoreCLI@2
     displayName: "test indicators"
     inputs:
       command: test
       projects: "tests/indicators"
-      arguments: --configuration $(BuildConfiguration) --no-restore --no-build --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
+      arguments: '--configuration $(BuildConfiguration) --no-restore --no-build --collect:"XPlat Code Coverage" --DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura'
       publishTestResults: true
       testRunTitle: "Indicator Tests"
 
@@ -64,7 +64,7 @@ steps:
     inputs:
       command: test
       projects: "tests/external"
-      arguments: --configuration $(BuildConfiguration) --no-restore --no-build /p:CollectCoverage=false
+      arguments: "--configuration $(BuildConfiguration) --no-restore --no-build /p:CollectCoverage=false"
       publishTestResults: true
       testRunTitle: "External Tests"
 

--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -59,6 +59,12 @@ steps:
       publishTestResults: true
       testRunTitle: "Indicator Tests"
 
+  - task: PublishCodeCoverageResults@1
+    displayName: "publish code coverage"
+    inputs:
+      codeCoverageTool: Cobertura
+      summaryFileLocation: "$(Agent.TempDirectory)/**/coverage.cobertura.xml"
+
   - task: DotNetCoreCLI@2
     displayName: "test external/other"
     inputs:
@@ -67,12 +73,6 @@ steps:
       arguments: "--configuration $(BuildConfiguration) --no-restore --no-build /p:CollectCoverage=false"
       publishTestResults: true
       testRunTitle: "External Tests"
-
-  - task: PublishCodeCoverageResults@1
-    displayName: "publish code coverage"
-    inputs:
-      codeCoverageTool: Cobertura
-      summaryFileLocation: "$(Agent.TempDirectory)/**/coverage.cobertura.xml"
 
   - task: DotNetCoreCLI@2
     displayName: "pack for NuGet"

--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -55,7 +55,7 @@ steps:
     inputs:
       testSelector: "testAssemblies"
       testAssemblyVer2: |
-        "**\*Skender.Stock.Indicators.dll"
+        **\*Skender.Stock.Indicators.dll
       codeCoverageEnabled: true
       testRunTitle: ".NET Indicator Tests"
 

--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -55,7 +55,7 @@ steps:
     inputs:
       command: test
       projects: "tests/indicators"
-      arguments: --configuration $(BuildConfiguration) --no-restore --no-build --collect:"XPlat Code Coverage --results-directory:$(Build.SourcesDirectory)/tests/indicators"
+      arguments: --configuration $(BuildConfiguration) --no-restore --no-build --collect:"XPlat Code Coverage" --results-directory:$(Build.SourcesDirectory)/tests/indicators"
       publishTestResults: true
       testRunTitle: "Indicator Tests"
 

--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -55,7 +55,7 @@ steps:
     inputs:
       command: test
       projects: "tests/indicators"
-      arguments: '--configuration $(BuildConfiguration) --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura'
+      arguments: '--configuration $(BuildConfiguration) --no-restore --no-build --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura'
       publishTestResults: true
       testRunTitle: "Indicator Tests"
 

--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -23,6 +23,9 @@ steps:
       versionSpec: 5.10.x
       checkLatest: false
 
+  - task: VisualStudioTestPlatformInstaller@1
+    displayName: use VS Test Platform
+
   - task: DotNetCoreCLI@2
     displayName: "use GitVersion"
     inputs:

--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -23,9 +23,6 @@ steps:
       versionSpec: 5.10.x
       checkLatest: false
 
-  - task: VisualStudioTestPlatformInstaller@1
-    displayName: use VS Test Platform
-
   - task: DotNetCoreCLI@2
     displayName: "use GitVersion"
     inputs:
@@ -51,15 +48,15 @@ steps:
     displayName: build
     inputs:
       projects: "**/*.csproj"
-      arguments: "--configuration $(BuildConfiguration) /p:Version=$(GitVersion.NuGetVersion)"
+      arguments: --configuration $(BuildConfiguration) /p:Version=$(GitVersion.NuGetVersion)
 
-  - task: VSTest@2
+  - task: DotNetCoreCLI@2
     displayName: "test indicators"
     inputs:
-      testSelector: "testAssemblies"
-      testAssemblyVer2: |
-        **\*Skender.Stock.Indicators.dll
-      codeCoverageEnabled: true
+      command: test
+      projects: "**/Tests.Indicators.csproj"
+      arguments: --configuration $(BuildConfiguration) --no-restore --no-build --collect "Code Coverage"
+      publishTestResults: true
       testRunTitle: ".NET Indicator Tests"
 
   - task: DotNetCoreCLI@2
@@ -67,7 +64,7 @@ steps:
     inputs:
       command: test
       projects: "**/Tests.Other.csproj"
-      arguments: "--configuration $(BuildConfiguration) --no-restore --no-build /p:CollectCoverage=false"
+      arguments: --configuration $(BuildConfiguration) --no-restore --no-build /p:CollectCoverage=false
       publishTestResults: true
       testRunTitle: ".NET External/Other Tests"
 

--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -6,7 +6,7 @@ pr:
 
 pool:
   name: Azure Pipelines
-  vmImage: "ubuntu-latest"
+  vmImage: "windows-latest"
 
 variables:
   BuildConfiguration: "Release"

--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -58,14 +58,13 @@ steps:
     inputs:
       command: test
       projects: "tests/indicators"
-      arguments: --configuration $(BuildConfiguration) --no-restore --no-build --collect:"XPlat Code Coverage"
+      arguments: --configuration $(BuildConfiguration) --no-restore --no-build --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
       publishTestResults: true
       testRunTitle: "Indicator Tests"
 
   - task: PublishCodeCoverageResults@1
     displayName: "publish code coverage"
     inputs:
-      codeCoverageTool: Cobertura
       summaryFileLocation: "$(Agent.TempDirectory)/**/coverage.cobertura.xml"
 
   - task: DotNetCoreCLI@2

--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -55,15 +55,9 @@ steps:
     inputs:
       command: test
       projects: "tests/indicators"
-      arguments: '--configuration $(BuildConfiguration) --no-restore --no-build --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura'
+      arguments: --configuration $(BuildConfiguration) --no-restore --no-build --collect:"XPlat Code Coverage --results-directory:$(Build.SourcesDirectory)/tests/indicators"
       publishTestResults: true
       testRunTitle: "Indicator Tests"
-
-  - task: PublishCodeCoverageResults@1
-    displayName: "publish code coverage"
-    inputs:
-      codeCoverageTool: Cobertura
-      summaryFileLocation: "$(Agent.TempDirectory)/**/coverage.cobertura.xml"
 
   - task: DotNetCoreCLI@2
     displayName: "test external/other"
@@ -73,6 +67,12 @@ steps:
       arguments: "--configuration $(BuildConfiguration) --no-restore --no-build /p:CollectCoverage=false"
       publishTestResults: true
       testRunTitle: "External Tests"
+
+  - task: PublishCodeCoverageResults@1
+    displayName: "publish code coverage"
+    inputs:
+      codeCoverageTool: Cobertura
+      summaryFileLocation: "$(Build.SourcesDirectory)/tests/indicators/**/coverage.cobertura.xml"
 
   - task: DotNetCoreCLI@2
     displayName: "pack for NuGet"

--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -55,7 +55,7 @@ steps:
     inputs:
       command: test
       projects: "tests/indicators"
-      arguments: '--configuration $(BuildConfiguration) --no-restore --no-build --collect:"XPlat Code Coverage" --DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura'
+      arguments: '--configuration $(BuildConfiguration) --no-restore --no-build --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura'
       publishTestResults: true
       testRunTitle: "Indicator Tests"
 

--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -55,7 +55,7 @@ steps:
     inputs:
       command: test
       projects: "tests/indicators"
-      arguments: --configuration $(BuildConfiguration) --no-restore --no-build --collect:"XPlat Code Coverage" --results-directory:$(Build.SourcesDirectory)/tests/indicators"
+      arguments: --configuration $(BuildConfiguration) --no-restore --no-build --collect:"XPlat Code Coverage" --results-directory $(Build.SourcesDirectory)/tests/indicators"
       publishTestResults: true
       testRunTitle: "Indicator Tests"
 

--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -65,6 +65,7 @@ steps:
   - task: PublishCodeCoverageResults@1
     displayName: "publish code coverage"
     inputs:
+      codeCoverageTool: Cobertura
       summaryFileLocation: "$(Agent.TempDirectory)/**/coverage.cobertura.xml"
 
   - task: DotNetCoreCLI@2

--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -72,7 +72,7 @@ steps:
     displayName: "publish code coverage"
     inputs:
       codeCoverageTool: Cobertura
-      summaryFileLocation: "$(Build.SourcesDirectory)/tests/indicators/coverage.cobertura.xml"
+      summaryFileLocation: "$(Build.SourcesDirectory)/**/coverage.cobertura.xml"
 
   - task: DotNetCoreCLI@2
     displayName: "pack for NuGet"

--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -8,11 +8,11 @@ pool:
   name: Azure Pipelines
   vmImage: "ubuntu-latest"
 
-variables:
-  BuildConfiguration: "Release"
-
 workspace:
     clean: all
+
+variables:
+  BuildConfiguration: "Release"
 
 steps:
   - task: UseDotNet@2
@@ -62,12 +62,6 @@ steps:
       arguments: '--configuration $(BuildConfiguration) --no-restore --no-build --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura'
       publishTestResults: true
 
-  - task: PublishCodeCoverageResults@1
-    displayName: "publish code coverage"
-    inputs:
-      codeCoverageTool: Cobertura
-      summaryFileLocation: "$(Agent.TempDirectory)/**/coverage.cobertura.xml"
-
   - task: DotNetCoreCLI@2
     displayName: "test external/other"
     inputs:
@@ -76,6 +70,12 @@ steps:
       projects: "tests/external/Tests.Other.csproj"
       arguments: "--configuration $(BuildConfiguration) --no-restore --no-build /p:CollectCoverage=false"
       publishTestResults: true
+
+  - task: PublishCodeCoverageResults@1
+    displayName: "publish code coverage"
+    inputs:
+      codeCoverageTool: Cobertura
+      summaryFileLocation: "$(Agent.TempDirectory)/**/coverage.cobertura.xml"
 
   - task: DotNetCoreCLI@2
     displayName: "pack for NuGet"

--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -57,10 +57,10 @@ steps:
     displayName: "test indicators"
     inputs:
       command: test
-      projects: "**/Tests.Indicators.csproj"
-      arguments: --configuration $(BuildConfiguration) --no-restore --no-build --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
-      publishTestResults: true
       testRunTitle: "Indicator Tests"
+      projects: "tests/indicators/Tests.Indicators.csproj"
+      arguments: '--configuration $(BuildConfiguration) --no-restore --no-build --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura'
+      publishTestResults: true
 
   - task: PublishCodeCoverageResults@1
     displayName: "publish code coverage"
@@ -72,10 +72,10 @@ steps:
     displayName: "test external/other"
     inputs:
       command: test
-      projects: "**/Tests.Other.csproj"
+      testRunTitle: "External Tests"
+      projects: "tests/external/Tests.Other.csproj"
       arguments: "--configuration $(BuildConfiguration) --no-restore --no-build /p:CollectCoverage=false"
       publishTestResults: true
-      testRunTitle: "External Tests"
 
   - task: DotNetCoreCLI@2
     displayName: "pack for NuGet"

--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -11,6 +11,9 @@ pool:
 variables:
   BuildConfiguration: "Release"
 
+workspace:
+    clean: all
+
 steps:
   - task: UseDotNet@2
     displayName: "use .NET SDK 5.0.x"
@@ -57,8 +60,13 @@ steps:
       projects: "tests/indicators"
       arguments: --configuration $(BuildConfiguration) --no-restore --no-build --collect:"XPlat Code Coverage"
       publishTestResults: true
-      modifyOutputPath: true
       testRunTitle: "Indicator Tests"
+
+  - task: PublishCodeCoverageResults@1
+    displayName: "publish code coverage"
+    inputs:
+      codeCoverageTool: Cobertura
+      summaryFileLocation: "$(Agent.TempDirectory)/**/coverage.cobertura.xml"
 
   - task: DotNetCoreCLI@2
     displayName: "test external/other"
@@ -68,12 +76,6 @@ steps:
       arguments: "--configuration $(BuildConfiguration) --no-restore --no-build /p:CollectCoverage=false"
       publishTestResults: true
       testRunTitle: "External Tests"
-
-  - task: PublishCodeCoverageResults@1
-    displayName: "publish code coverage"
-    inputs:
-      codeCoverageTool: Cobertura
-      summaryFileLocation: "$(Build.SourcesDirectory)/tests/indicators/**/coverage.cobertura.xml"
 
   - task: DotNetCoreCLI@2
     displayName: "pack for NuGet"

--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -72,7 +72,7 @@ steps:
     displayName: "publish code coverage"
     inputs:
       codeCoverageTool: Cobertura
-      summaryFileLocation: "$(Build.SourcesDirectory)/**/coverage.cobertura.xml"
+      summaryFileLocation: "$(Agent.TempDirectory)/**/coverage.cobertura.xml"
 
   - task: DotNetCoreCLI@2
     displayName: "pack for NuGet"

--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -55,7 +55,7 @@ steps:
     inputs:
       testSelector: "testAssemblies"
       testAssemblyVer2: |
-        Skender.Stock.Indicators.dll
+        "**\*Skender.Stock.Indicators.dll"
       codeCoverageEnabled: true
       testRunTitle: ".NET Indicator Tests"
 

--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -6,7 +6,7 @@ pr:
 
 pool:
   name: Azure Pipelines
-  vmImage: "windows-latest"
+  vmImage: "ubuntu-latest"
 
 variables:
   BuildConfiguration: "Release"
@@ -54,19 +54,25 @@ steps:
     displayName: "test indicators"
     inputs:
       command: test
-      projects: "**/Tests.Indicators.csproj"
-      arguments: --configuration $(BuildConfiguration) --no-restore --no-build --collect "Code Coverage"
+      projects: "tests/indicators"
+      arguments: --configuration $(BuildConfiguration) --no-restore --no-build --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
       publishTestResults: true
-      testRunTitle: ".NET Indicator Tests"
+      testRunTitle: "Indicator Tests"
 
   - task: DotNetCoreCLI@2
     displayName: "test external/other"
     inputs:
       command: test
-      projects: "**/Tests.Other.csproj"
+      projects: "tests/external"
       arguments: --configuration $(BuildConfiguration) --no-restore --no-build /p:CollectCoverage=false
       publishTestResults: true
-      testRunTitle: ".NET External/Other Tests"
+      testRunTitle: "External Tests"
+
+  - task: PublishCodeCoverageResults@1
+    displayName: "publish code coverage"
+    inputs:
+      codeCoverageTool: Cobertura
+      summaryFileLocation: "$(Build.SourcesDirectory)/tests/indicators/coverage.cobertura.xml"
 
   - task: DotNetCoreCLI@2
     displayName: "pack for NuGet"

--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -57,7 +57,7 @@ steps:
     displayName: "test indicators"
     inputs:
       command: test
-      projects: "tests/indicators"
+      projects: "**/Tests.Indicators.csproj"
       arguments: --configuration $(BuildConfiguration) --no-restore --no-build --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
       publishTestResults: true
       testRunTitle: "Indicator Tests"
@@ -72,7 +72,7 @@ steps:
     displayName: "test external/other"
     inputs:
       command: test
-      projects: "tests/external"
+      projects: "**/Tests.Other.csproj"
       arguments: "--configuration $(BuildConfiguration) --no-restore --no-build /p:CollectCoverage=false"
       publishTestResults: true
       testRunTitle: "External Tests"

--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -55,7 +55,7 @@ steps:
     inputs:
       command: test
       projects: "tests/indicators"
-      arguments: '--configuration $(BuildConfiguration) --no-restore --no-build --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura'
+      arguments: '--configuration $(BuildConfiguration) --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura'
       publishTestResults: true
       testRunTitle: "Indicator Tests"
 

--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -55,8 +55,9 @@ steps:
     inputs:
       command: test
       projects: "tests/indicators"
-      arguments: --configuration $(BuildConfiguration) --no-restore --no-build --collect:"XPlat Code Coverage" --results-directory $(Build.SourcesDirectory)/tests/indicators"
+      arguments: --configuration $(BuildConfiguration) --no-restore --no-build --collect:"XPlat Code Coverage"
       publishTestResults: true
+      modifyOutputPath: true
       testRunTitle: "Indicator Tests"
 
   - task: DotNetCoreCLI@2

--- a/.github/build.main.yml
+++ b/.github/build.main.yml
@@ -50,13 +50,13 @@ steps:
       projects: "**/*.csproj"
       arguments: "--configuration $(BuildConfiguration) /p:Version=$(GitVersion.NuGetVersion)"
 
-  - task: DotNetCoreCLI@2
-    displayName: "test internal"
+  - task: VSTest@2
+    displayName: "test indicators"
     inputs:
-      command: test
-      projects: "**/Tests.Indicators.csproj"
-      arguments: "--configuration $(BuildConfiguration) --no-restore --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura"
-      publishTestResults: true
+      testSelector: "testAssemblies"
+      testAssemblyVer2: |
+        Skender.Stock.Indicators.dll
+      codeCoverageEnabled: true
       testRunTitle: ".NET Indicator Tests"
 
   - task: DotNetCoreCLI@2
@@ -67,12 +67,6 @@ steps:
       arguments: "--configuration $(BuildConfiguration) --no-restore --no-build /p:CollectCoverage=false"
       publishTestResults: true
       testRunTitle: ".NET External/Other Tests"
-
-  - task: PublishCodeCoverageResults@1
-    displayName: "publish code coverage"
-    inputs:
-      codeCoverageTool: Cobertura
-      summaryFileLocation: "$(Build.SourcesDirectory)/tests/indicators/coverage.cobertura.xml"
 
   - task: DotNetCoreCLI@2
     displayName: "pack for NuGet"

--- a/indicators/Patterns/Marubozu/Marubozu.cs
+++ b/indicators/Patterns/Marubozu/Marubozu.cs
@@ -15,12 +15,11 @@ namespace Skender.Stock.Indicators
             double minBodyPercent = 0.95)
             where TQuote : IQuote
         {
+            // check parameter arguments
+            ValidateMarubozu(quotes, minBodyPercent);
 
             // sort quotes
             ReadOnlyCollection<Candle> candles = quotes.ConvertToCandles();
-
-            // check parameter arguments
-            ValidateMarubozu(quotes, minBodyPercent);
 
             // initialize
             int size = candles.Count;

--- a/indicators/_Common/Exceptions.cs
+++ b/indicators/_Common/Exceptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 
 #nullable enable
@@ -25,6 +26,7 @@ namespace Skender.Stock.Indicators
 
         // A constructor is needed for serialization when an
         // exception propagates from a remoting server to the client.
+        [ExcludeFromCodeCoverage]  // TODO: how do you test this?
         protected BadQuotesException(SerializationInfo info, StreamingContext context)
             : base(info, context) { }
     }

--- a/tests/indicators/Indicators/Test.Hurst.cs
+++ b/tests/indicators/Indicators/Test.Hurst.cs
@@ -29,6 +29,23 @@ namespace Internal.Tests
         }
 
         [TestMethod]
+        public void ConvertToQuotes()
+        {
+            List<Quote> newQuotes = longestQuotes
+                .GetHurst(longestQuotes.Count() - 1)
+                .ConvertToQuotes()
+                .ToList();
+
+            Assert.AreEqual(1, newQuotes.Count);
+
+            Quote q = newQuotes.LastOrDefault();
+            Assert.AreEqual(0.483563m, Math.Round(q.Open, 6));
+            Assert.AreEqual(0.483563m, Math.Round(q.High, 6));
+            Assert.AreEqual(0.483563m, Math.Round(q.Low, 6));
+            Assert.AreEqual(0.483563m, Math.Round(q.Close, 6));
+        }
+
+        [TestMethod]
         public void BadData()
         {
             IEnumerable<HurstResult> r = Indicator.GetHurst(badQuotes, 150);

--- a/tests/indicators/Tests.Indicators.csproj
+++ b/tests/indicators/Tests.Indicators.csproj
@@ -20,10 +20,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Description

Moving from `dotnet test` to VSTest for the main indicator library to enable the use of native code coverage due to problems with Coburtura publishing of results.

## Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage
- [x] I have added or run the performance tests that depict optimal execution times
- [x] New and existing unit tests pass locally and in the build (below) with my changes

## Acknowledgements

- [x] I have read and understand [the Apache 2.0 license](https://opensource.org/licenses/Apache-2.0)
- [x] I agree to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)
