### PR TITLE
remove redundant HTL cast

### DIFF
--- a/indicators/HtTrendline/HtTrendline.cs
+++ b/indicators/HtTrendline/HtTrendline.cs
@@ -102,7 +102,7 @@ namespace Skender.Stock.Indicators
                     sd[i] = 0.33 * pd[i] + 0.67 * sd[i - 1];
 
                     // smooth dominant cycle period
-                    int dcPeriods = (int)(Math.Truncate(sd[i] + 0.5));
+                    int dcPeriods = (int)(sd[i] + 0.5);
                     double sumPr = 0;
                     for (int d = i - dcPeriods + 1; d <= i; d++)
                     {


### PR DESCRIPTION
## Description

Minor.  Removing unneeded/slower use of `Math.Truncate()` in HTL

## Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage
- [x] I have added or run the performance tests that depict optimal execution times
- [x] New and existing unit tests pass locally and in the build (below) with my changes

## Acknowledgements

- [x] I have read and understand [the Apache 2.0 license](https://opensource.org/licenses/Apache-2.0)
- [x] I agree to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)
