### PR TITLE
undo RO collection

### DIFF
--- a/indicators/Patterns/Marubozu/Marubozu.cs
+++ b/indicators/Patterns/Marubozu/Marubozu.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 
 namespace Skender.Stock.Indicators
@@ -19,7 +18,7 @@ namespace Skender.Stock.Indicators
             ValidateMarubozu(quotes, minBodyPercent);
 
             // sort quotes
-            ReadOnlyCollection<Candle> candles = quotes.ConvertToCandles();
+            List<Candle> candles = quotes.ConvertToCandles();
 
             // initialize
             int size = candles.Count;

--- a/indicators/_Common/Candles/Candles.cs
+++ b/indicators/_Common/Candles/Candles.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 
 namespace Skender.Stock.Indicators
@@ -7,11 +6,11 @@ namespace Skender.Stock.Indicators
     public static class Candlesticks
     {
         // convert/sort quotes into candles
-        internal static ReadOnlyCollection<Candle> ConvertToCandles<TQuote>(
+        internal static List<Candle> ConvertToCandles<TQuote>(
             this IEnumerable<TQuote> quotes)
             where TQuote : IQuote
         {
-            ReadOnlyCollection<Candle> candlesList = quotes
+            List<Candle> candlesList = quotes
                 .Select(x => new Candle
                 {
                     Date = x.Date,
@@ -21,8 +20,7 @@ namespace Skender.Stock.Indicators
                     Close = x.Close
                 })
                 .OrderBy(x => x.Date)
-                .ToList()
-                .AsReadOnly();
+                .ToList();
 
             // validate
             return candlesList == null || candlesList.Count == 0

--- a/tests/indicators/Patterns/Test.Candles.cs
+++ b/tests/indicators/Patterns/Test.Candles.cs
@@ -16,7 +16,7 @@ namespace Internal.Tests
             IEnumerable<Quote> quotes = TestData.GetMismatch();
 
             // sort
-            ReadOnlyCollection<Candle> candles = quotes.ConvertToCandles();
+            List<Candle> candles = quotes.ConvertToCandles();
 
             // assertions
 
@@ -40,7 +40,7 @@ namespace Internal.Tests
         public void CandleValues()
         {
             // sort
-            ReadOnlyCollection<Candle> candles = quotes.ConvertToCandles();
+            List<Candle> candles = quotes.ConvertToCandles();
 
             // assertions
 


### PR DESCRIPTION
## Description

When implementing Candles, we added it as a `ReadOnlyCollection` and had intended to do the same for internal `quotesList`; however, after performance inspection and learning a bit more, converting to this format requires to compose a list anyway, then add some additional overhead ... it's actually slower and not adding any real value.

As a result, we're removing this idea from Candles as well.

## Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage
- [x] I have added or run the performance tests that depict optimal execution times
- [x] New and existing unit tests pass locally and in the build (below) with my changes

## Acknowledgements

- [x] I have read and understand [the Apache 2.0 license](https://opensource.org/licenses/Apache-2.0)
- [x] I agree to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)
