### PR TITLE
add ToPeriodSize

### DIFF
--- a/src/_Common/Functions.cs
+++ b/src/_Common/Functions.cs
@@ -105,6 +105,36 @@ namespace Skender.Stock.Indicators
             };
         }
 
+        internal static PeriodSize? ToPeriodSize(this TimeSpan timeSpan)
+        {
+            PeriodSize? _periodSize = null;
+
+            if (timeSpan == TimeSpan.FromMinutes(1))
+                _periodSize = PeriodSize.OneMinute;
+            if (timeSpan == TimeSpan.FromMinutes(2))
+                _periodSize = PeriodSize.TwoMinutes;
+            if (timeSpan == TimeSpan.FromMinutes(3))
+                _periodSize = PeriodSize.ThreeMinutes;
+            if (timeSpan == TimeSpan.FromMinutes(5))
+                _periodSize = PeriodSize.FiveMinutes;
+            if (timeSpan == TimeSpan.FromMinutes(15))
+                _periodSize = PeriodSize.FifteenMinutes;
+            if (timeSpan == TimeSpan.FromMinutes(30))
+                _periodSize = PeriodSize.ThirtyMinutes;
+            if (timeSpan == TimeSpan.FromHours(1))
+                _periodSize = PeriodSize.OneHour;
+            if (timeSpan == TimeSpan.FromHours(2))
+                _periodSize = PeriodSize.TwoHours;
+            if (timeSpan == TimeSpan.FromHours(4))
+                _periodSize = PeriodSize.FourHours;
+            if (timeSpan == TimeSpan.FromDays(1))
+                _periodSize = PeriodSize.Day;
+            if (timeSpan == TimeSpan.FromDays(7))
+                _periodSize = PeriodSize.Week;
+
+            return _periodSize;
+        }
+
         // DETERMINE DECIMAL PLACES
         internal static int GetDecimalPlaces(this decimal n)
         {

--- a/tests/indicators/_Common/Test.Functions.cs
+++ b/tests/indicators/_Common/Test.Functions.cs
@@ -53,5 +53,25 @@ namespace Internal.Tests
 
             Assert.AreEqual(PeriodSize.Month.ToTimeSpan(), TimeSpan.Zero);
         }
+
+        [TestMethod]
+        public void ToPeriodSize()
+        {
+            //POSITIVE TEST
+            Assert.AreEqual(TimeSpan.FromMinutes(1).ToPeriodSize(), PeriodSize.OneMinute);
+            Assert.AreEqual(TimeSpan.FromMinutes(2).ToPeriodSize(), PeriodSize.TwoMinutes);
+            Assert.AreEqual(TimeSpan.FromMinutes(3).ToPeriodSize(), PeriodSize.ThreeMinutes);
+            Assert.AreEqual(TimeSpan.FromMinutes(5).ToPeriodSize(), PeriodSize.FiveMinutes);
+            Assert.AreEqual(TimeSpan.FromMinutes(15).ToPeriodSize(), PeriodSize.FifteenMinutes);
+            Assert.AreEqual(TimeSpan.FromMinutes(30).ToPeriodSize(), PeriodSize.ThirtyMinutes);
+            Assert.AreEqual(TimeSpan.FromHours(1).ToPeriodSize(), PeriodSize.OneHour);
+            Assert.AreEqual(TimeSpan.FromHours(2).ToPeriodSize(), PeriodSize.TwoHours);
+            Assert.AreEqual(TimeSpan.FromHours(4).ToPeriodSize(), PeriodSize.FourHours);
+            Assert.AreEqual(TimeSpan.FromDays(1).ToPeriodSize(), PeriodSize.Day);
+            Assert.AreEqual(TimeSpan.FromDays(7).ToPeriodSize(), PeriodSize.Week);
+
+            //NEGATIVE TEST - NOT MATCH --> NULL           
+            Assert.IsNull(TimeSpan.FromMinutes(4).ToPeriodSize());
+        }
     }
 }


### PR DESCRIPTION
## Description

Implemented extension function 

`internal static TimeSpan ToTimeSpan(this PeriodSize periodSize)`

I had to use a multi statement if as the `switch` statement does not support the TimeSpan type

P.S. Is my first contributions and i always i use TFS. I hope it is to your liking.

Implements #530 

## Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage
- [ ] I have added or run the performance tests that depict optimal execution times
- [ ] New and existing unit tests pass locally and in the build (below) with my changes

## Acknowledgements

- [ ] I have read and understand [the Apache 2.0 license](https://opensource.org/licenses/Apache-2.0)
- [ ] I agree to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)