### PR TITLE
warn: future GetVolSma() deprecation

### DIFF
--- a/docs/_indicators/VolSma.md
+++ b/docs/_indicators/VolSma.md
@@ -4,6 +4,8 @@ permalink: /indicators/VolSma/
 layout: default
 ---
 
+:warning: **Deprecation Warning!** `GetVolSma` is now redundant and will be removed from the library.  It is replaced by [GetSma()](../Sma/#content) with a `CandlePart.Volume` specification.
+
 # {{ page.title }}
 
 The Volume Simple Moving Average is the average volume over a lookback window.  This is helpful when you are trying to assess whether volume is above or below normal.

--- a/docs/indicators.md
+++ b/docs/indicators.md
@@ -84,7 +84,7 @@ redirect_from:
 - [Money Flow Index (MFI)](../indicators/Mfi/#content)
 - [On-balance Volume (OBV)](../indicators/Obv/#content)
 - [Percentage Volume Oscillator (PVO)](../indicators/Pvo/#content)
-- [Volume Simple Moving Average](../indicators/VolSma/#content)
+- [Volume Simple Moving Average](../indicators/Sma/#content)
 
 ## Moving averages
 

--- a/src/GlobalSuppressions.cs
+++ b/src/GlobalSuppressions.cs
@@ -1,4 +1,4 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
@@ -24,4 +24,10 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage(
     "Style",
     "IDE0130:Namespace does not match folder structure",
-    Justification = "Microsoft bug, not real")]
+    Justification = "Microsoft bug?, not a real problem")]
+
+[assembly: SuppressMessage("Globalization",
+    "CA1303:Do not pass literals as localized parameters",
+    Justification = "Temporary message",
+    Scope = "member",
+    Target = "~M:Skender.Stock.Indicators.Indicator.GetVolSma``1(System.Collections.Generic.IEnumerable{``0},System.Int32)~System.Collections.Generic.IEnumerable{Skender.Stock.Indicators.VolSmaResult}")]

--- a/src/s-z/VolSma/info.xml
+++ b/src/s-z/VolSma/info.xml
@@ -2,6 +2,9 @@
 
 <indicator>
   <summary>
+    WARNING! This indicator will be replaced by GetSma() and removed at the end of 2021 in future versions.
+    Please migrate your scripts now.
+
     Volume Simple Moving Average is the average volume over a lookback window.
     This is helpful when you are trying to assess whether volume is above or below normal.
     <para>


### PR DESCRIPTION
## Description

With the additon of `CandlePart.Volume` to `GetSma()`, this `GetVolSma()` is now fully redundant and unneeded.
This PR published a warning message in the documentation and a console message for users to encourage early migration.
`GetVolSma()` will not be available in versions published after 2021.

## Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage
- [x] I have added or run the performance tests that depict optimal execution times
- [x] New and existing unit tests pass locally and in the build (below) with my changes