### PR TITLE
chore: update build a11y tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,11 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v2
 
+      - name: Install Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -45,7 +50,6 @@ jobs:
       - name: Test accessibility
         working-directory: docs
         run: |
-          npm i -g pa11y-ci
-          pa11y-ci \
+          npx pa11y-ci \
             --sitemap http://127.0.0.1:4000/sitemap.xml \
             --sitemap-exclude "/*.pdf"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,10 @@ jobs:
             --url-swap "https\://daveskender.github.io/Stock.Indicators:http\://127.0.0.1:4000" \
             _site
 
+      - name: Show environment
+        working-directory: docs
+        run: npx pa11y --environment
+
       - name: Test accessibility
         working-directory: docs
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,10 +42,10 @@ jobs:
             --url-swap "https\://daveskender.github.io/Stock.Indicators:http\://127.0.0.1:4000" \
             _site
 
-      # - name: Test accessibility
-      #   working-directory: docs
-      #   run: |
-      #     npm i -g pa11y-ci
-      #     pa11y-ci \
-      #       --sitemap http://127.0.0.1:4000/sitemap.xml \
-      #       --sitemap-exclude "/*.pdf"
+      - name: Test accessibility
+        working-directory: docs
+        run: |
+          npm i -g pa11y-ci
+          pa11y-ci \
+            --sitemap http://127.0.0.1:4000/sitemap.xml \
+            --sitemap-exclude "/*.pdf"

--- a/docs/.pa11yci
+++ b/docs/.pa11yci
@@ -1,6 +1,6 @@
 {
   "defaults": {
-    "concurrency": 1,
+    "concurrency": 4,
     "standard": "WCAG2AA",
     "runners": ["htmlcs"],
     "timeout": 30000

--- a/docs/.pa11yci
+++ b/docs/.pa11yci
@@ -2,7 +2,7 @@
   "defaults": {
     "concurrency": 1,
     "standard": "WCAG2AA",
-    "runners": ["axe"],
+    "runners": ["htmlcs"],
     "timeout": 30000
   }
 }

--- a/docs/.pa11yci
+++ b/docs/.pa11yci
@@ -1,6 +1,6 @@
 {
   "defaults": {
-    "concurrency": 4,
+    "concurrency": 1,
     "standard": "WCAG2AA",
     "runners": ["htmlcs"],
     "timeout": 30000

--- a/docs/.pa11yci
+++ b/docs/.pa11yci
@@ -2,7 +2,6 @@
   "defaults": {
     "concurrency": 1,
     "standard": "WCAG2AA",
-    "runners": ["htmlcs"],
-    "timeout": 30000
+    "runners": ["htmlcs"]
   }
 }

--- a/docs/.pa11yci
+++ b/docs/.pa11yci
@@ -1,6 +1,6 @@
 {
   "defaults": {
-    "concurrency": 4,
+    "concurrency": 1,
     "standard": "WCAG2AA",
     "runners": ["axe"],
     "timeout": 30000

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -83,8 +83,7 @@ When adding or updating indicators:
 - build the site locally (see above), then:
 
 ```bash
-npm i -g pa11y-ci
-pa11y-ci --sitemap http://127.0.0.1:4000/sitemap.xml --sitemap-exclude "/*.pdf"
+npx pa11y-ci --sitemap http://127.0.0.1:4000/sitemap.xml --sitemap-exclude "/*.pdf"
 ```
 
 ### Testing for broken URLs


### PR DESCRIPTION
### Description

- add back a11y tests

### To do

- [x] recent update to pa11y-ci v3.0.0 did not seem to fix all issues; 
- implementing workaround from issue: https://github.com/pa11y/pa11y-ci/issues/168

### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
