### PR TITLE
refactor: quote converters

### DIFF
--- a/docs/_indicators/Chandelier.md
+++ b/docs/_indicators/Chandelier.md
@@ -23,7 +23,7 @@ IEnumerable<ChandelierResult> results =
 | name | type | notes
 | -- |-- |--
 | `lookbackPeriods` | int | Number of periods (`N`) for the lookback evaluation.  Default is 22.
-| `multiplier` | decimal | Multiplier number must be a positive value.  Default is 3.
+| `multiplier` | double | Multiplier number must be a positive value.  Default is 3.
 | `type` | ChandelierType | Direction of exit.  See [ChandelierType options](#chandeliertype-options) below.  Default is `ChandelierType.Long`.
 
 ### Historical quotes requirements

--- a/docs/_indicators/Ema.md
+++ b/docs/_indicators/Ema.md
@@ -46,6 +46,7 @@ You must have at least `2×N` or `N+100` periods of `quotes`, whichever is more.
 | `CandlePart.Low` | Use `Low` price
 | `CandlePart.Close` | Use `Close` price (default)
 | `CandlePart.Volume` | Use `Volume`
+| `CandlePart.HL2` | Use `(High+Low)/2`
 
 ## Response
 

--- a/docs/_indicators/Sma.md
+++ b/docs/_indicators/Sma.md
@@ -44,6 +44,7 @@ You must have at least `N` periods of `quotes`.
 | `CandlePart.Low` | Use `Low` price
 | `CandlePart.Close` | Use `Close` price (default)
 | `CandlePart.Volume` | Use `Volume`
+| `CandlePart.HL2` | Use `(High+Low)/2`
 
 ## Response
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,10 +1,7 @@
 ---
-title: Performance benchmarks for v1.20.0
+title: Performance benchmarks for v1.20.1
 permalink: /performance/
 layout: default
-redirect_from:
- - /tests/performance
- - /tests/performance/
 ---
 
 # {{ page.title }}
@@ -19,94 +16,95 @@ Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical co
 
 ## indicators
 
-|             Method |        Mean |     Error |    StdDev |
-|------------------- |------------:|----------:|----------:|
-|             GetAdl |   124.29 μs |  2.414 μs |  3.687 μs |
-|      GetAdlWithSma |   115.54 μs |  1.839 μs |  2.753 μs |
-|             GetAdx |   237.15 μs |  1.069 μs |  0.948 μs |
-|       GetAlligator |   155.55 μs |  0.993 μs |  0.880 μs |
-|            GetAlma |    83.36 μs |  0.531 μs |  0.444 μs |
-|           GetAroon |   309.18 μs |  1.777 μs |  1.576 μs |
-|             GetAtr |   156.35 μs |  0.484 μs |  0.404 μs |
-|         GetAwesome |    66.29 μs |  0.259 μs |  0.230 μs |
-|            GetBeta |   286.29 μs |  0.851 μs |  0.665 μs |
-|          GetBetaUp |   377.75 μs |  1.433 μs |  1.270 μs |
-|        GetBetaDown |   369.43 μs |  1.257 μs |  1.050 μs |
-|         GetBetaAll |   878.41 μs | 16.218 μs | 13.543 μs |
-|  GetBollingerBands |   259.73 μs |  1.392 μs |  1.234 μs |
-|             GetBop |   108.02 μs |  0.246 μs |  0.205 μs |
-|             GetCci |    81.89 μs |  0.852 μs |  0.797 μs |
-|      GetChaikinOsc |   162.76 μs |  1.113 μs |  0.987 μs |
-|      GetChandelier |   346.43 μs |  1.250 μs |  1.044 μs |
-|            GetChop |   119.33 μs |  0.454 μs |  0.402 μs |
-|             GetCmf |   212.59 μs |  1.732 μs |  1.446 μs |
-|      GetConnorsRsi |   249.64 μs |  1.196 μs |  0.999 μs |
-|     GetCorrelation |   229.14 μs |  0.633 μs |  0.494 μs |
-|        GetDonchian |   312.26 μs |  2.677 μs |  2.236 μs |
-|       GetDoubleEma |   100.06 μs |  0.361 μs |  0.302 μs |
-|             GetDpo |   149.42 μs |  0.430 μs |  0.402 μs |
-|        GetElderRay |   117.93 μs |  0.895 μs |  0.793 μs |
-|             GetEma |    57.01 μs |  0.494 μs |  0.386 μs |
-|            GetEpma |   154.44 μs |  0.546 μs |  0.456 μs |
-|             GetFcb |   346.71 μs |  3.460 μs |  3.067 μs |
-| GetFisherTransform |    80.28 μs |  0.213 μs |  0.178 μs |
-|      GetForceIndex |    48.03 μs |  0.178 μs |  0.149 μs |
-|         GetFractal |    95.96 μs |  0.528 μs |  0.441 μs |
-|           GetGator |   201.69 μs |  0.528 μs |  0.412 μs |
-|      GetHeikinAshi |   173.05 μs |  1.270 μs |  1.060 μs |
-|             GetHma |   326.51 μs |  2.386 μs |  2.116 μs |
-|     GetHtTrendline |   165.08 μs |  0.916 μs |  0.812 μs |
-|           GetHurst |   996.05 μs |  2.921 μs |  2.589 μs |
-|        GetIchimoku |   872.99 μs |  6.311 μs |  5.903 μs |
-|            GetKama |   218.28 μs |  1.158 μs |  1.026 μs |
-|         GetKlinger |    75.66 μs |  0.409 μs |  0.342 μs |
-|         GetKeltner |   381.80 μs |  1.465 μs |  1.299 μs |
-|            GetMacd |   143.19 μs |  0.550 μs |  0.429 μs |
-|     GetMaEnvelopes |    86.82 μs |  0.665 μs |  0.622 μs |
-|            GetMama |   132.06 μs |  1.773 μs |  1.571 μs |
-|        GetMarubozu |   125.23 μs |  2.474 μs |  2.540 μs |
-|             GetMfi |   172.48 μs |  1.895 μs |  1.773 μs |
-|             GetObv |    60.26 μs |  0.430 μs |  0.381 μs |
-|      GetObvWithSma |    65.82 μs |  0.340 μs |  0.302 μs |
-|    GetParabolicSar |    94.03 μs |  0.178 μs |  0.158 μs |
-|          GetPivots |   159.44 μs |  0.464 μs |  0.387 μs |
-|     GetPivotPoints |    93.03 μs |  0.871 μs |  0.772 μs |
-|             GetPmo |   113.49 μs |  2.236 μs |  2.196 μs |
-|             GetPrs |   133.71 μs |  1.256 μs |  1.175 μs |
-|      GetPrsWithSma |   138.15 μs |  0.610 μs |  0.541 μs |
-|             GetPvo |   203.95 μs |  0.467 μs |  0.390 μs |
-|           GetRenko |    94.77 μs |  0.744 μs |  0.659 μs |
-|        GetRenkoAtr |    99.85 μs |  0.271 μs |  0.240 μs |
-|             GetRoc |    95.43 μs |  0.331 μs |  0.310 μs |
-|           GetRocWb |   115.57 μs |  0.942 μs |  0.835 μs |
-|      GetRocWithSma |   106.40 μs |  0.837 μs |  0.742 μs |
-|   GetRollingPivots |   326.90 μs |  1.383 μs |  1.226 μs |
-|             GetRsi |    53.08 μs |  0.098 μs |  0.087 μs |
-|           GetSlope |   175.21 μs |  0.348 μs |  0.309 μs |
-|             GetSma |    82.92 μs |  0.180 μs |  0.159 μs |
-|     GetSmaExtended |   174.34 μs |  0.276 μs |  0.244 μs |
-|             GetSmi |   151.84 μs |  1.414 μs |  1.253 μs |
-|            GetSmma |    80.26 μs |  0.302 μs |  0.283 μs |
-|      GetStarcBands |   366.64 μs |  0.567 μs |  0.531 μs |
-|             GetStc |   395.16 μs |  3.675 μs |  3.257 μs |
-|          GetStdDev |   169.55 μs |  1.396 μs |  1.237 μs |
-|   GetStdDevWithSma |   178.82 μs |  0.296 μs |  0.247 μs |
-|  GetStdDevChannels |   209.56 μs |  0.692 μs |  0.613 μs |
-|           GetStoch |   290.82 μs |  0.536 μs |  0.418 μs |
-|       GetStochSMMA |   238.85 μs |  2.398 μs |  2.003 μs |
-|        GetStochRsi |   345.09 μs |  4.706 μs |  3.929 μs |
-|      GetSuperTrend |   247.28 μs |  1.870 μs |  1.658 μs |
-|       GetTripleEma |   143.98 μs |  2.074 μs |  1.619 μs |
-|            GetTrix |   185.84 μs |  1.499 μs |  1.402 μs |
-|     GetTrixWithSma |   243.63 μs |  1.639 μs |  1.533 μs |
-|             GetTsi |    61.29 μs |  0.603 μs |  0.564 μs |
-|              GetT3 |    66.47 μs |  0.776 μs |  0.726 μs |
-|      GetUlcerIndex | 1,102.98 μs |  3.249 μs |  3.039 μs |
-|        GetUltimate |   110.62 μs |  0.974 μs |  0.863 μs |
-|  GetVolatilityStop |   243.24 μs |  0.560 μs |  0.497 μs |
-|          GetVolSma |   159.04 μs |  1.197 μs |  1.120 μs |
-|          GetVortex |    90.71 μs |  1.141 μs |  0.953 μs |
-|            GetVwap |    67.75 μs |  0.362 μs |  0.338 μs |
-|       GetWilliamsR |   254.60 μs |  1.243 μs |  1.038 μs |
-|             GetWma |   101.64 μs |  0.579 μs |  0.541 μs |
-|          GetZigZag |   163.98 μs |  3.266 μs |  5.458 μs |
+|             Method |        Mean |    Error |   StdDev |
+|------------------- |------------:|---------:|---------:|
+|             GetAdl |    59.68 μs | 0.612 μs | 0.511 μs |
+|      GetAdlWithSma |    67.30 μs | 0.374 μs | 0.312 μs |
+|             GetAdx |   227.22 μs | 1.261 μs | 1.179 μs |
+|       GetAlligator |   169.23 μs | 0.986 μs | 0.874 μs |
+|            GetAlma |    67.03 μs | 0.328 μs | 0.310 μs |
+|           GetAroon |   142.20 μs | 1.460 μs | 0.931 μs |
+|             GetAtr |   154.96 μs | 0.970 μs | 0.810 μs |
+|         GetAwesome |    75.39 μs | 0.325 μs | 0.289 μs |
+|            GetBeta |   221.70 us | 1.780 us | 1.580 us |
+|          GetBetaUp |   247.50 us | 4.910 us | 5.050 us |
+|        GetBetaDown |   238.00 us | 4.040 us | 3.580 us |
+|         GetBetaAll |   510.90 us | 9.090 us | 8.500 us |
+|  GetBollingerBands |   234.42 μs | 2.059 μs | 1.926 μs |
+|             GetBop |    68.98 μs | 0.377 μs | 0.352 μs |
+|             GetCci |    84.67 μs | 0.498 μs | 0.465 μs |
+|      GetChaikinOsc |   120.65 μs | 0.722 μs | 0.603 μs |
+|      GetChandelier |   261.32 μs | 1.992 μs | 1.766 μs |
+|            GetChop |   123.77 μs | 2.411 μs | 2.476 μs |
+|             GetCmf |   127.10 μs | 1.330 μs | 1.179 μs |
+|      GetConnorsRsi |   241.61 μs | 1.411 μs | 1.178 μs |
+|     GetCorrelation |   161.66 μs | 0.403 μs | 0.336 μs |
+|        GetDonchian |   306.92 μs | 2.007 μs | 1.779 μs |
+|       GetDoubleEma |   100.55 μs | 0.709 μs | 0.592 μs |
+|             GetDpo |   148.78 μs | 0.998 μs | 0.833 μs |
+|        GetElderRay |   117.82 μs | 0.587 μs | 0.520 μs |
+|             GetEma |    56.83 μs | 0.394 μs | 0.350 μs |
+|            GetEpma |   100.15 μs | 0.331 μs | 0.276 μs |
+|             GetFcb |   347.82 μs | 2.644 μs | 2.473 μs |
+| GetFisherTransform |    95.40 μs | 0.474 μs | 0.420 μs |
+|      GetForceIndex |    59.93 μs | 0.317 μs | 0.296 μs |
+|         GetFractal |    95.72 μs | 0.244 μs | 0.190 μs |
+|           GetGator |   215.27 μs | 3.762 μs | 3.141 μs |
+|      GetHeikinAshi |   175.03 μs | 0.752 μs | 0.704 μs |
+|             GetHma |   272.68 μs | 2.637 μs | 2.338 μs |
+|     GetHtTrendline |   172.83 μs | 0.517 μs | 0.432 μs |
+|           GetHurst | 1,011.27 μs | 6.046 μs | 5.359 μs |
+|        GetIchimoku |   873.87 μs | 4.815 μs | 4.504 μs |
+|            GetKama |    73.26 μs | 0.215 μs | 0.179 μs |
+|         GetKlinger |    72.53 μs | 0.358 μs | 0.299 μs |
+|         GetKeltner |   380.42 μs | 1.897 μs | 1.682 μs |
+|            GetMacd |   143.73 μs | 0.983 μs | 0.821 μs |
+|     GetMaEnvelopes |    86.72 μs | 0.262 μs | 0.218 μs |
+|            GetMama |   139.66 μs | 0.942 μs | 0.787 μs |
+|        GetMarubozu |   121.28 μs | 0.531 μs | 0.471 μs |
+|             GetMfi |   170.07 μs | 1.090 μs | 0.910 μs |
+|             GetObv |    62.35 μs | 0.243 μs | 0.215 μs |
+|      GetObvWithSma |    68.61 μs | 0.340 μs | 0.284 μs |
+|    GetParabolicSar |    89.93 μs | 0.345 μs | 0.306 μs |
+|          GetPivots |   152.28 μs | 0.719 μs | 0.637 μs |
+|     GetPivotPoints |    89.46 μs | 1.640 μs | 1.454 μs |
+|             GetPmo |    72.27 μs | 0.722 μs | 0.640 μs |
+|             GetPrs |    99.20 μs | 0.969 μs | 0.859 μs |
+|      GetPrsWithSma |   104.46 μs | 0.530 μs | 0.443 μs |
+|             GetPvo |   202.49 μs | 0.312 μs | 0.292 μs |
+|           GetRenko |    94.08 μs | 0.379 μs | 0.336 μs |
+|        GetRenkoAtr |   106.52 μs | 0.576 μs | 0.539 μs |
+|             GetRoc |    51.75 μs | 0.234 μs | 0.208 μs |
+|           GetRocWb |    72.85 μs | 0.723 μs | 0.604 μs |
+|      GetRocWithSma |    64.66 μs | 0.605 μs | 0.537 μs |
+|   GetRollingPivots |   327.67 μs | 1.436 μs | 1.344 μs |
+|             GetRsi |    53.78 μs | 0.559 μs | 0.523 μs |
+|           GetSlope |    89.19 μs | 0.617 μs | 0.547 μs |
+|             GetSma |    83.13 μs | 0.216 μs | 0.202 μs |
+|     GetSmaExtended |   161.42 μs | 1.721 μs | 1.610 μs |
+|             GetSmi |    97.64 μs | 0.958 μs | 0.800 μs |
+|            GetSmma |    87.28 μs | 0.452 μs | 0.401 μs |
+|      GetStarcBands |   326.62 μs | 2.351 μs | 2.084 μs |
+|             GetStc |   350.88 μs | 3.121 μs | 2.767 μs |
+|          GetStdDev |    99.60 μs | 0.198 μs | 0.185 μs |
+|   GetStdDevWithSma |   108.41 μs | 0.873 μs | 0.774 μs |
+|  GetStdDevChannels |   132.02 μs | 0.365 μs | 0.305 μs |
+|           GetStoch |   190.20 μs | 2.084 μs | 1.949 μs |
+|       GetStochSMMA |   168.71 μs | 1.463 μs | 1.222 μs |
+|        GetStochRsi |   248.17 μs | 1.562 μs | 1.385 μs |
+|      GetSuperTrend |   250.22 μs | 1.499 μs | 1.329 μs |
+|       GetTripleEma |   145.27 μs | 0.634 μs | 0.593 μs |
+|            GetTrix |   184.90 μs | 3.073 μs | 2.724 μs |
+|     GetTrixWithSma |   240.74 μs | 2.872 μs | 2.687 μs |
+|             GetTsi |    59.69 μs | 0.749 μs | 0.626 μs |
+|              GetT3 |    68.81 μs | 0.475 μs | 0.421 μs |
+|      GetUlcerIndex |   236.90 μs | 0.593 μs | 0.555 μs |
+|        GetUltimate |   110.23 μs | 0.766 μs | 0.679 μs |
+|  GetVolatilityStop |   255.43 μs | 3.474 μs | 3.080 μs |
+|          GetVolSma |   158.92 μs | 1.231 μs | 1.152 μs |
+|          GetVortex |    72.22 μs | 0.549 μs | 0.487 μs |
+|            GetVwap |    73.41 μs | 0.248 μs | 0.207 μs |
+|            GetVwma |    88.79 μs | 0.417 μs | 0.390 μs |
+|       GetWilliamsR |   154.25 μs | 1.395 μs | 1.165 μs |
+|             GetWma |    68.90 μs | 0.380 μs | 0.317 μs |
+|          GetZigZag |   140.25 μs | 0.718 μs | 0.637 μs |

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,10 +1,10 @@
 ---
-title: Performance benchmarks for v1.20.1
+title: Performance benchmarks
 permalink: /performance/
 layout: default
 ---
 
-# {{ page.title }}
+# {{ page.title }} for v1.20.1
 
 These are the execution times for the current indicators using two years of historical daily stock quotes (502 periods) with default or typical parameters.
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -21,11 +21,11 @@ Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical co
 |             GetAdl |    59.68 μs | 0.612 μs | 0.511 μs |
 |      GetAdlWithSma |    67.30 μs | 0.374 μs | 0.312 μs |
 |             GetAdx |   227.22 μs | 1.261 μs | 1.179 μs |
-|       GetAlligator |   169.23 μs | 0.986 μs | 0.874 μs |
+|       GetAlligator |   167.23 μs | 0.986 μs | 0.874 μs |
 |            GetAlma |    67.03 μs | 0.328 μs | 0.310 μs |
 |           GetAroon |   142.20 μs | 1.460 μs | 0.931 μs |
 |             GetAtr |   154.96 μs | 0.970 μs | 0.810 μs |
-|         GetAwesome |    75.39 μs | 0.325 μs | 0.289 μs |
+|         GetAwesome |    73.39 μs | 0.325 μs | 0.289 μs |
 |            GetBeta |   221.70 us | 1.780 us | 1.580 us |
 |          GetBetaUp |   247.50 us | 4.910 us | 5.050 us |
 |        GetBetaDown |   238.00 us | 4.040 us | 3.580 us |
@@ -46,7 +46,7 @@ Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical co
 |             GetEma |    56.83 μs | 0.394 μs | 0.350 μs |
 |            GetEpma |   100.15 μs | 0.331 μs | 0.276 μs |
 |             GetFcb |   347.82 μs | 2.644 μs | 2.473 μs |
-| GetFisherTransform |    95.40 μs | 0.474 μs | 0.420 μs |
+| GetFisherTransform |    89.40 μs | 0.474 μs | 0.420 μs |
 |      GetForceIndex |    59.93 μs | 0.317 μs | 0.296 μs |
 |         GetFractal |    95.72 μs | 0.244 μs | 0.190 μs |
 |           GetGator |   215.27 μs | 3.762 μs | 3.141 μs |

--- a/src/GlobalSuppressions.cs
+++ b/src/GlobalSuppressions.cs
@@ -17,20 +17,6 @@ using System.Diagnostics.CodeAnalysis;
     "CA1716:Identifiers should not match keywords",
     Justification = "Making an exception",
     Scope = "member",
-    Target = "~P:Skender.Stock.Indicators.IQuoteDouble.Date")]
-
-[assembly: SuppressMessage(
-    "Naming",
-    "CA1716:Identifiers should not match keywords",
-    Justification = "Making an exception",
-    Scope = "member",
-    Target = "~P:Skender.Stock.Indicators.IQuoteFloat.Date")]
-
-[assembly: SuppressMessage(
-    "Naming",
-    "CA1716:Identifiers should not match keywords",
-    Justification = "Making an exception",
-    Scope = "member",
     Target = "~P:Skender.Stock.Indicators.IResult.Date")]
 
 // this can be removed after Microsoft publishes fix,

--- a/src/GlobalSuppressions.cs
+++ b/src/GlobalSuppressions.cs
@@ -17,6 +17,20 @@ using System.Diagnostics.CodeAnalysis;
     "CA1716:Identifiers should not match keywords",
     Justification = "Making an exception",
     Scope = "member",
+    Target = "~P:Skender.Stock.Indicators.IQuoteDouble.Date")]
+
+[assembly: SuppressMessage(
+    "Naming",
+    "CA1716:Identifiers should not match keywords",
+    Justification = "Making an exception",
+    Scope = "member",
+    Target = "~P:Skender.Stock.Indicators.IQuoteFloat.Date")]
+
+[assembly: SuppressMessage(
+    "Naming",
+    "CA1716:Identifiers should not match keywords",
+    Justification = "Making an exception",
+    Scope = "member",
     Target = "~P:Skender.Stock.Indicators.IResult.Date")]
 
 // this can be removed after Microsoft publishes fix,

--- a/src/_common/Enums.cs
+++ b/src/_common/Enums.cs
@@ -9,7 +9,8 @@ namespace Skender.Stock.Indicators
         High,
         Low,
         Close,
-        Volume
+        Volume,
+        HL2
     }
 
     public enum EndType

--- a/src/_common/Quotes/Models.cs
+++ b/src/_common/Quotes/Models.cs
@@ -26,14 +26,18 @@ namespace Skender.Stock.Indicators
     }
 
     [Serializable]
-    internal class BasicData
+    internal class QuoteD
     {
         internal DateTime Date { get; set; }
-        internal decimal Value { get; set; }
+        internal double Open { get; set; }
+        internal double High { get; set; }
+        internal double Low { get; set; }
+        internal double Close { get; set; }
+        internal double Volume { get; set; }
     }
 
     [Serializable]
-    internal class BasicDouble
+    internal class BasicD
     {
         internal DateTime Date { get; set; }
         internal double Value { get; set; }

--- a/src/_common/Quotes/Quotes.Functions.cs
+++ b/src/_common/Quotes/Quotes.Functions.cs
@@ -141,6 +141,7 @@ namespace Skender.Stock.Indicators
                 CandlePart.Low => quotes.Select(x => new BasicD { Date = x.Date, Value = (double)x.Low }),
                 CandlePart.Close => quotes.Select(x => new BasicD { Date = x.Date, Value = (double)x.Close }),
                 CandlePart.Volume => quotes.Select(x => new BasicD { Date = x.Date, Value = (double)x.Volume }),
+                CandlePart.HL2 => quotes.Select(x => new BasicD { Date = x.Date, Value = (double)(x.High + x.Low) / 2 }),
                 _ => new List<BasicD>(),
             };
 

--- a/src/_common/Quotes/Quotes.Functions.cs
+++ b/src/_common/Quotes/Quotes.Functions.cs
@@ -20,7 +20,7 @@ namespace Skender.Stock.Indicators
         {
             // we cannot rely on date consistency when looking back, so we add an index and sort
 
-            List<TQuote> quotesList = quotes.Sort();
+            List<TQuote> quotesList = quotes.SortToList();
 
             // check for duplicates
             DateTime lastDate = DateTime.MinValue;
@@ -92,8 +92,8 @@ namespace Skender.Stock.Indicators
                     });
         }
 
-        // sort
-        internal static List<TQuote> Sort<TQuote>(this IEnumerable<TQuote> quotes)
+        // sort quotes
+        internal static List<TQuote> SortToList<TQuote>(this IEnumerable<TQuote> quotes)
             where TQuote : IQuote
         {
             List<TQuote> quotesList = quotes.OrderBy(x => x.Date).ToList();
@@ -104,49 +104,47 @@ namespace Skender.Stock.Indicators
                 : quotesList;
         }
 
-        // convert to basic
-        internal static List<BasicData> ConvertToBasic<TQuote>(
-            this IEnumerable<TQuote> quotes, CandlePart element = CandlePart.Close)
+        internal static List<QuoteD> ConvertToList<TQuote>(
+            this IEnumerable<TQuote> quotes)
             where TQuote : IQuote
         {
-            // elements represents the targeted OHLCV parts, so use "O" to return <Open> as base data, etc.
-            // convert to basic data format
-            IEnumerable<BasicData> basicData = element switch
-            {
-                CandlePart.Open => quotes.Select(x => new BasicData { Date = x.Date, Value = x.Open }),
-                CandlePart.High => quotes.Select(x => new BasicData { Date = x.Date, Value = x.High }),
-                CandlePart.Low => quotes.Select(x => new BasicData { Date = x.Date, Value = x.Low }),
-                CandlePart.Close => quotes.Select(x => new BasicData { Date = x.Date, Value = x.Close }),
-                CandlePart.Volume => quotes.Select(x => new BasicData { Date = x.Date, Value = x.Volume }),
-                _ => new List<BasicData>(),
-            };
-
-            List<BasicData> bdList = basicData.OrderBy(x => x.Date).ToList();
+            List<QuoteD> quotesList = quotes
+                .Select(x => new QuoteD
+                {
+                    Date = x.Date,
+                    Open = (double)x.Open,
+                    High = (double)x.High,
+                    Low = (double)x.Low,
+                    Close = (double)x.Close,
+                    Volume = (double)x.Volume
+                })
+                .OrderBy(x => x.Date)
+                .ToList();
 
             // validate
-            return bdList == null || bdList.Count == 0
+            return quotesList == null || quotesList.Count == 0
                 ? throw new BadQuotesException(nameof(quotes), "No historical quotes provided.")
-                : bdList;
+                : quotesList;
         }
 
         // convert to basic double
-        internal static List<BasicDouble> ConvertToBasicDouble<TQuote>(
+        internal static List<BasicD> ConvertToBasic<TQuote>(
             this IEnumerable<TQuote> quotes, CandlePart element = CandlePart.Close)
             where TQuote : IQuote
         {
             // elements represents the targeted OHLCV parts, so use "O" to return <Open> as base data, etc.
             // convert to basic double precision format
-            IEnumerable<BasicDouble> basicDouble = element switch
+            IEnumerable<BasicD> basicDouble = element switch
             {
-                CandlePart.Open => quotes.Select(x => new BasicDouble { Date = x.Date, Value = (double)x.Open }),
-                CandlePart.High => quotes.Select(x => new BasicDouble { Date = x.Date, Value = (double)x.High }),
-                CandlePart.Low => quotes.Select(x => new BasicDouble { Date = x.Date, Value = (double)x.Low }),
-                CandlePart.Close => quotes.Select(x => new BasicDouble { Date = x.Date, Value = (double)x.Close }),
-                CandlePart.Volume => quotes.Select(x => new BasicDouble { Date = x.Date, Value = (double)x.Volume }),
-                _ => new List<BasicDouble>(),
+                CandlePart.Open => quotes.Select(x => new BasicD { Date = x.Date, Value = (double)x.Open }),
+                CandlePart.High => quotes.Select(x => new BasicD { Date = x.Date, Value = (double)x.High }),
+                CandlePart.Low => quotes.Select(x => new BasicD { Date = x.Date, Value = (double)x.Low }),
+                CandlePart.Close => quotes.Select(x => new BasicD { Date = x.Date, Value = (double)x.Close }),
+                CandlePart.Volume => quotes.Select(x => new BasicD { Date = x.Date, Value = (double)x.Volume }),
+                _ => new List<BasicD>(),
             };
 
-            List<BasicDouble> bdList = basicDouble.OrderBy(x => x.Date).ToList();
+            List<BasicD> bdList = basicDouble.OrderBy(x => x.Date).ToList();
 
             // validate
             return bdList == null || bdList.Count == 0

--- a/src/a-d/Adl/Adl.cs
+++ b/src/a-d/Adl/Adl.cs
@@ -15,8 +15,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateAdl(quotes, smaPeriods);
@@ -28,11 +28,11 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < quotesList.Count; i++)
             {
-                TQuote q = quotesList[i];
+                QuoteD q = quotesList[i];
                 int index = i + 1;
 
-                double mfm = (q.High == q.Low) ? 0 : (double)(((q.Close - q.Low) - (q.High - q.Close)) / (q.High - q.Low));
-                double mfv = mfm * (double)q.Volume;
+                double mfm = (q.High == q.Low) ? 0 : ((q.Close - q.Low) - (q.High - q.Close)) / (q.High - q.Low);
+                double mfv = mfm * q.Volume;
                 double adl = mfv + prevAdl;
 
                 AdlResult result = new()

--- a/src/a-d/Adx/Adx.cs
+++ b/src/a-d/Adx/Adx.cs
@@ -15,8 +15,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateAdx(quotes, lookbackPeriods);
@@ -25,8 +25,8 @@ namespace Skender.Stock.Indicators
             List<AdxResult> results = new(quotesList.Count);
             List<AtrResult> atr = GetAtr(quotes, lookbackPeriods).ToList(); // get True Range info
 
-            decimal prevHigh = 0;
-            decimal prevLow = 0;
+            double prevHigh = 0;
+            double prevLow = 0;
             double prevTrs = 0; // smoothed
             double prevPdm = 0;
             double prevMdm = 0;
@@ -40,7 +40,7 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < quotesList.Count; i++)
             {
-                TQuote q = quotesList[i];
+                QuoteD q = quotesList[i];
                 int index = i + 1;
 
                 AdxResult result = new()
@@ -60,10 +60,10 @@ namespace Skender.Stock.Indicators
                 double tr = (double)atr[i].Tr;
 
                 double pdm1 = (q.High - prevHigh) > (prevLow - q.Low) ?
-                    (double)Math.Max(q.High - prevHigh, 0) : 0;
+                    Math.Max(q.High - prevHigh, 0) : 0;
 
                 double mdm1 = (prevLow - q.Low) > (q.High - prevHigh) ?
-                    (double)Math.Max(prevLow - q.Low, 0) : 0;
+                    Math.Max(prevLow - q.Low, 0) : 0;
 
                 prevHigh = q.High;
                 prevLow = q.Low;

--- a/src/a-d/Alligator/Alligator.cs
+++ b/src/a-d/Alligator/Alligator.cs
@@ -14,13 +14,13 @@ namespace Skender.Stock.Indicators
         {
 
             // convert quotes
-            List<QuoteD> quotesList = quotes.ConvertToList();
+            List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.HL2);
 
             // check parameter arguments
             ValidateAlligator(quotes);
 
             // initialize
-            int size = quotesList.Count;
+            int size = bdList.Count;
             double[] pr = new double[size]; // median price
 
             int jawLookback = 13;
@@ -31,7 +31,7 @@ namespace Skender.Stock.Indicators
             int lipsOffset = 3;
 
             List<AlligatorResult> results =
-                quotesList
+                bdList
                 .Select(x => new AlligatorResult
                 {
                     Date = x.Date
@@ -41,9 +41,9 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < size; i++)
             {
-                QuoteD q = quotesList[i];
+                BasicD q = bdList[i];
                 int index = i + 1;
-                pr[i] = (q.High + q.Low) / 2;
+                pr[i] = q.Value;
 
                 // only calculate jaw if the array index + offset is still in valid range
                 if (i + jawOffset < size)

--- a/src/a-d/Alligator/Alligator.cs
+++ b/src/a-d/Alligator/Alligator.cs
@@ -13,8 +13,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateAlligator(quotes);
@@ -41,9 +41,9 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < size; i++)
             {
-                TQuote q = quotesList[i];
+                QuoteD q = quotesList[i];
                 int index = i + 1;
-                pr[i] = (double)(q.High + q.Low) / 2;
+                pr[i] = (q.High + q.Low) / 2;
 
                 // only calculate jaw if the array index + offset is still in valid range
                 if (i + jawOffset < size)

--- a/src/a-d/Alma/Alma.cs
+++ b/src/a-d/Alma/Alma.cs
@@ -17,8 +17,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateAlma(quotes, lookbackPeriods, offset, sigma);
@@ -43,7 +43,7 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < quotesList.Count; i++)
             {
-                TQuote q = quotesList[i];
+                QuoteD q = quotesList[i];
                 int index = i + 1;
 
                 AlmaResult r = new()
@@ -58,7 +58,7 @@ namespace Skender.Stock.Indicators
 
                     for (int p = index - lookbackPeriods; p < index; p++)
                     {
-                        TQuote d = quotesList[p];
+                        QuoteD d = quotesList[p];
                         weightedSum += weight[n] * (double)d.Close;
                         n++;
                     }

--- a/src/a-d/Alma/Alma.cs
+++ b/src/a-d/Alma/Alma.cs
@@ -18,13 +18,13 @@ namespace Skender.Stock.Indicators
         {
 
             // convert quotes
-            List<QuoteD> quotesList = quotes.ConvertToList();
+            List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Close);
 
             // check parameter arguments
             ValidateAlma(quotes, lookbackPeriods, offset, sigma);
 
             // initialize
-            List<AlmaResult> results = new(quotesList.Count);
+            List<AlmaResult> results = new(bdList.Count);
 
             // determine price weights
             double m = offset * (lookbackPeriods - 1);
@@ -41,9 +41,9 @@ namespace Skender.Stock.Indicators
             }
 
             // roll through quotes
-            for (int i = 0; i < quotesList.Count; i++)
+            for (int i = 0; i < bdList.Count; i++)
             {
-                QuoteD q = quotesList[i];
+                BasicD q = bdList[i];
                 int index = i + 1;
 
                 AlmaResult r = new()
@@ -58,8 +58,8 @@ namespace Skender.Stock.Indicators
 
                     for (int p = index - lookbackPeriods; p < index; p++)
                     {
-                        QuoteD d = quotesList[p];
-                        weightedSum += weight[n] * (double)d.Close;
+                        BasicD d = bdList[p];
+                        weightedSum += weight[n] * d.Value;
                         n++;
                     }
 

--- a/src/a-d/Aroon/Aroon.cs
+++ b/src/a-d/Aroon/Aroon.cs
@@ -16,7 +16,7 @@ namespace Skender.Stock.Indicators
         {
 
             // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            List<TQuote> quotesList = quotes.SortToList();
 
             // check parameter arguments
             ValidateAroon(quotes, lookbackPeriods);

--- a/src/a-d/Aroon/Aroon.cs
+++ b/src/a-d/Aroon/Aroon.cs
@@ -15,8 +15,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.SortToList();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateAroon(quotes, lookbackPeriods);
@@ -27,7 +27,7 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < quotesList.Count; i++)
             {
-                TQuote q = quotesList[i];
+                QuoteD q = quotesList[i];
                 int index = i + 1;
 
                 AroonResult result = new()
@@ -38,14 +38,14 @@ namespace Skender.Stock.Indicators
                 // add aroons
                 if (index > lookbackPeriods)
                 {
-                    decimal lastHighPrice = 0;
-                    decimal lastLowPrice = decimal.MaxValue;
+                    double lastHighPrice = 0;
+                    double lastLowPrice = double.MaxValue;
                     int lastHighIndex = 0;
                     int lastLowIndex = 0;
 
                     for (int p = index - lookbackPeriods - 1; p < index; p++)
                     {
-                        TQuote d = quotesList[p];
+                        QuoteD d = quotesList[p];
 
                         if (d.High > lastHighPrice)
                         {

--- a/src/a-d/Atr/Atr.cs
+++ b/src/a-d/Atr/Atr.cs
@@ -16,7 +16,7 @@ namespace Skender.Stock.Indicators
         {
 
             // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            List<TQuote> quotesList = quotes.SortToList();
 
             // check parameter arguments
             ValidateAtr(quotes, lookbackPeriods);

--- a/src/a-d/Awesome/Awesome.cs
+++ b/src/a-d/Awesome/Awesome.cs
@@ -17,21 +17,21 @@ namespace Skender.Stock.Indicators
         {
 
             // convert quotes
-            List<QuoteD> quotesList = quotes.ConvertToList();
+            List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.HL2);
 
             // check parameter arguments
             ValidateAwesome(quotes, fastPeriods, slowPeriods);
 
             // initialize
-            int size = quotesList.Count;
+            int size = bdList.Count;
             List<AwesomeResult> results = new();
             double[] pr = new double[size]; // median price
 
             // roll through quotes
             for (int i = 0; i < size; i++)
             {
-                QuoteD q = quotesList[i];
-                pr[i] = (q.High + q.Low) / 2;
+                BasicD q = bdList[i];
+                pr[i] = q.Value;
                 int index = i + 1;
 
                 AwesomeResult r = new()

--- a/src/a-d/Awesome/Awesome.cs
+++ b/src/a-d/Awesome/Awesome.cs
@@ -16,8 +16,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateAwesome(quotes, fastPeriods, slowPeriods);
@@ -30,8 +30,8 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < size; i++)
             {
-                TQuote q = quotesList[i];
-                pr[i] = (double)(q.High + q.Low) / 2;
+                QuoteD q = quotesList[i];
+                pr[i] = (q.High + q.Low) / 2;
                 int index = i + 1;
 
                 AwesomeResult r = new()

--- a/src/a-d/Beta/Beta.cs
+++ b/src/a-d/Beta/Beta.cs
@@ -17,9 +17,9 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesListEval = quotesEval.Sort();
-            List<TQuote> quotesListMrkt = quotesMarket.Sort();
+            // convert quotes
+            List<QuoteD> quotesListEval = quotesEval.ConvertToList();
+            List<QuoteD> quotesListMrkt = quotesMarket.ConvertToList();
 
             // check parameter arguments
             ValidateBeta(quotesMarket, quotesEval, lookbackPeriods);
@@ -33,7 +33,7 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < quotesListEval.Count; i++)
             {
-                TQuote e = quotesListEval[i];
+                QuoteD e = quotesListEval[i];
 
                 BetaResult r = new()
                 {
@@ -97,14 +97,13 @@ namespace Skender.Stock.Indicators
 
 
         // calculate beta
-        private static void CalcBeta<TQuote>(
+        private static void CalcBeta(
             this BetaResult r,
             int index,
             int lookbackPeriods,
-            List<TQuote> quotesListMrkt,
-            List<TQuote> quotesListEval,
+            List<QuoteD> quotesListMrkt,
+            List<QuoteD> quotesListEval,
             BetaType type)
-            where TQuote : IQuote
         {
             // do not supply type==BetaType.All
             if (type is BetaType.All)
@@ -120,8 +119,8 @@ namespace Skender.Stock.Indicators
 
             for (int p = index - lookbackPeriods + 1; p <= index; p++)
             {
-                double a = (double)quotesListMrkt[p].Close;
-                double b = (double)quotesListEval[p].Close;
+                double a = quotesListMrkt[p].Close;
+                double b = quotesListEval[p].Close;
 
                 if (type is BetaType.Standard)
                 {
@@ -129,13 +128,13 @@ namespace Skender.Stock.Indicators
                     dataB.Add(b);
                 }
                 else if (type is BetaType.Down
-                    && a < (double)quotesListMrkt[p - 1].Close)
+                    && a < quotesListMrkt[p - 1].Close)
                 {
                     dataA.Add(a);
                     dataB.Add(b);
                 }
                 else if (type is BetaType.Up
-                    && a > (double)quotesListMrkt[p - 1].Close)
+                    && a > quotesListMrkt[p - 1].Close)
                 {
                     dataA.Add(a);
                     dataB.Add(b);

--- a/src/a-d/BollingerBands/BollingerBands.cs
+++ b/src/a-d/BollingerBands/BollingerBands.cs
@@ -17,19 +17,19 @@ namespace Skender.Stock.Indicators
         {
 
             // convert quotes
-            List<QuoteD> quotesList = quotes.ConvertToList();
+            List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Close);
 
             // check parameter arguments
             ValidateBollingerBands(quotes, lookbackPeriods, standardDeviations);
 
             // initialize
-            List<BollingerBandsResult> results = new(quotesList.Count);
+            List<BollingerBandsResult> results = new(bdList.Count);
 
             // roll through quotes
-            for (int i = 0; i < quotesList.Count; i++)
+            for (int i = 0; i < bdList.Count; i++)
             {
-                QuoteD q = quotesList[i];
-                decimal close = (decimal)q.Close;
+                BasicD q = bdList[i];
+                decimal close = (decimal)q.Value;
                 int index = i + 1;
 
                 BollingerBandsResult r = new()
@@ -45,9 +45,9 @@ namespace Skender.Stock.Indicators
 
                     for (int p = index - lookbackPeriods; p < index; p++)
                     {
-                        QuoteD d = quotesList[p];
-                        periodClose[n] = d.Close;
-                        sum += d.Close;
+                        BasicD d = bdList[p];
+                        periodClose[n] = d.Value;
+                        sum += d.Value;
                         n++;
                     }
 

--- a/src/a-d/BollingerBands/BollingerBands.cs
+++ b/src/a-d/BollingerBands/BollingerBands.cs
@@ -16,8 +16,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateBollingerBands(quotes, lookbackPeriods, standardDeviations);
@@ -28,7 +28,8 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < quotesList.Count; i++)
             {
-                TQuote q = quotesList[i];
+                QuoteD q = quotesList[i];
+                decimal close = (decimal)q.Close;
                 int index = i + 1;
 
                 BollingerBandsResult r = new()
@@ -44,10 +45,9 @@ namespace Skender.Stock.Indicators
 
                     for (int p = index - lookbackPeriods; p < index; p++)
                     {
-                        TQuote d = quotesList[p];
-                        double close = (double)d.Close;
-                        periodClose[n] = close;
-                        sum += close;
+                        QuoteD d = quotesList[p];
+                        periodClose[n] = d.Close;
+                        sum += d.Close;
                         n++;
                     }
 
@@ -59,9 +59,9 @@ namespace Skender.Stock.Indicators
                     r.LowerBand = (decimal)(periodAvg - standardDeviations * stdDev);
 
                     r.PercentB = (r.UpperBand == r.LowerBand) ? null
-                        : (double)((q.Close - r.LowerBand) / (r.UpperBand - r.LowerBand));
+                        : (double)((close - r.LowerBand) / (r.UpperBand - r.LowerBand));
 
-                    r.ZScore = (stdDev == 0) ? null : (double)(q.Close - r.Sma) / stdDev;
+                    r.ZScore = (stdDev == 0) ? null : (double)(close - r.Sma) / stdDev;
                     r.Width = (periodAvg == 0) ? null : (double)(r.UpperBand - r.LowerBand) / periodAvg;
                 }
 

--- a/src/a-d/Bop/Bop.cs
+++ b/src/a-d/Bop/Bop.cs
@@ -15,8 +15,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateBop(quotes, smoothPeriods);

--- a/src/a-d/Cci/Cci.cs
+++ b/src/a-d/Cci/Cci.cs
@@ -15,8 +15,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateCci(quotes, lookbackPeriods);
@@ -27,7 +27,7 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < quotesList.Count; i++)
             {
-                TQuote q = quotesList[i];
+                QuoteD q = quotesList[i];
                 int index = i + 1;
 
                 CciResult result = new()

--- a/src/a-d/Cci/Cci.cs
+++ b/src/a-d/Cci/Cci.cs
@@ -33,7 +33,7 @@ namespace Skender.Stock.Indicators
                 CciResult result = new()
                 {
                     Date = q.Date,
-                    Tp = (double?)(q.High + q.Low + q.Close) / 3
+                    Tp = (q.High + q.Low + q.Close) / 3
                 };
                 results.Add(result);
 

--- a/src/a-d/ChaikinOsc/ChaikinOsc.cs
+++ b/src/a-d/ChaikinOsc/ChaikinOsc.cs
@@ -31,12 +31,12 @@ namespace Skender.Stock.Indicators
                 .ToList();
 
             // EMA of ADL
-            List<BasicD> adlBasicData = results
+            List<BasicD> bdAdl = results
                 .Select(x => new BasicD { Date = x.Date, Value = x.Adl })
                 .ToList();
 
-            List<EmaResult> adlEmaSlow = CalcEma(adlBasicData, slowPeriods);
-            List<EmaResult> adlEmaFast = CalcEma(adlBasicData, fastPeriods);
+            List<EmaResult> adlEmaSlow = CalcEma(bdAdl, slowPeriods);
+            List<EmaResult> adlEmaFast = CalcEma(bdAdl, fastPeriods);
 
             // add Oscillator
             for (int i = slowPeriods - 1; i < results.Count; i++)

--- a/src/a-d/ChaikinOsc/ChaikinOsc.cs
+++ b/src/a-d/ChaikinOsc/ChaikinOsc.cs
@@ -31,8 +31,8 @@ namespace Skender.Stock.Indicators
                 .ToList();
 
             // EMA of ADL
-            List<BasicDouble> adlBasicData = results
-                .Select(x => new BasicDouble { Date = x.Date, Value = x.Adl })
+            List<BasicD> adlBasicData = results
+                .Select(x => new BasicD { Date = x.Date, Value = x.Adl })
                 .ToList();
 
             List<EmaResult> adlEmaSlow = CalcEma(adlBasicData, slowPeriods);

--- a/src/a-d/Chandelier/Chandelier.cs
+++ b/src/a-d/Chandelier/Chandelier.cs
@@ -12,13 +12,13 @@ namespace Skender.Stock.Indicators
         public static IEnumerable<ChandelierResult> GetChandelier<TQuote>(
             this IEnumerable<TQuote> quotes,
             int lookbackPeriods = 22,
-            decimal multiplier = 3.0m,
+            double multiplier = 3,
             ChandelierType type = ChandelierType.Long)
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateChandelier(quotes, lookbackPeriods, multiplier);
@@ -30,7 +30,7 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < quotesList.Count; i++)
             {
-                TQuote q = quotesList[i];
+                QuoteD q = quotesList[i];
                 int index = i + 1;
 
                 ChandelierResult result = new()
@@ -42,38 +42,38 @@ namespace Skender.Stock.Indicators
                 if (index >= lookbackPeriods)
                 {
 
-                    decimal atr = (decimal)atrResult[i].Atr;
+                    double? atr = (double?)atrResult[i].Atr;
 
                     switch (type)
                     {
                         case ChandelierType.Long:
 
-                            decimal maxHigh = 0;
+                            double maxHigh = 0;
                             for (int p = index - lookbackPeriods; p < index; p++)
                             {
-                                TQuote d = quotesList[p];
+                                QuoteD d = quotesList[p];
                                 if (d.High > maxHigh)
                                 {
                                     maxHigh = d.High;
                                 }
                             }
 
-                            result.ChandelierExit = maxHigh - atr * multiplier;
+                            result.ChandelierExit = (decimal?)(maxHigh - atr * multiplier);
                             break;
 
                         case ChandelierType.Short:
 
-                            decimal minLow = decimal.MaxValue;
+                            double minLow = double.MaxValue;
                             for (int p = index - lookbackPeriods; p < index; p++)
                             {
-                                TQuote d = quotesList[p];
+                                QuoteD d = quotesList[p];
                                 if (d.Low < minLow)
                                 {
                                     minLow = d.Low;
                                 }
                             }
 
-                            result.ChandelierExit = minLow + atr * multiplier;
+                            result.ChandelierExit = (decimal?)(minLow + atr * multiplier);
                             break;
 
                         default:
@@ -106,7 +106,7 @@ namespace Skender.Stock.Indicators
         private static void ValidateChandelier<TQuote>(
             IEnumerable<TQuote> quotes,
             int lookbackPeriods,
-            decimal multiplier)
+            double multiplier)
             where TQuote : IQuote
         {
 

--- a/src/a-d/Chop/Chop.cs
+++ b/src/a-d/Chop/Chop.cs
@@ -15,8 +15,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateChop(quotesList, lookbackPeriods);
@@ -44,8 +44,8 @@ namespace Skender.Stock.Indicators
 
                 if (i > 0)
                 {
-                    trueHigh[i] = (double)Math.Max(quotesList[i].High, quotesList[i - 1].Close);
-                    trueLow[i] = (double)Math.Min(quotesList[i].Low, quotesList[i - 1].Close);
+                    trueHigh[i] = Math.Max(quotesList[i].High, quotesList[i - 1].Close);
+                    trueLow[i] = Math.Min(quotesList[i].Low, quotesList[i - 1].Close);
                     trueRange[i] = trueHigh[i] - trueLow[i];
 
                     // calculate CHOP
@@ -94,11 +94,9 @@ namespace Skender.Stock.Indicators
 
 
         // parameter validation
-        private static void ValidateChop<TQuote>(
-            List<TQuote> quotes,
+        private static void ValidateChop(
+            List<QuoteD> quotes,
             int lookbackPeriods)
-            where TQuote : IQuote
-
         {
             // check parameter arguments
             if (lookbackPeriods <= 1)

--- a/src/a-d/Cmf/Cmf.cs
+++ b/src/a-d/Cmf/Cmf.cs
@@ -15,14 +15,14 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Volume);
 
             // check parameter arguments
             ValidateCmf(quotes, lookbackPeriods);
 
             // initialize
-            List<CmfResult> results = new(quotesList.Count);
+            List<CmfResult> results = new(bdList.Count);
             List<AdlResult> adlResults = GetAdl(quotes).ToList();
 
             // roll through quotes
@@ -45,8 +45,8 @@ namespace Skender.Stock.Indicators
 
                     for (int p = index - lookbackPeriods; p < index; p++)
                     {
-                        TQuote q = quotesList[p];
-                        sumVol += (double)q.Volume;
+                        BasicD q = bdList[p];
+                        sumVol += q.Value;
 
                         AdlResult d = adlResults[p];
                         sumMfv += (double)d.MoneyFlowVolume;

--- a/src/a-d/ConnorsRsi/ConnorsRsi.cs
+++ b/src/a-d/ConnorsRsi/ConnorsRsi.cs
@@ -17,7 +17,7 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // convert quotes to basic format
+            // convert quotes
             List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Close);
 
             // check parameter arguments

--- a/src/a-d/ConnorsRsi/ConnorsRsi.cs
+++ b/src/a-d/ConnorsRsi/ConnorsRsi.cs
@@ -18,7 +18,7 @@ namespace Skender.Stock.Indicators
         {
 
             // convert quotes to basic format
-            List<BasicDouble> bdList = quotes.ConvertToBasicDouble(CandlePart.Close);
+            List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Close);
 
             // check parameter arguments
             ValidateConnorsRsi(bdList, rsiPeriods, streakPeriods, rankPeriods);
@@ -28,9 +28,9 @@ namespace Skender.Stock.Indicators
             int startPeriod = Math.Max(rsiPeriods, Math.Max(streakPeriods, rankPeriods)) + 2;
 
             // RSI of streak
-            List<BasicDouble> bdStreak = results
+            List<BasicD> bdStreak = results
                 .Where(x => x.Streak != null)
-                .Select(x => new BasicDouble { Date = x.Date, Value = (double)x.Streak })
+                .Select(x => new BasicD { Date = x.Date, Value = (double)x.Streak })
                 .ToList();
 
             List<RsiResult> rsiStreakResults = CalcRsi(bdStreak, streakPeriods);
@@ -69,7 +69,7 @@ namespace Skender.Stock.Indicators
 
         // parameter validation
         private static List<ConnorsRsiResult> CalcConnorsRsiBaseline(
-            List<BasicDouble> bdList, int rsiPeriods, int rankPeriods)
+            List<BasicD> bdList, int rsiPeriods, int rankPeriods)
         {
             // initialize
             List<RsiResult> rsiResults = CalcRsi(bdList, rsiPeriods);
@@ -84,7 +84,7 @@ namespace Skender.Stock.Indicators
             // compose interim results
             for (int i = 0; i < size; i++)
             {
-                BasicDouble q = bdList[i];
+                BasicD q = bdList[i];
                 int index = i + 1;
 
                 ConnorsRsiResult r = new()
@@ -157,7 +157,7 @@ namespace Skender.Stock.Indicators
 
 
         private static void ValidateConnorsRsi(
-            IEnumerable<BasicDouble> quotes,
+            IEnumerable<BasicD> quotes,
             int rsiPeriods,
             int streakPeriods,
             int rankPeriods)

--- a/src/a-d/Correlation/Correlation.cs
+++ b/src/a-d/Correlation/Correlation.cs
@@ -17,20 +17,20 @@ namespace Skender.Stock.Indicators
         {
 
             // convert quotes
-            List<QuoteD> quotesListA = quotesA.ConvertToList();
-            List<QuoteD> quotesListB = quotesB.ConvertToList();
+            List<BasicD> bdListA = quotesA.ConvertToBasic(CandlePart.Close);
+            List<BasicD> bdListB = quotesB.ConvertToBasic(CandlePart.Close);
 
             // check parameter arguments
             ValidateCorrelation(quotesA, quotesB, lookbackPeriods);
 
             // initialize
-            List<CorrResult> results = new(quotesListA.Count);
+            List<CorrResult> results = new(bdListA.Count);
 
             // roll through quotes
-            for (int i = 0; i < quotesListA.Count; i++)
+            for (int i = 0; i < bdListA.Count; i++)
             {
-                QuoteD a = quotesListA[i];
-                QuoteD b = quotesListB[i];
+                BasicD a = bdListA[i];
+                BasicD b = bdListB[i];
                 int index = i + 1;
 
                 if (a.Date != b.Date)
@@ -53,8 +53,8 @@ namespace Skender.Stock.Indicators
 
                     for (int p = index - lookbackPeriods; p < index; p++)
                     {
-                        dataA[z] = quotesListA[p].Close;
-                        dataB[z] = quotesListB[p].Close;
+                        dataA[z] = bdListA[p].Value;
+                        dataB[z] = bdListB[p].Value;
 
                         z++;
                     }

--- a/src/a-d/Correlation/Correlation.cs
+++ b/src/a-d/Correlation/Correlation.cs
@@ -16,9 +16,9 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesListA = quotesA.Sort();
-            List<TQuote> quotesListB = quotesB.Sort();
+            // convert quotes
+            List<QuoteD> quotesListA = quotesA.ConvertToList();
+            List<QuoteD> quotesListB = quotesB.ConvertToList();
 
             // check parameter arguments
             ValidateCorrelation(quotesA, quotesB, lookbackPeriods);
@@ -29,8 +29,8 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < quotesListA.Count; i++)
             {
-                TQuote a = quotesListA[i];
-                TQuote b = quotesListB[i];
+                QuoteD a = quotesListA[i];
+                QuoteD b = quotesListB[i];
                 int index = i + 1;
 
                 if (a.Date != b.Date)
@@ -53,8 +53,8 @@ namespace Skender.Stock.Indicators
 
                     for (int p = index - lookbackPeriods; p < index; p++)
                     {
-                        dataA[z] = (double)quotesListA[p].Close;
-                        dataB[z] = (double)quotesListB[p].Close;
+                        dataA[z] = quotesListA[p].Close;
+                        dataB[z] = quotesListB[p].Close;
 
                         z++;
                     }

--- a/src/a-d/Donchian/Donchian.cs
+++ b/src/a-d/Donchian/Donchian.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -16,7 +16,7 @@ namespace Skender.Stock.Indicators
         {
 
             // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            List<TQuote> quotesList = quotes.SortToList();
 
             // check parameter arguments
             ValidateDonchian(quotes, lookbackPeriods);

--- a/src/a-d/DoubleEma/DoubleEma.cs
+++ b/src/a-d/DoubleEma/DoubleEma.cs
@@ -15,7 +15,7 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // convert quotes to basic format
+            // convert quotes
             List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Close);
 
             // check parameter arguments

--- a/src/a-d/DoubleEma/DoubleEma.cs
+++ b/src/a-d/DoubleEma/DoubleEma.cs
@@ -16,7 +16,7 @@ namespace Skender.Stock.Indicators
         {
 
             // convert quotes to basic format
-            List<BasicDouble> bdList = quotes.ConvertToBasicDouble(CandlePart.Close);
+            List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Close);
 
             // check parameter arguments
             ValidateDema(bdList, lookbackPeriods);
@@ -25,9 +25,9 @@ namespace Skender.Stock.Indicators
             List<DemaResult> results = new(bdList.Count);
             List<EmaResult> emaN = CalcEma(bdList, lookbackPeriods);
 
-            List<BasicDouble> bd2 = emaN
+            List<BasicD> bd2 = emaN
                 .Where(x => x.Ema != null)
-                .Select(x => new BasicDouble { Date = x.Date, Value = (double)x.Ema })
+                .Select(x => new BasicD { Date = x.Date, Value = (double)x.Ema })
                 .ToList();  // note: ToList seems to be required when changing data
 
             List<EmaResult> emaN2 = CalcEma(bd2, lookbackPeriods);
@@ -72,7 +72,7 @@ namespace Skender.Stock.Indicators
 
         // parameter validation
         private static void ValidateDema(
-            IEnumerable<BasicDouble> quotes,
+            IEnumerable<BasicD> quotes,
             int lookbackPeriods)
         {
 

--- a/src/a-d/Dpo/Dpo.cs
+++ b/src/a-d/Dpo/Dpo.cs
@@ -16,7 +16,7 @@ namespace Skender.Stock.Indicators
         {
 
             // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            List<TQuote> quotesList = quotes.SortToList();
 
             // check parameter arguments
             ValidateDpo(quotes, lookbackPeriods);

--- a/src/e-k/ElderRay/ElderRay.cs
+++ b/src/e-k/ElderRay/ElderRay.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -16,7 +16,7 @@ namespace Skender.Stock.Indicators
         {
 
             // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            List<TQuote> quotesList = quotes.SortToList();
 
             // check parameter arguments
             ValidateElderRay(quotes, lookbackPeriods);

--- a/src/e-k/Ema/Ema.cs
+++ b/src/e-k/Ema/Ema.cs
@@ -16,7 +16,7 @@ namespace Skender.Stock.Indicators
         {
 
             // convert quotes to basic format
-            List<BasicDouble> bdList = quotes.ConvertToBasicDouble(CandlePart.Close);
+            List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Close);
 
             // calculate
             return bdList.CalcEma(lookbackPeriods);
@@ -34,7 +34,7 @@ namespace Skender.Stock.Indicators
         {
 
             // convert quotes to basic format
-            List<BasicDouble> bdList = quotes.ConvertToBasicDouble(candlePart);
+            List<BasicD> bdList = quotes.ConvertToBasic(candlePart);
 
             // calculate
             return bdList.CalcEma(lookbackPeriods);
@@ -57,7 +57,7 @@ namespace Skender.Stock.Indicators
 
         // standard calculation
         private static List<EmaResult> CalcEma(
-            this List<BasicDouble> bdList, int lookbackPeriods)
+            this List<BasicD> bdList, int lookbackPeriods)
         {
 
             // check parameter arguments
@@ -78,7 +78,7 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < bdList.Count; i++)
             {
-                BasicDouble h = bdList[i];
+                BasicD h = bdList[i];
                 int index = i + 1;
 
                 EmaResult result = new()
@@ -106,7 +106,7 @@ namespace Skender.Stock.Indicators
 
         // parameter validation
         private static void ValidateEma(
-            List<BasicDouble> quotes,
+            List<BasicD> quotes,
             int lookbackPeriods)
         {
 

--- a/src/e-k/Ema/Ema.cs
+++ b/src/e-k/Ema/Ema.cs
@@ -15,7 +15,7 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // convert quotes to basic format
+            // convert quotes
             List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Close);
 
             // calculate
@@ -33,7 +33,7 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // convert quotes to basic format
+            // convert quotes
             List<BasicD> bdList = quotes.ConvertToBasic(candlePart);
 
             // calculate

--- a/src/e-k/FisherTransform/FisherTransform.cs
+++ b/src/e-k/FisherTransform/FisherTransform.cs
@@ -16,23 +16,23 @@ namespace Skender.Stock.Indicators
         {
 
             // convert quotes
-            List<QuoteD> quotesList = quotes.ConvertToList();
+            List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.HL2);
 
             // check parameter arguments
             ValidateFisherTransform(quotes, lookbackPeriods);
 
             // initialize
-            int size = quotesList.Count;
+            int size = bdList.Count;
             double[] pr = new double[size]; // median price
             double[] xv = new double[size];  // price transform "value"
             List<FisherTransformResult> results = new(size);
 
 
             // roll through quotes
-            for (int i = 0; i < quotesList.Count; i++)
+            for (int i = 0; i < bdList.Count; i++)
             {
-                QuoteD q = quotesList[i];
-                pr[i] = (q.High + q.Low) / 2;
+                BasicD q = bdList[i];
+                pr[i] = q.Value;
 
                 double minPrice = pr[i];
                 double maxPrice = pr[i];

--- a/src/e-k/FisherTransform/FisherTransform.cs
+++ b/src/e-k/FisherTransform/FisherTransform.cs
@@ -15,8 +15,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateFisherTransform(quotes, lookbackPeriods);
@@ -31,8 +31,8 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < quotesList.Count; i++)
             {
-                TQuote q = quotesList[i];
-                pr[i] = (double)(q.High + q.Low) / 2;
+                QuoteD q = quotesList[i];
+                pr[i] = (q.High + q.Low) / 2;
 
                 double minPrice = pr[i];
                 double maxPrice = pr[i];

--- a/src/e-k/ForceIndex/ForceIndex.cs
+++ b/src/e-k/ForceIndex/ForceIndex.cs
@@ -15,8 +15,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateForceIndex(quotes, lookbackPeriods);
@@ -30,9 +30,8 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < size; i++)
             {
-                TQuote q = quotesList[i];
+                QuoteD q = quotesList[i];
                 int index = i + 1;
-                double? close = (double?)q.Close;
 
                 ForceIndexResult r = new()
                 {
@@ -43,13 +42,13 @@ namespace Skender.Stock.Indicators
                 // skip first period
                 if (i == 0)
                 {
-                    prevClose = close;
+                    prevClose = q.Close;
                     continue;
                 }
 
                 // raw Force Index
-                double? rawFI = (double?)q.Volume * (close - prevClose);
-                prevClose = close;
+                double? rawFI = q.Volume * (q.Close - prevClose);
+                prevClose = q.Close;
 
                 // calculate EMA
                 if (index > lookbackPeriods + 1)

--- a/src/e-k/Fractal/Fractal.cs
+++ b/src/e-k/Fractal/Fractal.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -33,7 +33,7 @@ namespace Skender.Stock.Indicators
             ValidateFractal(quotes, Math.Min(leftSpan, rightSpan));
 
             // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            List<TQuote> quotesList = quotes.SortToList();
 
             // initialize
             List<FractalResult> results = new(quotesList.Count);

--- a/src/e-k/HeikinAshi/HeikinAshi.cs
+++ b/src/e-k/HeikinAshi/HeikinAshi.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Skender.Stock.Indicators
@@ -14,7 +14,7 @@ namespace Skender.Stock.Indicators
         {
 
             // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            List<TQuote> quotesList = quotes.SortToList();
 
             // check parameter arguments
             ValidateHeikinAshi(quotes);

--- a/src/e-k/Hma/Hma.cs
+++ b/src/e-k/Hma/Hma.cs
@@ -16,7 +16,7 @@ namespace Skender.Stock.Indicators
         {
 
             // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            List<TQuote> quotesList = quotes.SortToList();
 
             // check parameter arguments
             ValidateHma(quotes, lookbackPeriods);

--- a/src/e-k/HtTrendline/HtTrendline.cs
+++ b/src/e-k/HtTrendline/HtTrendline.cs
@@ -15,13 +15,13 @@ namespace Skender.Stock.Indicators
         {
 
             // convert quotes
-            List<QuoteD> quotesList = quotes.ConvertToList();
+            List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.HL2);
 
             // check parameter arguments
             ValidateHtTrendline(quotes);
 
             // initialize
-            int size = quotesList.Count;
+            int size = bdList.Count;
             List<HtlResult> results = new(size);
 
             double[] pr = new double[size]; // price
@@ -47,8 +47,8 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < size; i++)
             {
-                QuoteD q = quotesList[i];
-                pr[i] = (q.High + q.Low) / 2;
+                BasicD q = bdList[i];
+                pr[i] = q.Value;
 
                 HtlResult r = new()
                 {

--- a/src/e-k/HtTrendline/HtTrendline.cs
+++ b/src/e-k/HtTrendline/HtTrendline.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -14,8 +14,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateHtTrendline(quotes);
@@ -47,8 +47,8 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < size; i++)
             {
-                TQuote q = quotesList[i];
-                pr[i] = (double)(q.High + q.Low) / 2;
+                QuoteD q = quotesList[i];
+                pr[i] = (q.High + q.Low) / 2;
 
                 HtlResult r = new()
                 {

--- a/src/e-k/Hurst/Hurst.cs
+++ b/src/e-k/Hurst/Hurst.cs
@@ -15,22 +15,21 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<BasicD> quotesList =
-                quotes.ConvertToBasic(CandlePart.Close);
+            // convert quotes
+            List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Close);
 
             // check parameter arguments
             ValidateHurst(quotes, lookbackPeriods);
 
             // initialize
-            int size = quotesList.Count;
+            int size = bdList.Count;
             List<HurstResult> results = new(size);
 
             // roll through quotes
             for (int i = 0; i < size; i++)
             {
                 int index = i + 1;
-                BasicD q = quotesList[i];
+                BasicD q = bdList[i];
 
                 HurstResult result = new()
                 {
@@ -46,9 +45,9 @@ namespace Skender.Stock.Indicators
                     for (int p = index - lookbackPeriods; p < index; p++)
                     {
                         // compile return values
-                        if (quotesList[p - 1].Value != 0)
+                        if (bdList[p - 1].Value != 0)
                         {
-                            values[x] = quotesList[p].Value / quotesList[p - 1].Value - 1;
+                            values[x] = bdList[p].Value / bdList[p - 1].Value - 1;
                         }
 
                         x++;

--- a/src/e-k/Hurst/Hurst.cs
+++ b/src/e-k/Hurst/Hurst.cs
@@ -16,8 +16,8 @@ namespace Skender.Stock.Indicators
         {
 
             // sort quotes
-            List<BasicDouble> quotesList =
-                quotes.ConvertToBasicDouble(CandlePart.Close);
+            List<BasicD> quotesList =
+                quotes.ConvertToBasic(CandlePart.Close);
 
             // check parameter arguments
             ValidateHurst(quotes, lookbackPeriods);
@@ -30,7 +30,7 @@ namespace Skender.Stock.Indicators
             for (int i = 0; i < size; i++)
             {
                 int index = i + 1;
-                BasicDouble q = quotesList[i];
+                BasicD q = quotesList[i];
 
                 HurstResult result = new()
                 {

--- a/src/e-k/Ichimoku/Ichimoku.cs
+++ b/src/e-k/Ichimoku/Ichimoku.cs
@@ -55,7 +55,7 @@ namespace Skender.Stock.Indicators
         {
 
             // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            List<TQuote> quotesList = quotes.SortToList();
 
             // check parameter arguments
             ValidateIchimoku(

--- a/src/e-k/Keltner/Keltner.cs
+++ b/src/e-k/Keltner/Keltner.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -18,7 +18,7 @@ namespace Skender.Stock.Indicators
         {
 
             // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            List<TQuote> quotesList = quotes.SortToList();
 
             // check parameter arguments
             ValidateKeltner(quotes, emaPeriods, multiplier, atrPeriods);

--- a/src/e-k/Kvo/Kvo.cs
+++ b/src/e-k/Kvo/Kvo.cs
@@ -17,8 +17,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateKlinger(quotes, fastPeriods, slowPeriods, signalPeriods);
@@ -43,7 +43,7 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < size; i++)
             {
-                TQuote q = quotesList[i];
+                QuoteD q = quotesList[i];
                 int index = i + 1;
 
                 KvoResult r = new()
@@ -53,10 +53,10 @@ namespace Skender.Stock.Indicators
                 results.Add(r);
 
                 // trend basis comparator
-                hlc[i] = (double)(q.High + q.Low + q.Close);
+                hlc[i] = q.High + q.Low + q.Close;
 
                 // daily measurement
-                dm[i] = (double)(q.High - q.Low);
+                dm[i] = q.High - q.Low;
 
                 if (i <= 0)
                 {
@@ -78,8 +78,8 @@ namespace Skender.Stock.Indicators
 
                 // volume force (VF)
                 vf[i] = (dm[i] == cm[i] || q.Volume == 0) ? 0
-                    : (dm[i] == 0) ? (double)q.Volume * 2 * t[i] * 100d
-                    : (cm[i] != 0) ? (double)q.Volume * Math.Abs(2 * (dm[i] / cm[i] - 1)) * t[i] * 100d
+                    : (dm[i] == 0) ? q.Volume * 2d * t[i] * 100d
+                    : (cm[i] != 0) ? q.Volume * Math.Abs(2d * (dm[i] / cm[i] - 1)) * t[i] * 100d
                     : vf[i - 1];
 
                 // fast-period EMA of VF

--- a/src/m-r/Macd/Macd.cs
+++ b/src/m-r/Macd/Macd.cs
@@ -17,7 +17,7 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // convert quotes to basic format
+            // convert quotes
             List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Close);
 
             // check parameter arguments

--- a/src/m-r/Macd/Macd.cs
+++ b/src/m-r/Macd/Macd.cs
@@ -18,7 +18,7 @@ namespace Skender.Stock.Indicators
         {
 
             // convert quotes to basic format
-            List<BasicDouble> bdList = quotes.ConvertToBasicDouble(CandlePart.Close);
+            List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Close);
 
             // check parameter arguments
             ValidateMacd(quotes, fastPeriods, slowPeriods, signalPeriods);
@@ -28,13 +28,13 @@ namespace Skender.Stock.Indicators
             List<EmaResult> emaSlow = CalcEma(bdList, slowPeriods);
 
             int size = bdList.Count;
-            List<BasicDouble> emaDiff = new();
+            List<BasicD> emaDiff = new();
             List<MacdResult> results = new(size);
 
             // roll through quotes
             for (int i = 0; i < size; i++)
             {
-                BasicDouble h = bdList[i];
+                BasicD h = bdList[i];
                 EmaResult df = emaFast[i];
                 EmaResult ds = emaSlow[i];
 
@@ -52,7 +52,7 @@ namespace Skender.Stock.Indicators
                     result.Macd = (decimal)macd;
 
                     // temp data for interim EMA of macd
-                    BasicDouble diff = new()
+                    BasicD diff = new()
                     {
                         Date = h.Date,
                         Value = macd

--- a/src/m-r/Mama/Mama.cs
+++ b/src/m-r/Mama/Mama.cs
@@ -16,8 +16,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateMama(quotes, fastLimit, slowLimit);
@@ -50,8 +50,8 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < size; i++)
             {
-                TQuote q = quotesList[i];
-                pr[i] = (double)(q.High + q.Low) / 2;
+                QuoteD q = quotesList[i];
+                pr[i] = (q.High + q.Low) / 2;
 
                 MamaResult r = new()
                 {

--- a/src/m-r/Mama/Mama.cs
+++ b/src/m-r/Mama/Mama.cs
@@ -17,13 +17,13 @@ namespace Skender.Stock.Indicators
         {
 
             // convert quotes
-            List<QuoteD> quotesList = quotes.ConvertToList();
+            List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.HL2);
 
             // check parameter arguments
             ValidateMama(quotes, fastLimit, slowLimit);
 
             // initialize
-            int size = quotesList.Count;
+            int size = bdList.Count;
             List<MamaResult> results = new(size);
 
             double sumPr = 0d;
@@ -50,8 +50,8 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < size; i++)
             {
-                QuoteD q = quotesList[i];
-                pr[i] = (q.High + q.Low) / 2;
+                BasicD q = bdList[i];
+                pr[i] = q.Value;
 
                 MamaResult r = new()
                 {

--- a/src/m-r/Marubozu/Marubozu.cs
+++ b/src/m-r/Marubozu/Marubozu.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -17,7 +17,7 @@ namespace Skender.Stock.Indicators
             // check parameter arguments
             ValidateMarubozu(quotes, minBodyPercent);
 
-            // sort quotes
+            // convert quotes
             List<Candle> candles = quotes.ConvertToCandles();
 
             // initialize

--- a/src/m-r/Mfi/Mfi.cs
+++ b/src/m-r/Mfi/Mfi.cs
@@ -15,8 +15,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateMfi(quotes, lookbackPeriods);
@@ -33,7 +33,7 @@ namespace Skender.Stock.Indicators
             // roll through quotes, to get preliminary data
             for (int i = 0; i < quotesList.Count; i++)
             {
-                TQuote q = quotesList[i];
+                QuoteD q = quotesList[i];
 
                 MfiResult result = new()
                 {

--- a/src/m-r/Mfi/Mfi.cs
+++ b/src/m-r/Mfi/Mfi.cs
@@ -41,10 +41,10 @@ namespace Skender.Stock.Indicators
                 };
 
                 // true price
-                tp[i] = (double)(q.High + q.Low + q.Close) / 3;
+                tp[i] = (q.High + q.Low + q.Close) / 3;
 
                 // raw money flow
-                mf[i] = tp[i] * (double)q.Volume;
+                mf[i] = tp[i] * q.Volume;
 
                 // direction
                 if (prevTP == null || tp[i] == prevTP)

--- a/src/m-r/Obv/Obv.cs
+++ b/src/m-r/Obv/Obv.cs
@@ -15,8 +15,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateObv(quotes, smaPeriods);
@@ -24,15 +24,14 @@ namespace Skender.Stock.Indicators
             // initialize
             List<ObvResult> results = new(quotesList.Count);
 
-            decimal? prevClose = null;
+            double? prevClose = null;
             double obv = 0;
 
             // roll through quotes
             for (int i = 0; i < quotesList.Count; i++)
             {
-                TQuote q = quotesList[i];
+                QuoteD q = quotesList[i];
                 int index = i + 1;
-                double volume = (double)q.Volume;
 
                 if (prevClose == null || q.Close == prevClose)
                 {
@@ -40,11 +39,11 @@ namespace Skender.Stock.Indicators
                 }
                 else if (q.Close > prevClose)
                 {
-                    obv += volume;
+                    obv += q.Volume;
                 }
                 else if (q.Close < prevClose)
                 {
-                    obv -= volume;
+                    obv -= q.Volume;
                 }
 
                 ObvResult result = new()

--- a/src/m-r/ParabolicSar/ParabolicSar.cs
+++ b/src/m-r/ParabolicSar/ParabolicSar.cs
@@ -32,7 +32,7 @@ namespace Skender.Stock.Indicators
         {
 
             // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            List<TQuote> quotesList = quotes.SortToList();
 
             // check parameter arguments
             ValidateParabolicSar(

--- a/src/m-r/PivotPoints/PivotPoints.cs
+++ b/src/m-r/PivotPoints/PivotPoints.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -17,7 +17,7 @@ namespace Skender.Stock.Indicators
         {
 
             // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            List<TQuote> quotesList = quotes.SortToList();
 
             // check parameter arguments
             ValidatePivotPoints(quotes, windowSize);

--- a/src/m-r/Prs/Prs.cs
+++ b/src/m-r/Prs/Prs.cs
@@ -17,21 +17,21 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> historyBaseList = historyBase.Sort();
-            List<TQuote> historyEvalList = historyEval.Sort();
+            // convert quotes
+            List<QuoteD> quotesBaseList = historyBase.ConvertToList();
+            List<QuoteD> quotesEvalList = historyEval.ConvertToList();
 
             // check parameter arguments
             ValidatePriceRelative(historyBase, historyEval, lookbackPeriods, smaPeriods);
 
             // initialize
-            List<PrsResult> results = new(historyEvalList.Count);
+            List<PrsResult> results = new(quotesEvalList.Count);
 
             // roll through quotes
-            for (int i = 0; i < historyEvalList.Count; i++)
+            for (int i = 0; i < quotesEvalList.Count; i++)
             {
-                TQuote bi = historyBaseList[i];
-                TQuote ei = historyEvalList[i];
+                QuoteD bi = quotesBaseList[i];
+                QuoteD ei = quotesEvalList[i];
                 int index = i + 1;
 
                 if (ei.Date != bi.Date)
@@ -49,13 +49,13 @@ namespace Skender.Stock.Indicators
 
                 if (lookbackPeriods != null && index > lookbackPeriods)
                 {
-                    TQuote bo = historyBaseList[i - (int)lookbackPeriods];
-                    TQuote eo = historyEvalList[i - (int)lookbackPeriods];
+                    QuoteD bo = quotesBaseList[i - (int)lookbackPeriods];
+                    QuoteD eo = quotesEvalList[i - (int)lookbackPeriods];
 
                     if (bo.Close != 0 && eo.Close != 0)
                     {
-                        double pctB = (double)((bi.Close - bo.Close) / bo.Close);
-                        double pctE = (double)((ei.Close - eo.Close) / eo.Close);
+                        double pctB = (bi.Close - bo.Close) / bo.Close;
+                        double pctE = (ei.Close - eo.Close) / eo.Close;
 
                         r.PrsPercent = pctE - pctB;
                     }

--- a/src/m-r/Prs/Prs.cs
+++ b/src/m-r/Prs/Prs.cs
@@ -18,20 +18,20 @@ namespace Skender.Stock.Indicators
         {
 
             // convert quotes
-            List<QuoteD> quotesBaseList = historyBase.ConvertToList();
-            List<QuoteD> quotesEvalList = historyEval.ConvertToList();
+            List<BasicD> bdBaseList = historyBase.ConvertToBasic(CandlePart.Close);
+            List<BasicD> bdEvalList = historyEval.ConvertToBasic(CandlePart.Close);
 
             // check parameter arguments
             ValidatePriceRelative(historyBase, historyEval, lookbackPeriods, smaPeriods);
 
             // initialize
-            List<PrsResult> results = new(quotesEvalList.Count);
+            List<PrsResult> results = new(bdEvalList.Count);
 
             // roll through quotes
-            for (int i = 0; i < quotesEvalList.Count; i++)
+            for (int i = 0; i < bdEvalList.Count; i++)
             {
-                QuoteD bi = quotesBaseList[i];
-                QuoteD ei = quotesEvalList[i];
+                BasicD bi = bdBaseList[i];
+                BasicD ei = bdEvalList[i];
                 int index = i + 1;
 
                 if (ei.Date != bi.Date)
@@ -43,19 +43,19 @@ namespace Skender.Stock.Indicators
                 PrsResult r = new()
                 {
                     Date = ei.Date,
-                    Prs = (bi.Close == 0) ? null : (double)(ei.Close / bi.Close)  // relative strength ratio
+                    Prs = (bi.Value == 0) ? null : (ei.Value / bi.Value)  // relative strength ratio
                 };
                 results.Add(r);
 
                 if (lookbackPeriods != null && index > lookbackPeriods)
                 {
-                    QuoteD bo = quotesBaseList[i - (int)lookbackPeriods];
-                    QuoteD eo = quotesEvalList[i - (int)lookbackPeriods];
+                    BasicD bo = bdBaseList[i - (int)lookbackPeriods];
+                    BasicD eo = bdEvalList[i - (int)lookbackPeriods];
 
-                    if (bo.Close != 0 && eo.Close != 0)
+                    if (bo.Value != 0 && eo.Value != 0)
                     {
-                        double pctB = (bi.Close - bo.Close) / bo.Close;
-                        double pctE = (ei.Close - eo.Close) / eo.Close;
+                        double pctB = (bi.Value - bo.Value) / bo.Value;
+                        double pctE = (ei.Value - eo.Value) / eo.Value;
 
                         r.PrsPercent = pctE - pctB;
                     }

--- a/src/m-r/Pvo/Pvo.cs
+++ b/src/m-r/Pvo/Pvo.cs
@@ -17,7 +17,7 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // convert quotes to basic format
+            // convert quotes
             List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Volume);
 
             // check parameter arguments

--- a/src/m-r/Pvo/Pvo.cs
+++ b/src/m-r/Pvo/Pvo.cs
@@ -18,7 +18,7 @@ namespace Skender.Stock.Indicators
         {
 
             // convert quotes to basic format
-            List<BasicDouble> bdList = quotes.ConvertToBasicDouble(CandlePart.Volume);
+            List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Volume);
 
             // check parameter arguments
             ValidatePvo(quotes, fastPeriods, slowPeriods, signalPeriods);
@@ -28,13 +28,13 @@ namespace Skender.Stock.Indicators
             List<EmaResult> emaSlow = CalcEma(bdList, slowPeriods);
 
             int size = bdList.Count;
-            List<BasicDouble> emaDiff = new();
+            List<BasicD> emaDiff = new();
             List<PvoResult> results = new(size);
 
             // roll through quotes
             for (int i = 0; i < size; i++)
             {
-                BasicDouble h = bdList[i];
+                BasicD h = bdList[i];
                 EmaResult df = emaFast[i];
                 EmaResult ds = emaSlow[i];
 
@@ -52,7 +52,7 @@ namespace Skender.Stock.Indicators
                     result.Pvo = (decimal?)pvo;
 
                     // temp data for interim EMA of PVO
-                    BasicDouble diff = new()
+                    BasicD diff = new()
                     {
                         Date = h.Date,
                         Value = (double)pvo

--- a/src/m-r/Renko/Renko.cs
+++ b/src/m-r/Renko/Renko.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -17,7 +17,7 @@ namespace Skender.Stock.Indicators
         {
 
             // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            List<TQuote> quotesList = quotes.SortToList();
 
             // check parameter arguments
             ValidateRenko(quotes, brickSize);

--- a/src/m-r/Roc/Roc.cs
+++ b/src/m-r/Roc/Roc.cs
@@ -17,18 +17,18 @@ namespace Skender.Stock.Indicators
         {
 
             // convert quotes
-            List<QuoteD> quotesList = quotes.ConvertToList();
+            List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Close);
 
             // check parameter arguments
             ValidateRoc(quotes, lookbackPeriods, smaPeriods);
 
             // initialize
-            List<RocResult> results = new(quotesList.Count);
+            List<RocResult> results = new(bdList.Count);
 
             // roll through quotes
-            for (int i = 0; i < quotesList.Count; i++)
+            for (int i = 0; i < bdList.Count; i++)
             {
-                QuoteD q = quotesList[i];
+                BasicD q = bdList[i];
                 int index = i + 1;
 
                 RocResult result = new()
@@ -38,10 +38,10 @@ namespace Skender.Stock.Indicators
 
                 if (index > lookbackPeriods)
                 {
-                    QuoteD back = quotesList[index - lookbackPeriods - 1];
+                    BasicD back = bdList[index - lookbackPeriods - 1];
 
-                    result.Roc = (back.Close == 0) ? null
-                        : 100d * (q.Close - back.Close) / back.Close;
+                    result.Roc = (back.Value == 0) ? null
+                        : 100d * (q.Value - back.Value) / back.Value;
                 }
 
                 results.Add(result);

--- a/src/m-r/Roc/Roc.cs
+++ b/src/m-r/Roc/Roc.cs
@@ -16,8 +16,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateRoc(quotes, lookbackPeriods, smaPeriods);
@@ -28,7 +28,7 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < quotesList.Count; i++)
             {
-                TQuote q = quotesList[i];
+                QuoteD q = quotesList[i];
                 int index = i + 1;
 
                 RocResult result = new()
@@ -38,10 +38,10 @@ namespace Skender.Stock.Indicators
 
                 if (index > lookbackPeriods)
                 {
-                    TQuote back = quotesList[index - lookbackPeriods - 1];
+                    QuoteD back = quotesList[index - lookbackPeriods - 1];
 
                     result.Roc = (back.Close == 0) ? null
-                        : 100 * (double)((q.Close - back.Close) / back.Close);
+                        : 100d * (q.Close - back.Close) / back.Close;
                 }
 
                 results.Add(result);

--- a/src/m-r/RollingPivots/RollingPivots.cs
+++ b/src/m-r/RollingPivots/RollingPivots.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -18,7 +18,7 @@ namespace Skender.Stock.Indicators
         {
 
             // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            List<TQuote> quotesList = quotes.SortToList();
 
             // check parameter arguments
             ValidateRollingPivots(quotes, windowPeriods, offsetPeriods);

--- a/src/m-r/Rsi/Rsi.cs
+++ b/src/m-r/Rsi/Rsi.cs
@@ -16,7 +16,7 @@ namespace Skender.Stock.Indicators
         {
 
             // convert quotes to basic format
-            List<BasicDouble> bdList = quotes.ConvertToBasicDouble(CandlePart.Close);
+            List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Close);
 
             // calculate
             return CalcRsi(bdList, lookbackPeriods);
@@ -57,7 +57,7 @@ namespace Skender.Stock.Indicators
 
 
         // internals
-        private static List<RsiResult> CalcRsi(List<BasicDouble> bdList, int lookbackPeriods)
+        private static List<RsiResult> CalcRsi(List<BasicD> bdList, int lookbackPeriods)
         {
 
             // check parameter arguments
@@ -76,7 +76,7 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < bdList.Count; i++)
             {
-                BasicDouble h = bdList[i];
+                BasicD h = bdList[i];
                 int index = i + 1;
 
                 RsiResult r = new()
@@ -130,7 +130,7 @@ namespace Skender.Stock.Indicators
 
         // parameter validation
         private static void ValidateRsi(
-            List<BasicDouble> quotes,
+            List<BasicD> quotes,
             int lookbackPeriods)
         {
 

--- a/src/m-r/Rsi/Rsi.cs
+++ b/src/m-r/Rsi/Rsi.cs
@@ -15,7 +15,7 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // convert quotes to basic format
+            // convert quotes
             List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Close);
 
             // calculate

--- a/src/s-z/Slope/Slope.cs
+++ b/src/s-z/Slope/Slope.cs
@@ -15,8 +15,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateSlope(quotes, lookbackPeriods);
@@ -28,7 +28,7 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < size; i++)
             {
-                TQuote q = quotesList[i];
+                QuoteD q = quotesList[i];
                 int index = i + 1;
 
                 SlopeResult r = new()
@@ -50,10 +50,10 @@ namespace Skender.Stock.Indicators
 
                 for (int p = index - lookbackPeriods; p < index; p++)
                 {
-                    TQuote d = quotesList[p];
+                    QuoteD d = quotesList[p];
 
                     sumX += p + 1d;
-                    sumY += (double)d.Close;
+                    sumY += d.Close;
                 }
 
                 double avgX = sumX / lookbackPeriods;
@@ -66,10 +66,10 @@ namespace Skender.Stock.Indicators
 
                 for (int p = index - lookbackPeriods; p < index; p++)
                 {
-                    TQuote d = quotesList[p];
+                    QuoteD d = quotesList[p];
 
                     double devX = (p + 1d - avgX);
-                    double devY = ((double)d.Close - avgY);
+                    double devY = (d.Close - avgY);
 
                     sumSqX += devX * devX;
                     sumSqY += devY * devY;

--- a/src/s-z/Slope/Slope.cs
+++ b/src/s-z/Slope/Slope.cs
@@ -16,19 +16,19 @@ namespace Skender.Stock.Indicators
         {
 
             // convert quotes
-            List<QuoteD> quotesList = quotes.ConvertToList();
+            List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Close);
 
             // check parameter arguments
             ValidateSlope(quotes, lookbackPeriods);
 
             // initialize
-            int size = quotesList.Count;
+            int size = bdList.Count;
             List<SlopeResult> results = new(size);
 
             // roll through quotes
             for (int i = 0; i < size; i++)
             {
-                QuoteD q = quotesList[i];
+                BasicD q = bdList[i];
                 int index = i + 1;
 
                 SlopeResult r = new()
@@ -50,10 +50,10 @@ namespace Skender.Stock.Indicators
 
                 for (int p = index - lookbackPeriods; p < index; p++)
                 {
-                    QuoteD d = quotesList[p];
+                    BasicD d = bdList[p];
 
                     sumX += p + 1d;
-                    sumY += d.Close;
+                    sumY += d.Value;
                 }
 
                 double avgX = sumX / lookbackPeriods;
@@ -66,10 +66,10 @@ namespace Skender.Stock.Indicators
 
                 for (int p = index - lookbackPeriods; p < index; p++)
                 {
-                    QuoteD d = quotesList[p];
+                    BasicD d = bdList[p];
 
                     double devX = (p + 1d - avgX);
-                    double devY = (d.Close - avgY);
+                    double devY = (d.Value - avgY);
 
                     sumSqX += devX * devX;
                     sumSqY += devY * devY;

--- a/src/s-z/Sma/Sma.cs
+++ b/src/s-z/Sma/Sma.cs
@@ -19,7 +19,7 @@ namespace Skender.Stock.Indicators
             ValidateSma(quotes, lookbackPeriods);
 
             // initialize
-            List<BasicDouble> bdList = quotes.ConvertToBasicDouble(CandlePart.Close);
+            List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Close);
 
             // calculate
             return bdList.CalcSma(lookbackPeriods);
@@ -40,7 +40,7 @@ namespace Skender.Stock.Indicators
             ValidateSma(quotes, lookbackPeriods);
 
             // initialize
-            List<BasicDouble> bdList = quotes.ConvertToBasicDouble(candlePart);
+            List<BasicD> bdList = quotes.ConvertToBasic(candlePart);
 
             // calculate
             return bdList.CalcSma(lookbackPeriods);
@@ -63,7 +63,7 @@ namespace Skender.Stock.Indicators
 
         // calculate
         private static IEnumerable<SmaResult> CalcSma(
-            this List<BasicDouble> bdList,
+            this List<BasicD> bdList,
             int lookbackPeriods)
         {
 
@@ -74,7 +74,7 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < bdList.Count; i++)
             {
-                BasicDouble q = bdList[i];
+                BasicD q = bdList[i];
                 int index = i + 1;
 
                 SmaResult result = new()
@@ -87,7 +87,7 @@ namespace Skender.Stock.Indicators
                     double sumSma = 0;
                     for (int p = index - lookbackPeriods; p < index; p++)
                     {
-                        BasicDouble d = bdList[p];
+                        BasicD d = bdList[p];
                         sumSma += d.Value;
                     }
 

--- a/src/s-z/Sma/SmaExtended.cs
+++ b/src/s-z/Sma/SmaExtended.cs
@@ -15,8 +15,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<BasicD> quotesList = quotes.ConvertToBasic(CandlePart.Close);
 
             // initialize
             List<SmaExtendedResult> results = GetSma(quotes, lookbackPeriods)
@@ -36,8 +36,8 @@ namespace Skender.Stock.Indicators
 
                 for (int p = index - lookbackPeriods; p < index; p++)
                 {
-                    TQuote d = quotesList[p];
-                    double close = (double)d.Close;
+                    BasicD d = quotesList[p];
+                    double close = d.Value;
 
                     sumMad += Math.Abs(close - sma);
                     sumMse += (close - sma) * (close - sma);

--- a/src/s-z/Smi/Smi.cs
+++ b/src/s-z/Smi/Smi.cs
@@ -19,8 +19,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateSmi(
@@ -47,7 +47,7 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < size; i++)
             {
-                TQuote q = quotesList[i];
+                QuoteD q = quotesList[i];
                 int index = i + 1;
 
                 SmiResult r = new()
@@ -57,12 +57,12 @@ namespace Skender.Stock.Indicators
 
                 if (index >= lookbackPeriods)
                 {
-                    decimal HH = decimal.MinValue;
-                    decimal LL = decimal.MaxValue;
+                    double HH = double.MinValue;
+                    double LL = double.MaxValue;
 
                     for (int p = index - lookbackPeriods; p < index; p++)
                     {
-                        TQuote x = quotesList[p];
+                        QuoteD x = quotesList[p];
 
                         if (x.High > HH)
                         {
@@ -75,8 +75,8 @@ namespace Skender.Stock.Indicators
                         }
                     }
 
-                    double sm = (double)(q.Close - 0.5m * (HH + LL));
-                    double hl = (double)(HH - LL);
+                    double sm = q.Close - 0.5d * (HH + LL);
+                    double hl = HH - LL;
 
                     // initialize last EMA values
                     if (index == lookbackPeriods)

--- a/src/s-z/Smma/Smma.cs
+++ b/src/s-z/Smma/Smma.cs
@@ -14,8 +14,8 @@ namespace Skender.Stock.Indicators
             int lookbackPeriods)
             where TQuote : IQuote
         {
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<BasicD> quotesList = quotes.ConvertToBasic(CandlePart.Close);
 
             // check parameter arguments
             ValidateSmma(quotes, lookbackPeriods);
@@ -27,7 +27,7 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < quotesList.Count; i++)
             {
-                TQuote q = quotesList[i];
+                BasicD q = quotesList[i];
                 int index = i + 1;
 
                 SmmaResult result = new()
@@ -38,7 +38,7 @@ namespace Skender.Stock.Indicators
                 // calculate SMMA
                 if (index > lookbackPeriods)
                 {
-                    result.Smma = (decimal)(prevValue * (lookbackPeriods - 1) + (double)q.Close)
+                    result.Smma = (decimal)(prevValue * (lookbackPeriods - 1) + q.Value)
                                 / lookbackPeriods;
                 }
 
@@ -48,8 +48,8 @@ namespace Skender.Stock.Indicators
                     double sumClose = 0;
                     for (int p = index - lookbackPeriods; p < index; p++)
                     {
-                        TQuote d = quotesList[p];
-                        sumClose += (double)d.Close;
+                        BasicD d = quotesList[p];
+                        sumClose += d.Value;
                     }
 
                     result.Smma = (decimal)(sumClose / lookbackPeriods);

--- a/src/s-z/Stc/Stc.cs
+++ b/src/s-z/Stc/Stc.cs
@@ -17,8 +17,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<BasicD> quotesList = quotes.ConvertToBasic(CandlePart.Close);
 
             // check parameter arguments
             ValidateStc(quotes, cyclePeriods, fastPeriods, slowPeriods);
@@ -42,7 +42,7 @@ namespace Skender.Stock.Indicators
 
             for (int i = 0; i < slowPeriods - 1; i++)
             {
-                TQuote q = quotesList[i];
+                BasicD q = quotesList[i];
                 results.Add(new StcResult() { Date = q.Date });
             }
 

--- a/src/s-z/StdDev/StdDev.cs
+++ b/src/s-z/StdDev/StdDev.cs
@@ -16,8 +16,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // convert to basic data
-            List<BasicData> bdList = quotes.ConvertToBasic(CandlePart.Close);
+            // convert quotes
+            List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Close);
 
             // calculate
             return CalcStdDev(bdList, lookbackPeriods, smaPeriods);
@@ -40,7 +40,7 @@ namespace Skender.Stock.Indicators
 
         // internals
         private static List<StdDevResult> CalcStdDev(
-            List<BasicData> bdList, int lookbackPeriods, int? smaPeriods = null)
+            List<BasicD> bdList, int lookbackPeriods, int? smaPeriods = null)
         {
 
             // check parameter arguments
@@ -52,7 +52,7 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < bdList.Count; i++)
             {
-                BasicData bd = bdList[i];
+                BasicD bd = bdList[i];
                 int index = i + 1;
 
                 StdDevResult result = new()
@@ -68,9 +68,9 @@ namespace Skender.Stock.Indicators
 
                     for (int p = index - lookbackPeriods; p < index; p++)
                     {
-                        BasicData d = bdList[p];
-                        periodValues[n] = (double)d.Value;
-                        sum += (double)d.Value;
+                        BasicD d = bdList[p];
+                        periodValues[n] = d.Value;
+                        sum += d.Value;
                         n++;
                     }
 
@@ -80,7 +80,7 @@ namespace Skender.Stock.Indicators
                     result.Mean = periodAvg;
 
                     result.ZScore = (result.StdDev == 0) ? null
-                        : ((double)bd.Value - periodAvg) / result.StdDev;
+                        : (bd.Value - periodAvg) / result.StdDev;
                 }
 
                 results.Add(result);
@@ -104,7 +104,7 @@ namespace Skender.Stock.Indicators
 
         // parameter validation
         private static void ValidateStdDev(
-            List<BasicData> quotes,
+            List<BasicD> quotes,
             int lookbackPeriods,
             int? smaPeriods)
         {

--- a/src/s-z/Stoch/Stoch.cs
+++ b/src/s-z/Stoch/Stoch.cs
@@ -36,8 +36,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateStoch(
@@ -51,7 +51,7 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < quotesList.Count; i++)
             {
-                TQuote q = quotesList[i];
+                QuoteD q = quotesList[i];
                 int index = i + 1;
 
                 StochResult result = new()
@@ -66,21 +66,21 @@ namespace Skender.Stock.Indicators
 
                     for (int p = index - lookbackPeriods; p < index; p++)
                     {
-                        TQuote x = quotesList[p];
+                        QuoteD x = quotesList[p];
 
-                        if ((double?)x.High > highHigh)
+                        if (x.High > highHigh)
                         {
-                            highHigh = (double?)x.High;
+                            highHigh = x.High;
                         }
 
-                        if ((double?)x.Low < lowLow)
+                        if (x.Low < lowLow)
                         {
-                            lowLow = (double?)x.Low;
+                            lowLow = x.Low;
                         }
                     }
 
                     result.Oscillator = lowLow != highHigh
-                        ? 100 * (decimal?)(((double?)q.Close - lowLow) / (highHigh - lowLow))
+                        ? 100 * (decimal?)((q.Close - lowLow) / (highHigh - lowLow))
                         : 0;
                 }
                 results.Add(result);

--- a/src/s-z/StochRsi/StochRsi.cs
+++ b/src/s-z/StochRsi/StochRsi.cs
@@ -38,7 +38,9 @@ namespace Skender.Stock.Indicators
                 .ToList();
 
             // get Stochastic of RSI
-            List<StochResult> stoResults = GetStoch(rsiQuotes, stochPeriods, signalPeriods, smoothPeriods).ToList();
+            List<StochResult> stoResults =
+                GetStoch(rsiQuotes, stochPeriods, signalPeriods, smoothPeriods)
+                .ToList();
 
             // compose
             for (int i = 0; i < rsiResults.Count; i++)

--- a/src/s-z/SuperTrend/SuperTrend.cs
+++ b/src/s-z/SuperTrend/SuperTrend.cs
@@ -16,8 +16,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateSuperTrend(quotes, lookbackPeriods, multiplier);
@@ -33,7 +33,7 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < quotesList.Count; i++)
             {
-                TQuote q = quotesList[i];
+                QuoteD q = quotesList[i];
 
                 SuperTrendResult r = new()
                 {
@@ -43,9 +43,9 @@ namespace Skender.Stock.Indicators
                 if (i >= lookbackPeriods - 1)
                 {
 
-                    double mid = (double)(q.High + q.Low) / 2;
+                    double mid = (q.High + q.Low) / 2;
                     double atr = (double)atrResults[i].Atr;
-                    double prevClose = (double)quotesList[i - 1].Close;
+                    double prevClose = quotesList[i - 1].Close;
 
                     // potential bands
                     double upperEval = mid + multiplier * atr;
@@ -54,7 +54,7 @@ namespace Skender.Stock.Indicators
                     // initial values
                     if (i == lookbackPeriods - 1)
                     {
-                        isBullish = ((double)q.Close >= mid);
+                        isBullish = (q.Close >= mid);
 
                         upperBand = upperEval;
                         lowerBand = lowerEval;
@@ -73,7 +73,7 @@ namespace Skender.Stock.Indicators
                     }
 
                     // supertrend
-                    if ((double)q.Close <= ((isBullish) ? lowerBand : upperBand))
+                    if (q.Close <= ((isBullish) ? lowerBand : upperBand))
                     {
                         r.SuperTrend = (decimal?)upperBand;
                         r.UpperBand = (decimal?)upperBand;

--- a/src/s-z/T3/T3.cs
+++ b/src/s-z/T3/T3.cs
@@ -16,8 +16,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateT3(quotes, lookbackPeriods, volumeFactor);
@@ -39,7 +39,7 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < size; i++)
             {
-                TQuote q = quotesList[i];
+                QuoteD q = quotesList[i];
                 T3Result r = new()
                 {
                     Date = q.Date
@@ -48,7 +48,7 @@ namespace Skender.Stock.Indicators
                 // first smoothing
                 if (i > lookbackPeriods - 1)
                 {
-                    e1 += k * ((double)q.Close - e1);
+                    e1 += k * (q.Close - e1);
 
                     // second smoothing
                     if (i > 2 * (lookbackPeriods - 1))

--- a/src/s-z/T3/T3.cs
+++ b/src/s-z/T3/T3.cs
@@ -17,13 +17,13 @@ namespace Skender.Stock.Indicators
         {
 
             // convert quotes
-            List<QuoteD> quotesList = quotes.ConvertToList();
+            List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Close);
 
             // check parameter arguments
             ValidateT3(quotes, lookbackPeriods, volumeFactor);
 
             // initialize
-            int size = quotesList.Count;
+            int size = bdList.Count;
             List<T3Result> results = new(size);
 
             double k = 2d / (lookbackPeriods + 1);
@@ -39,7 +39,7 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < size; i++)
             {
-                QuoteD q = quotesList[i];
+                BasicD q = bdList[i];
                 T3Result r = new()
                 {
                     Date = q.Date
@@ -48,7 +48,7 @@ namespace Skender.Stock.Indicators
                 // first smoothing
                 if (i > lookbackPeriods - 1)
                 {
-                    e1 += k * (q.Close - e1);
+                    e1 += k * (q.Value - e1);
 
                     // second smoothing
                     if (i > 2 * (lookbackPeriods - 1))
@@ -145,7 +145,7 @@ namespace Skender.Stock.Indicators
                 // first warmup
                 else
                 {
-                    sum1 += (double)q.Close;
+                    sum1 += (double)q.Value;
 
                     if (i == lookbackPeriods - 1)
                     {

--- a/src/s-z/TripleEma/TripleEma.cs
+++ b/src/s-z/TripleEma/TripleEma.cs
@@ -15,7 +15,7 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // convert quotes to basic format
+            // convert quotes
             List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Close);
 
             // check parameter arguments

--- a/src/s-z/TripleEma/TripleEma.cs
+++ b/src/s-z/TripleEma/TripleEma.cs
@@ -16,7 +16,7 @@ namespace Skender.Stock.Indicators
         {
 
             // convert quotes to basic format
-            List<BasicDouble> bdList = quotes.ConvertToBasicDouble(CandlePart.Close);
+            List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Close);
 
             // check parameter arguments
             ValidateTema(bdList, lookbackPeriods);
@@ -25,16 +25,16 @@ namespace Skender.Stock.Indicators
             List<TemaResult> results = new(bdList.Count);
             List<EmaResult> emaN1 = CalcEma(bdList, lookbackPeriods);
 
-            List<BasicDouble> bd2 = emaN1
+            List<BasicD> bd2 = emaN1
                 .Where(x => x.Ema != null)
-                .Select(x => new BasicDouble { Date = x.Date, Value = (double)x.Ema })
+                .Select(x => new BasicD { Date = x.Date, Value = (double)x.Ema })
                 .ToList();
 
             List<EmaResult> emaN2 = CalcEma(bd2, lookbackPeriods);
 
-            List<BasicDouble> bd3 = emaN2
+            List<BasicD> bd3 = emaN2
                 .Where(x => x.Ema != null)
-                .Select(x => new BasicDouble { Date = x.Date, Value = (double)x.Ema })
+                .Select(x => new BasicD { Date = x.Date, Value = (double)x.Ema })
                 .ToList();
 
             List<EmaResult> emaN3 = CalcEma(bd3, lookbackPeriods);
@@ -81,7 +81,7 @@ namespace Skender.Stock.Indicators
 
         // parameter validation
         private static void ValidateTema(
-            IEnumerable<BasicDouble> quotes,
+            IEnumerable<BasicD> quotes,
             int lookbackPeriods)
         {
 

--- a/src/s-z/Trix/Trix.cs
+++ b/src/s-z/Trix/Trix.cs
@@ -17,7 +17,7 @@ namespace Skender.Stock.Indicators
         {
 
             // convert quotes to basic format
-            List<BasicDouble> bdList = quotes.ConvertToBasicDouble(CandlePart.Close);
+            List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Close);
 
             // check parameter arguments
             ValidateTrix(bdList, lookbackPeriods);
@@ -28,16 +28,16 @@ namespace Skender.Stock.Indicators
 
             List<EmaResult> emaN1 = CalcEma(bdList, lookbackPeriods);
 
-            List<BasicDouble> bd2 = emaN1
+            List<BasicD> bd2 = emaN1
                 .Where(x => x.Ema != null)
-                .Select(x => new BasicDouble { Date = x.Date, Value = (double)x.Ema })
+                .Select(x => new BasicD { Date = x.Date, Value = (double)x.Ema })
                 .ToList();
 
             List<EmaResult> emaN2 = CalcEma(bd2, lookbackPeriods);
 
-            List<BasicDouble> bd3 = emaN2
+            List<BasicD> bd3 = emaN2
                 .Where(x => x.Ema != null)
-                .Select(x => new BasicDouble { Date = x.Date, Value = (double)x.Ema })
+                .Select(x => new BasicD { Date = x.Date, Value = (double)x.Ema })
                 .ToList();
 
             List<EmaResult> emaN3 = CalcEma(bd3, lookbackPeriods);
@@ -111,7 +111,7 @@ namespace Skender.Stock.Indicators
 
         // parameter validation
         private static void ValidateTrix(
-            IEnumerable<BasicDouble> quotes,
+            IEnumerable<BasicD> quotes,
             int lookbackPeriods)
         {
 

--- a/src/s-z/Trix/Trix.cs
+++ b/src/s-z/Trix/Trix.cs
@@ -16,7 +16,7 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // convert quotes to basic format
+            // convert quotes
             List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Close);
 
             // check parameter arguments

--- a/src/s-z/Tsi/Tsi.cs
+++ b/src/s-z/Tsi/Tsi.cs
@@ -17,14 +17,14 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<QuoteD> quotesList = quotes.ConvertToList();
+            // convert quotes
+            List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Close);
 
             // check parameter arguments
             ValidateTsi(quotes, lookbackPeriods, smoothPeriods, signalPeriods);
 
             // initialize
-            int size = quotesList.Count;
+            int size = bdList.Count;
             double mult1 = 2d / (lookbackPeriods + 1);
             double mult2 = 2d / (smoothPeriods + 1);
             double multS = 2d / (signalPeriods + 1);
@@ -47,7 +47,7 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < size; i++)
             {
-                QuoteD q = quotesList[i];
+                BasicD q = bdList[i];
                 int index = i + 1;
 
                 TsiResult r = new()
@@ -63,7 +63,7 @@ namespace Skender.Stock.Indicators
                 }
 
                 // price change
-                c[i] = q.Close - quotesList[i - 1].Close;
+                c[i] = q.Value - bdList[i - 1].Value;
                 a[i] = Math.Abs(c[i]);
 
                 // smoothing

--- a/src/s-z/Tsi/Tsi.cs
+++ b/src/s-z/Tsi/Tsi.cs
@@ -18,7 +18,7 @@ namespace Skender.Stock.Indicators
         {
 
             // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateTsi(quotes, lookbackPeriods, smoothPeriods, signalPeriods);
@@ -47,7 +47,7 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < size; i++)
             {
-                TQuote q = quotesList[i];
+                QuoteD q = quotesList[i];
                 int index = i + 1;
 
                 TsiResult r = new()
@@ -63,7 +63,7 @@ namespace Skender.Stock.Indicators
                 }
 
                 // price change
-                c[i] = (double)(q.Close - quotesList[i - 1].Close);
+                c[i] = q.Close - quotesList[i - 1].Close;
                 a[i] = Math.Abs(c[i]);
 
                 // smoothing

--- a/src/s-z/UlcerIndex/UlcerIndex.cs
+++ b/src/s-z/UlcerIndex/UlcerIndex.cs
@@ -15,8 +15,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateUlcer(quotes, lookbackPeriods);
@@ -27,7 +27,7 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < quotesList.Count; i++)
             {
-                TQuote q = quotesList[i];
+                QuoteD q = quotesList[i];
                 int index = i + 1;
 
                 UlcerIndexResult result = new()
@@ -40,13 +40,13 @@ namespace Skender.Stock.Indicators
                     double? sumSquared = 0;
                     for (int p = index - lookbackPeriods; p < index; p++)
                     {
-                        TQuote d = quotesList[p];
+                        QuoteD d = quotesList[p];
                         int dIndex = p + 1;
 
-                        decimal maxClose = 0;
+                        double maxClose = 0;
                         for (int s = index - lookbackPeriods; s < dIndex; s++)
                         {
-                            TQuote dd = quotesList[s];
+                            QuoteD dd = quotesList[s];
                             if (dd.Close > maxClose)
                             {
                                 maxClose = dd.Close;

--- a/src/s-z/UlcerIndex/UlcerIndex.cs
+++ b/src/s-z/UlcerIndex/UlcerIndex.cs
@@ -16,18 +16,18 @@ namespace Skender.Stock.Indicators
         {
 
             // convert quotes
-            List<QuoteD> quotesList = quotes.ConvertToList();
+            List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Close);
 
             // check parameter arguments
             ValidateUlcer(quotes, lookbackPeriods);
 
             // initialize
-            List<UlcerIndexResult> results = new(quotesList.Count);
+            List<UlcerIndexResult> results = new(bdList.Count);
 
             // roll through quotes
-            for (int i = 0; i < quotesList.Count; i++)
+            for (int i = 0; i < bdList.Count; i++)
             {
-                QuoteD q = quotesList[i];
+                BasicD q = bdList[i];
                 int index = i + 1;
 
                 UlcerIndexResult result = new()
@@ -40,21 +40,21 @@ namespace Skender.Stock.Indicators
                     double? sumSquared = 0;
                     for (int p = index - lookbackPeriods; p < index; p++)
                     {
-                        QuoteD d = quotesList[p];
+                        BasicD d = bdList[p];
                         int dIndex = p + 1;
 
                         double maxClose = 0;
                         for (int s = index - lookbackPeriods; s < dIndex; s++)
                         {
-                            QuoteD dd = quotesList[s];
-                            if (dd.Close > maxClose)
+                            BasicD dd = bdList[s];
+                            if (dd.Value > maxClose)
                             {
-                                maxClose = dd.Close;
+                                maxClose = dd.Value;
                             }
                         }
 
                         double? percentDrawdown = (maxClose == 0) ? null
-                            : 100 * (double)((d.Close - maxClose) / maxClose);
+                            : 100 * (double)((d.Value - maxClose) / maxClose);
 
                         sumSquared += percentDrawdown * percentDrawdown;
                     }

--- a/src/s-z/Ultimate/Ultimate.cs
+++ b/src/s-z/Ultimate/Ultimate.cs
@@ -17,8 +17,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateUltimate(quotes, shortPeriods, middlePeriods, longPeriods);
@@ -29,12 +29,12 @@ namespace Skender.Stock.Indicators
             double[] bp = new double[size]; // buying pressure
             double[] tr = new double[size]; // true range
 
-            decimal priorClose = 0;
+            double priorClose = 0;
 
             // roll through quotes
             for (int i = 0; i < quotesList.Count; i++)
             {
-                TQuote q = quotesList[i];
+                QuoteD q = quotesList[i];
                 int index = i + 1;
 
                 UltimateResult r = new()
@@ -45,8 +45,8 @@ namespace Skender.Stock.Indicators
 
                 if (i > 0)
                 {
-                    bp[i] = (double)(q.Close - Math.Min(q.Low, priorClose));
-                    tr[i] = (double)(Math.Max(q.High, priorClose) - Math.Min(q.Low, priorClose));
+                    bp[i] = q.Close - Math.Min(q.Low, priorClose);
+                    tr[i] = Math.Max(q.High, priorClose) - Math.Min(q.Low, priorClose);
                 }
 
                 if (index >= longPeriods + 1)
@@ -86,7 +86,7 @@ namespace Skender.Stock.Indicators
                     double? avg2 = (sumTR2 == 0) ? null : sumBP2 / sumTR2;
                     double? avg3 = (sumTR3 == 0) ? null : sumBP3 / sumTR3;
 
-                    r.Ultimate = (decimal?)(100 * (4d * avg1 + 2d * avg2 + avg3) / 7d);
+                    r.Ultimate = (decimal?)(100d * (4d * avg1 + 2d * avg2 + avg3) / 7d);
                 }
 
                 priorClose = q.Close;

--- a/src/s-z/VolSma/VolSma.cs
+++ b/src/s-z/VolSma/VolSma.cs
@@ -16,7 +16,7 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            List<TQuote> quotesList = quotes.Sort();
+            List<TQuote> quotesList = quotes.SortToList();
 
             // check parameter arguments
             ValidateVolSma(quotes, lookbackPeriods);

--- a/src/s-z/VolatilityStop/VolatilityStop.cs
+++ b/src/s-z/VolatilityStop/VolatilityStop.cs
@@ -17,24 +17,24 @@ namespace Skender.Stock.Indicators
         {
 
             // convert quotes
-            List<QuoteD> quotesList = quotes.ConvertToList();
+            List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Close);
 
             // check parameter arguments
             ValidateVolatilityStop(quotes, lookbackPeriods, multiplier);
 
             // initialize
-            int size = quotesList.Count;
+            int size = bdList.Count;
             List<VolatilityStopResult> results = new(size);
             List<AtrResult> atrList = quotes.GetAtr(lookbackPeriods).ToList();
 
             // initial trend (guess)
-            double sic = (double)quotesList[0].Close;
-            bool isLong = ((double)quotesList[lookbackPeriods - 1].Close > sic);
+            double sic = (double)bdList[0].Value;
+            bool isLong = ((double)bdList[lookbackPeriods - 1].Value > sic);
 
             for (int i = 0; i < lookbackPeriods; i++)
             {
-                QuoteD q = quotesList[i];
-                double close = (double)q.Close;
+                BasicD q = bdList[i];
+                double close = (double)q.Value;
                 sic = isLong ? Math.Max(sic, close) : Math.Min(sic, close);
                 results.Add(new VolatilityStopResult() { Date = q.Date });
             }
@@ -42,8 +42,8 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = lookbackPeriods; i < size; i++)
             {
-                QuoteD q = quotesList[i];
-                double close = (double)q.Close;
+                BasicD q = bdList[i];
+                double close = (double)q.Value;
 
                 // average true range × multiplier constant
                 double arc = (double)atrList[i - 1].Atr * multiplier;
@@ -68,8 +68,8 @@ namespace Skender.Stock.Indicators
                 }
 
                 // evaluate stop and reverse
-                if ((isLong && (decimal?)q.Close < r.Sar)
-                || (!isLong && (decimal?)q.Close > r.Sar))
+                if ((isLong && (decimal?)q.Value < r.Sar)
+                || (!isLong && (decimal?)q.Value > r.Sar))
                 {
                     r.IsStop = true;
                     sic = close;

--- a/src/s-z/VolatilityStop/VolatilityStop.cs
+++ b/src/s-z/VolatilityStop/VolatilityStop.cs
@@ -16,8 +16,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateVolatilityStop(quotes, lookbackPeriods, multiplier);
@@ -33,7 +33,7 @@ namespace Skender.Stock.Indicators
 
             for (int i = 0; i < lookbackPeriods; i++)
             {
-                TQuote q = quotesList[i];
+                QuoteD q = quotesList[i];
                 double close = (double)q.Close;
                 sic = isLong ? Math.Max(sic, close) : Math.Min(sic, close);
                 results.Add(new VolatilityStopResult() { Date = q.Date });
@@ -42,7 +42,7 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = lookbackPeriods; i < size; i++)
             {
-                TQuote q = quotesList[i];
+                QuoteD q = quotesList[i];
                 double close = (double)q.Close;
 
                 // average true range × multiplier constant
@@ -68,7 +68,8 @@ namespace Skender.Stock.Indicators
                 }
 
                 // evaluate stop and reverse
-                if ((isLong && q.Close < r.Sar) || (!isLong && q.Close > r.Sar))
+                if ((isLong && (decimal?)q.Close < r.Sar)
+                || (!isLong && (decimal?)q.Close > r.Sar))
                 {
                     r.IsStop = true;
                     sic = close;

--- a/src/s-z/Vortex/Vortex.cs
+++ b/src/s-z/Vortex/Vortex.cs
@@ -15,8 +15,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateVortex(quotes, lookbackPeriods);
@@ -29,14 +29,14 @@ namespace Skender.Stock.Indicators
             double[] pvm = new double[size];
             double[] nvm = new double[size];
 
-            decimal prevHigh = 0;
-            decimal prevLow = 0;
-            decimal prevClose = 0;
+            double prevHigh = 0;
+            double prevLow = 0;
+            double prevClose = 0;
 
             // roll through quotes
             for (int i = 0; i < size; i++)
             {
-                TQuote q = quotesList[i];
+                QuoteD q = quotesList[i];
                 int index = i + 1;
 
                 VortexResult result = new()
@@ -55,12 +55,12 @@ namespace Skender.Stock.Indicators
                 }
 
                 // trend information
-                decimal highMinusPrevClose = Math.Abs(q.High - prevClose);
-                decimal lowMinusPrevClose = Math.Abs(q.Low - prevClose);
+                double highMinusPrevClose = Math.Abs(q.High - prevClose);
+                double lowMinusPrevClose = Math.Abs(q.Low - prevClose);
 
-                tr[i] = (double)Math.Max((q.High - q.Low), Math.Max(highMinusPrevClose, lowMinusPrevClose));
-                pvm[i] = (double)Math.Abs(q.High - prevLow);
-                nvm[i] = (double)Math.Abs(q.Low - prevHigh);
+                tr[i] = Math.Max((q.High - q.Low), Math.Max(highMinusPrevClose, lowMinusPrevClose));
+                pvm[i] = Math.Abs(q.High - prevLow);
+                nvm[i] = Math.Abs(q.Low - prevHigh);
 
                 prevHigh = q.High;
                 prevLow = q.Low;

--- a/src/s-z/Vwap/Vwap.cs
+++ b/src/s-z/Vwap/Vwap.cs
@@ -15,8 +15,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateVwap(quotesList, startDate);
@@ -32,11 +32,11 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < size; i++)
             {
-                TQuote q = quotesList[i];
-                double? v = (double?)q.Volume;
-                double? h = (double?)q.High;
-                double? l = (double?)q.Low;
-                double? c = (double?)q.Close;
+                QuoteD q = quotesList[i];
+                double? v = q.Volume;
+                double? h = q.High;
+                double? l = q.Low;
+                double? c = q.Close;
 
                 VwapResult r = new()
                 {
@@ -73,10 +73,9 @@ namespace Skender.Stock.Indicators
 
 
         // parameter validation
-        private static void ValidateVwap<TQuote>(
-            List<TQuote> quotesList,
+        private static void ValidateVwap(
+            List<QuoteD> quotesList,
             DateTime? startDate)
-            where TQuote : IQuote
         {
 
             // check quotes: done under Sort() for 0 length

--- a/src/s-z/Vwma/Vwma.cs
+++ b/src/s-z/Vwma/Vwma.cs
@@ -15,7 +15,8 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<QuoteD> quotesList = quotes.ConvertToList();
 
             // check parameter arguments
             ValidateVwma(quotes, lookbackPeriods);
@@ -27,7 +28,7 @@ namespace Skender.Stock.Indicators
             // roll through quotes
             for (int i = 0; i < size; i++)
             {
-                TQuote q = quotesList[i];
+                QuoteD q = quotesList[i];
                 int index = i + 1;
 
                 VwmaResult result = new()
@@ -41,9 +42,9 @@ namespace Skender.Stock.Indicators
                     double? sumVl = 0;
                     for (int p = index - lookbackPeriods; p < index; p++)
                     {
-                        TQuote d = quotesList[p];
-                        double? c = (double)d.Close;
-                        double? v = (double?)d.Volume;
+                        QuoteD d = quotesList[p];
+                        double? c = d.Close;
+                        double? v = d.Volume;
 
                         sumCl += c * v;
                         sumVl += v;

--- a/src/s-z/Wma/Wma.cs
+++ b/src/s-z/Wma/Wma.cs
@@ -15,20 +15,20 @@ namespace Skender.Stock.Indicators
             where TQuote : IQuote
         {
 
-            // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            // convert quotes
+            List<BasicD> bdList = quotes.ConvertToBasic(CandlePart.Close);
 
             // check parameter arguments
             ValidateWma(quotes, lookbackPeriods);
 
             // initialize
-            List<WmaResult> results = new(quotesList.Count);
+            List<WmaResult> results = new(bdList.Count);
             double divisor = (lookbackPeriods * (lookbackPeriods + 1)) / 2d;
 
             // roll through quotes
-            for (int i = 0; i < quotesList.Count; i++)
+            for (int i = 0; i < bdList.Count; i++)
             {
-                TQuote q = quotesList[i];
+                BasicD q = bdList[i];
                 int index = i + 1;
 
                 WmaResult result = new()
@@ -41,8 +41,8 @@ namespace Skender.Stock.Indicators
                     double wma = 0;
                     for (int p = index - lookbackPeriods; p < index; p++)
                     {
-                        TQuote d = quotesList[p];
-                        wma += (double)d.Close * (lookbackPeriods - (index - p - 1)) / divisor;
+                        BasicD d = bdList[p];
+                        wma += (double)d.Value * (lookbackPeriods - (index - p - 1)) / divisor;
                     }
 
                     result.Wma = (decimal)wma;

--- a/src/s-z/ZigZag/ZigZag.cs
+++ b/src/s-z/ZigZag/ZigZag.cs
@@ -17,7 +17,7 @@ namespace Skender.Stock.Indicators
         {
 
             // sort quotes
-            List<TQuote> quotesList = quotes.Sort();
+            List<TQuote> quotesList = quotes.SortToList();
 
             // check parameter arguments
             ValidateZigZag(quotes, percentChange);

--- a/tests/external/Tests.Other.csproj
+++ b/tests/external/Tests.Other.csproj
@@ -14,8 +14,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/indicators/Tests.Indicators.csproj
+++ b/tests/indicators/Tests.Indicators.csproj
@@ -14,8 +14,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
     <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/indicators/_common/Test.QuoteHistory.cs
+++ b/tests/indicators/_common/Test.QuoteHistory.cs
@@ -212,6 +212,7 @@ namespace Internal.Tests
             List<BasicD> l = quotes.ConvertToBasic(CandlePart.Low);
             List<BasicD> c = quotes.ConvertToBasic(CandlePart.Close);
             List<BasicD> v = quotes.ConvertToBasic(CandlePart.Volume);
+            List<BasicD> x = quotes.ConvertToBasic(CandlePart.HL2);
 
             // assertions
 
@@ -224,6 +225,7 @@ namespace Internal.Tests
             BasicD rl = l[501];
             BasicD rc = c[501];
             BasicD rv = v[501];
+            BasicD rx = x[501];
 
             // proper last date
             DateTime lastDate = DateTime.ParseExact("12/31/2018", "MM/dd/yyyy", EnglishCulture);
@@ -235,6 +237,7 @@ namespace Internal.Tests
             Assert.AreEqual(242.87, rl.Value);
             Assert.AreEqual(245.28, rc.Value);
             Assert.AreEqual(147031456, rv.Value);
+            Assert.AreEqual(244.205, rx.Value);
         }
 
 

--- a/tests/indicators/_common/Test.QuoteHistory.cs
+++ b/tests/indicators/_common/Test.QuoteHistory.cs
@@ -93,7 +93,7 @@ namespace Internal.Tests
             IEnumerable<Quote> quotes = TestData.GetMismatch();
 
             // clean
-            List<Quote> h = quotes.Sort();
+            List<Quote> h = quotes.SortToList();
 
             // assertions
 
@@ -207,11 +207,11 @@ namespace Internal.Tests
         public void ConvertToBasic()
         {
             // compose basic data
-            List<BasicData> o = quotes.ConvertToBasic(CandlePart.Open);
-            List<BasicData> h = quotes.ConvertToBasic(CandlePart.High);
-            List<BasicData> l = quotes.ConvertToBasic(CandlePart.Low);
-            List<BasicData> c = quotes.ConvertToBasic(CandlePart.Close);
-            List<BasicData> v = quotes.ConvertToBasic(CandlePart.Volume);
+            List<BasicD> o = quotes.ConvertToBasic(CandlePart.Open);
+            List<BasicD> h = quotes.ConvertToBasic(CandlePart.High);
+            List<BasicD> l = quotes.ConvertToBasic(CandlePart.Low);
+            List<BasicD> c = quotes.ConvertToBasic(CandlePart.Close);
+            List<BasicD> v = quotes.ConvertToBasic(CandlePart.Volume);
 
             // assertions
 
@@ -219,21 +219,21 @@ namespace Internal.Tests
             Assert.AreEqual(502, c.Count);
 
             // samples
-            BasicData ro = o[501];
-            BasicData rh = h[501];
-            BasicData rl = l[501];
-            BasicData rc = c[501];
-            BasicData rv = v[501];
+            BasicD ro = o[501];
+            BasicD rh = h[501];
+            BasicD rl = l[501];
+            BasicD rc = c[501];
+            BasicD rv = v[501];
 
             // proper last date
             DateTime lastDate = DateTime.ParseExact("12/31/2018", "MM/dd/yyyy", EnglishCulture);
             Assert.AreEqual(lastDate, rc.Date);
 
             // last values should be correct
-            Assert.AreEqual(244.92m, ro.Value);
-            Assert.AreEqual(245.54m, rh.Value);
-            Assert.AreEqual(242.87m, rl.Value);
-            Assert.AreEqual(245.28m, rc.Value);
+            Assert.AreEqual(244.92, ro.Value);
+            Assert.AreEqual(245.54, rh.Value);
+            Assert.AreEqual(242.87, rl.Value);
+            Assert.AreEqual(245.28, rc.Value);
             Assert.AreEqual(147031456, rv.Value);
         }
 

--- a/tests/indicators/a-d/Chandelier/Chandelier.Tests.cs
+++ b/tests/indicators/a-d/Chandelier/Chandelier.Tests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -16,7 +16,7 @@ namespace Internal.Tests
             int lookbackPeriods = 22;
 
             List<ChandelierResult> longResult =
-                quotes.GetChandelier(lookbackPeriods, 3.0m)
+                quotes.GetChandelier(lookbackPeriods, 3)
                 .ToList();
 
             // assertions
@@ -35,7 +35,7 @@ namespace Internal.Tests
 
             // short
             List<ChandelierResult> shortResult =
-                Indicator.GetChandelier(quotes, lookbackPeriods, 3.0m, ChandelierType.Short)
+                Indicator.GetChandelier(quotes, lookbackPeriods, 3, ChandelierType.Short)
                 .ToList();
 
             ChandelierResult c = shortResult[501];
@@ -45,7 +45,7 @@ namespace Internal.Tests
         [TestMethod]
         public void BadData()
         {
-            IEnumerable<ChandelierResult> r = Indicator.GetChandelier(badQuotes, 15, 2m);
+            IEnumerable<ChandelierResult> r = Indicator.GetChandelier(badQuotes, 15, 2);
             Assert.AreEqual(502, r.Count());
         }
 
@@ -53,7 +53,7 @@ namespace Internal.Tests
         public void Removed()
         {
             List<ChandelierResult> longResult =
-                quotes.GetChandelier(22, 3.0m)
+                quotes.GetChandelier(22, 3)
                     .RemoveWarmupPeriods()
                     .ToList();
 

--- a/tests/performance/Perf.Helpers.cs
+++ b/tests/performance/Perf.Helpers.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using BenchmarkDotNet.Attributes;
 using Internal.Tests;
@@ -22,9 +22,15 @@ namespace Tests.Performance
         }
 
         [Benchmark]
-        public object Sort()
+        public object SortToList()
         {
-            return h.Sort();
+            return h.SortToList();
+        }
+
+        [Benchmark]
+        public object ConvertToList()
+        {
+            return h.ConvertToList();
         }
 
         [Benchmark]


### PR DESCRIPTION
### Description

Making better use of quote converters for data precision and internal performance.

Breaking changes:

- Chandelier `multiplier` was changed from `decimal` to `double`

### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x]  I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation