### PR TITLE
add obsolete attribute to VolSma

### DIFF
--- a/src/s-z/VolSma/VolSma.cs
+++ b/src/s-z/VolSma/VolSma.cs
@@ -7,9 +7,10 @@ namespace Skender.Stock.Indicators
     public static partial class Indicator
     {
         // SIMPLE MOVING AVERAGE of VOLUME
-        // DO NOT USE - WILL BE DEPRECATED AT END OF 2021
         /// <include file='./info.xml' path='indicator/*' />
-        /// 
+        ///
+        [Obsolete("Use GetSma() with CandlePart.Volume instead."
+                + "It will be removed in versions released after 2021.")]
         public static IEnumerable<VolSmaResult> GetVolSma<TQuote>(
             this IEnumerable<TQuote> quotes,
             int lookbackPeriods)
@@ -41,11 +42,6 @@ namespace Skender.Stock.Indicators
                     Volume = q.Volume
                 });
             }
-
-            string msg = "WARNING! This indicator will be replaced by GetSma() "
-                       + "and removed at the end of 2021 in future versions. "
-                       + "Please migrate your scripts now.";
-            Console.WriteLine(msg);
 
             return results;
         }

--- a/tests/indicators/s-z/VolSma/VolSma.Tests.cs
+++ b/tests/indicators/s-z/VolSma/VolSma.Tests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -7,6 +7,7 @@ using Skender.Stock.Indicators;
 namespace Internal.Tests
 {
     [TestClass]
+    [Obsolete("Use GetSma() instead.")]
     public class VolSma : TestBase
     {
 


### PR DESCRIPTION
### Description

Adding a more meaningful way to show VolSma is obsolete; it now shows up as a Warning in user builds.

### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
