### PR TITLE
fix: volSma perf test

### DIFF
--- a/tests/performance/Perf.Indicators.cs
+++ b/tests/performance/Perf.Indicators.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
 using Internal.Tests;
@@ -535,6 +536,7 @@ namespace Tests.Performance
         }
 
         [Benchmark]
+        [Obsolete("Use GetVol() instead.")]
         public object GetVolSma()
         {
             return h.GetVolSma(14);


### PR DESCRIPTION
Fixes minor extraneous warning in performance tests, related to soon deprecated VolSma.