### PR TITLE
simplify adrx calculation

### DIFF
--- a/src/a-d/Adx/Adx.cs
+++ b/src/a-d/Adx/Adx.cs
@@ -127,7 +127,7 @@ public static partial class Indicator
 
                 double? priorAdx = results[index - lookbackPeriods].Adx;
 
-                result.Adxr = (priorAdx == 0) ? null : (adx + priorAdx) / 2;
+                result.Adxr = (adx + priorAdx) / 2;
                 prevAdx = adx;
             }
 

--- a/tests/indicators/a-d/Adx/Adx.Tests.cs
+++ b/tests/indicators/a-d/Adx/Adx.Tests.cs
@@ -18,6 +18,7 @@ public class Adx : TestBase
         // should always be the same number of results as there is quotes
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(475, results.Where(x => x.Adx != null).Count());
+        Assert.AreEqual(462, results.Where(x => x.Adxr != null).Count());
 
         // sample values
         AdxResult r19 = results[19];


### PR DESCRIPTION
### Description

Last change made the conditional expression unnecessary + ADX could legitimately be zero.  Prior ADX in the warmup period is null, so addition will be null (correct).

### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
