### PR TITLE
base Heikin-Ashi and Renko results on IQuote

### DIFF
--- a/docs/_indicators/HeikinAshi.md
+++ b/docs/_indicators/HeikinAshi.md
@@ -36,6 +36,12 @@ IEnumerable<HeikinAshiResult>
 - It always returns the same number of elements as there are in the historical quotes.
 - It does not return a single incremental indicator value.
 - The first period will have `null` values since there's not enough data to calculate.
+- `HeikinAshiResult` is based on `IQuote`, so it can be used as a direct replacement for `quotes`.  In other words, you can use it as base quotes for other indicators. Example:
+
+  ```csharp
+  var haQuotes = quotes.GetHeikinAshi();
+  var haRsi = haQuotes.GetRsi(14);
+  ```
 
 ### HeikinAshiResult
 

--- a/docs/_indicators/Renko.md
+++ b/docs/_indicators/Renko.md
@@ -46,6 +46,12 @@ IEnumerable<RenkoResult>
 
 - This method returns a time series of all available indicator values for the `quotes` provided.
 - It does not return a single incremental indicator value.
+- `RenkoResult` is based on `IQuote`, so it can be used as a direct replacement for `quotes`.  In other words, you can use it as base quotes for other indicators. Example:
+
+  ```csharp
+  var renkoQuotes = quotes.GetRenko(..);
+  var renkoRsi = renkoQuotes.GetRsi(..);
+  ```
 
 :warning: WARNING!  Unlike most indicators in this library, this indicator DOES NOT return the same number of elements as there are in the historical quotes.  Renko bricks are added to the results once the `brickSize` change is achieved.  For example, if it takes 3 days for a $2.50 price change to occur an entry is made on the third day while the first two are skipped.  If a period change occurs at multiples of `brickSize`, multiple bricks are drawn with the same `Date`.  See [online documentation](https://www.investopedia.com/terms/r/renkochart.asp) for more information.
 

--- a/src/e-k/HeikinAshi/HeikinAshi.Models.cs
+++ b/src/e-k/HeikinAshi/HeikinAshi.Models.cs
@@ -1,7 +1,7 @@
-﻿namespace Skender.Stock.Indicators;
+namespace Skender.Stock.Indicators;
 
 [Serializable]
-public class HeikinAshiResult : ResultBase
+public class HeikinAshiResult : ResultBase, IQuote
 {
     public decimal Open { get; set; }
     public decimal High { get; set; }

--- a/src/m-r/Renko/Renko.Models.cs
+++ b/src/m-r/Renko/Renko.Models.cs
@@ -1,7 +1,7 @@
-﻿namespace Skender.Stock.Indicators;
+namespace Skender.Stock.Indicators;
 
 [Serializable]
-public class RenkoResult : ResultBase
+public class RenkoResult : ResultBase, IQuote
 {
     public decimal Open { get; set; }
     public decimal High { get; set; }

--- a/tests/indicators/e-k/HeikinAshi/HeikinAshi.Tests.cs
+++ b/tests/indicators/e-k/HeikinAshi/HeikinAshi.Tests.cs
@@ -45,6 +45,14 @@ public class HeikinAshi : TestBase
     }
 
     [TestMethod]
+    public void UseAsQuotes()
+    {
+        IEnumerable<HeikinAshiResult> haQuotes = quotes.GetHeikinAshi();
+        IEnumerable<SmaResult> haSma = haQuotes.GetSma(5);
+        Assert.AreEqual(498, haSma.Count(x => x.Sma != null));
+    }
+
+    [TestMethod]
     public void BadData()
     {
         IEnumerable<HeikinAshiResult> r = Indicator.GetHeikinAshi(badQuotes);

--- a/tests/indicators/m-r/Renko/Renko.Tests.cs
+++ b/tests/indicators/m-r/Renko/Renko.Tests.cs
@@ -163,6 +163,14 @@ public class Renko : TestBase
     }
 
     [TestMethod]
+    public void UseAsQuotes()
+    {
+        IEnumerable<RenkoResult> renkoQuotes = quotes.GetRenko(0.5m);
+        IEnumerable<SmaResult> renkoSma = renkoQuotes.GetSma(5);
+        Assert.AreEqual(1124, renkoSma.Count(x => x.Sma != null));
+    }
+
+    [TestMethod]
     public void BadData()
     {
         IEnumerable<RenkoResult> r = badQuotes.GetRenko(100m);


### PR DESCRIPTION
### Description

Improves usability of both Heikin-Ashi and Renko results classes, so they can be used directly as `quotes`.  Both result classes are now based on `IQuote`.

Inspired by #717

### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
