### PR TITLE
chore: update url checker

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           BUNDLE_GEMFILE="${{github.workspace}}/docs/GemFile" bundle exec htmlproofer \
             --assume-extension \
-            --http-status-ignore "403,999" \
+            --http-status-ignore "403,429,999" \
             --url-swap "https\://daveskender.github.io/Stock.Indicators:http\://127.0.0.1:4000" \
             _site
 


### PR DESCRIPTION
### Description

Ignores 429 error in URL checker, for "too many requests", which can happen with GitHub URLs (e.g. to Discussions) if running too frequently.

### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
