### PR TITLE
add validation to Pivot Points

### DIFF
--- a/src/m-r/PivotPoints/PivotPoints.cs
+++ b/src/m-r/PivotPoints/PivotPoints.cs
@@ -31,7 +31,8 @@ public static partial class Indicator
 
         int windowId = GetWindowNumber(h0.Date, windowSize);
 
-        if(windowId == 0){
+        if (windowId == 0)
+        {
             throw new ArgumentOutOfRangeException(nameof(windowSize), windowSize,
                 "Invalid Window Size for Pivot Points.  See documentation for valid PeriodSize options.");
         }

--- a/src/m-r/PivotPoints/PivotPoints.cs
+++ b/src/m-r/PivotPoints/PivotPoints.cs
@@ -30,6 +30,12 @@ public static partial class Indicator
         }
 
         int windowId = GetWindowNumber(h0.Date, windowSize);
+
+        if(windowId == 0){
+            throw new ArgumentOutOfRangeException(nameof(windowSize), windowSize,
+                "Invalid Window Size for Pivot Points.  See documentation for valid PeriodSize options.");
+        }
+
         int windowEval;
         bool firstWindow = true;
 

--- a/tests/indicators/m-r/PivotPoints/PivotPoints.Tests.cs
+++ b/tests/indicators/m-r/PivotPoints/PivotPoints.Tests.cs
@@ -434,4 +434,12 @@ public class PivotPoints : TestBase
         Assert.AreEqual(294.3833m, Math.Round((decimal)last.R3, 4));
         Assert.AreEqual(null, last.R4);
     }
+
+    [TestMethod]
+    public void Exceptions()
+    {
+        // bad window size
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
+            quotes.GetPivotPoints(PeriodSize.ThreeMinutes));
+    }
 }


### PR DESCRIPTION
### Description

Adds parameter validation for Pivot Points `windowSize` since it uses a subset of PeriodSize options.  Helps to prevent #719 

### To do

- [x] add unit test

### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
