### PR TITLE
rename Candle class

### DIFF
--- a/docs/_includes/candle-result.md
+++ b/docs/_includes/candle-result.md
@@ -5,4 +5,4 @@
 | `Date` | DateTime | Date
 | `Price` | decimal | Price of the most relevant OHLC candle element when a signal is present
 | `Signal` | [Signal]({{site.baseurl}}/guide/#signal) | Generated signal type
-| `Candle` | [Candle]({{site.baseurl}}/guide/#candle) | Candle properties
+| `Candle` | [CandleProperties]({{site.baseurl}}/guide/#candle) | Candle properties

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -266,7 +266,7 @@ When a candlestick pattern is recognized, it produces a signal.  In some cases, 
 
 ### Candle
 
-The `Candle` class is an extended version of `Quote`, and contains additional calculated properties.
+The `CandleProperties` class is an extended version of `Quote`, and contains additional calculated properties.
 
 | name | type | notes
 | -- |-- |--

--- a/src/_common/Candles/Candles.cs
+++ b/src/_common/Candles/Candles.cs
@@ -20,7 +20,7 @@ public static class Candlesticks
             {
                 Date = x.Date,
                 Signal = Signal.None,
-                Candle = new Candle
+                Candle = new CandleProperties
                 {
                     Date = x.Date,
                     Open = x.Open,

--- a/src/_common/Candles/Models.cs
+++ b/src/_common/Candles/Models.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 // CANDLESTICK MODELS
 
 [Serializable]
-public class Candle : Quote
+public class CandleProperties : Quote
 {
     // raw sizes
     internal decimal Size => High - Low;
@@ -27,5 +27,5 @@ public class CandleResult : ResultBase
 {
     public decimal? Price { get; set; }
     public Signal Signal { get; set; }
-    public Candle Candle { get; set; }
+    public CandleProperties Candle { get; set; }
 }


### PR DESCRIPTION
### Description

Renaming public class `Candle` to `CandleProperties` to reduce some user friction.  `Candle` is a commonly used end user class name for generic types and tends to create naming conflicts.

Closes #712 

### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
