### PR TITLE
add back legacy .NET framework 4.6.1

### DIFF
--- a/src/Indicators.csproj
+++ b/src/Indicators.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
 
     <Authors>Dave Skender</Authors>
     <Product>Stock Indicators for .NET</Product>


### PR DESCRIPTION
Still seeing people using older frameworks, so adding back support for .NET 4.6.1 targeting.

- [x] re-consider before merging.  if this is not supported in newer IDEs, maybe it’s not a good idea