### PR TITLE
fix: no reversal case for PSAR

### DIFF
--- a/src/m-r/ParabolicSar/ParabolicSar.cs
+++ b/src/m-r/ParabolicSar/ParabolicSar.cs
@@ -164,22 +164,21 @@ public static partial class Indicator
             priorSar = (decimal)r.Sar;
         }
 
-        // remove first trend to reversal, since it is an invalid guess
+        // remove first trendline since it is an invalid guess
         ParabolicSarResult firstReversal = results
             .Where(x => x.IsReversal == true)
             .OrderBy(x => x.Date)
             .FirstOrDefault();
 
-        if (firstReversal != null)
-        {
-            int cutIndex = results.IndexOf(firstReversal);
+        int cutIndex = (firstReversal != null)
+            ? results.IndexOf(firstReversal)
+            : length - 1;
 
-            for (int d = 0; d <= cutIndex; d++)
-            {
-                ParabolicSarResult r = results[d];
-                r.Sar = null;
-                r.IsReversal = null;
-            }
+        for (int d = 0; d <= cutIndex; d++)
+        {
+            ParabolicSarResult r = results[d];
+            r.Sar = null;
+            r.IsReversal = null;
         }
 
         return results;

--- a/tests/indicators/m-r/ParabolicSar/ParabolicSar.Tests.cs
+++ b/tests/indicators/m-r/ParabolicSar/ParabolicSar.Tests.cs
@@ -83,6 +83,27 @@ public class ParabolicSar : TestBase
     }
 
     [TestMethod]
+    public void InsufficientQuotes()
+    {
+        decimal acclerationStep = 0.02m;
+        decimal maxAccelerationFactor = 0.2m;
+
+        IEnumerable<Quote> insufficientQuotes = TestData.GetDefault()
+            .OrderBy(x => x.Date)
+            .Take(10);
+
+        List<ParabolicSarResult> results =
+            insufficientQuotes.GetParabolicSar(acclerationStep, maxAccelerationFactor)
+                .ToList();
+
+        // assertions
+
+        // proper quantities
+        Assert.AreEqual(10, results.Count);
+        Assert.AreEqual(0, results.Where(x => x.Sar != null).Count());
+    }
+
+    [TestMethod]
     public void BadData()
     {
         IEnumerable<ParabolicSarResult> r = Indicator.GetParabolicSar(badQuotes);


### PR DESCRIPTION
### Description

The first leg of PSAR persisted when insufficient quote history was provided to produce any pivot reversals.  Normally it is excluded.  This fixes that inconsistency so it does not return a repainted trendline if no reversals are present.

Fixes #743 

### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
