### PR TITLE
candle pattern preview updates

### DIFF
--- a/docs/_data/categories.yml
+++ b/docs/_data/categories.yml
@@ -6,7 +6,7 @@
   type: oscillator
 - name: Stop and reverse
   type: stop-and-reverse
-- name: Candlestick patterns
+- name: Candlestick patterns (preview)
   type: candlestick-pattern
   subcategories:
   - name: Other price patterns

--- a/docs/_includes/candle-result.md
+++ b/docs/_includes/candle-result.md
@@ -4,5 +4,5 @@
 | -- |-- |--
 | `Date` | DateTime | Date
 | `Price` | decimal | Price of the most relevant OHLC candle element when a signal is present
-| `Signal` | [Signal]({{site.baseurl}}/guide/#signal) | Generated signal type
+| `Match` | [Match]({{site.baseurl}}/guide/#signal) | Generated signal type
 | `Candle` | [CandleProperties]({{site.baseurl}}/guide/#candle) | Candle properties

--- a/docs/_includes/candle-result.md
+++ b/docs/_includes/candle-result.md
@@ -4,5 +4,5 @@
 | -- |-- |--
 | `Date` | DateTime | Date
 | `Price` | decimal | Price of the most relevant OHLC candle element when a signal is present
-| `Match` | [Match]({{site.baseurl}}/guide/#signal) | Generated signal type
+| `Match` | [Match]({{site.baseurl}}/guide/#match) | Generated signal type
 | `Candle` | [CandleProperties]({{site.baseurl}}/guide/#candle) | Candle properties

--- a/docs/_indicators/Doji.md
+++ b/docs/_indicators/Doji.md
@@ -22,7 +22,7 @@ IEnumerable<CandleResult> results =
 
 | name | type | notes
 | -- |-- |--
-| `maxPriceChangePercent` | double | Optional.  Maximum absolute decimalized percent difference in open and close price.  Must be between 0 and 0.005, if specified.  Default is 0.001 (0.1%).
+| `maxPriceChangePercent` | double | Optional.  Maximum absolute percent difference in open and close price.  Example: 0.3% would be entered as 0.3 (not 0.003).  Must be between 0 and 0.5 percent, if specified.  Default is 0.1 (0.1%).
 
 ### Historical quotes requirements
 

--- a/docs/_indicators/Doji.md
+++ b/docs/_indicators/Doji.md
@@ -39,8 +39,8 @@ IEnumerable<CandleResult>
 - This method returns a time series of all available indicator values for the `quotes` provided.
 - It always returns the same number of elements as there are in the historical quotes.
 - It does not return a single incremental indicator value.
-- The candlestick pattern is indicated on dates where `Signal` is `Signal.Neutral`.
-- `Price` is `Close` price; however, all OHLC elements are included in the `Candle` properties.
+- The candlestick pattern is indicated on dates where `Match` is `Match.Neutral`.
+- `Price` is `Close` price; however, all OHLC elements are included in `CandleProperties`.
 - There is no intrinsic basis or confirmation signal provided for this pattern.
 
 {% include candle-result.md %}

--- a/docs/_indicators/Doji.md
+++ b/docs/_indicators/Doji.md
@@ -1,5 +1,5 @@
 ---
-title: Doji (Preview)
+title: Doji
 permalink: /indicators/Doji/
 layout: indicator
 type: candlestick-pattern

--- a/docs/_indicators/Marubozu.md
+++ b/docs/_indicators/Marubozu.md
@@ -1,5 +1,5 @@
 ---
-title: Marubozu (Preview)
+title: Marubozu
 permalink: /indicators/Marubozu/
 layout: indicator
 type: candlestick-pattern

--- a/docs/_indicators/Marubozu.md
+++ b/docs/_indicators/Marubozu.md
@@ -22,7 +22,7 @@ IEnumerable<CandleResult> results =
 
 | name | type | notes
 | -- |-- |--
-| `minBodyPercent` | double | Optional.  Minimum body size as a decimalized percent of total candle size.  Must be between 0.8 and 1, if specified.  Default is 0.95 (95%).
+| `minBodyPercent` | double | Optional.  Minimum body size as a percent of total candle size.  Example: 85% would be entered as 85 (not 0.85).  Must be between 80 and 100, if specified.  Default is 95 (95%).
 
 ### Historical quotes requirements
 

--- a/docs/_indicators/Marubozu.md
+++ b/docs/_indicators/Marubozu.md
@@ -39,8 +39,8 @@ IEnumerable<CandleResult>
 - This method returns a time series of all available indicator values for the `quotes` provided.
 - It always returns the same number of elements as there are in the historical quotes.
 - It does not return a single incremental indicator value.
-- The candlestick pattern is indicated on dates where `Signal` is `Signal.BullSignal` or `Signal.BearSignal`.
-- `Price` is `Close` price; however, all OHLC elements are included in the `Candle` properties.
+- The candlestick pattern is indicated on dates where `Match` is `Match.BullSignal` or `Match.BearSignal`.
+- `Price` is `Close` price; however, all OHLC elements are included in `CandleProperties`.
 - There is no intrinsic basis or confirmation signal provided for this pattern.
 
 {% include candle-result.md %}

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -250,20 +250,20 @@ IEnumerable<RsiResult> results = obvQuotes.GetRsi(14);
 
 {% include candle-result.md %}
 
-### Signal
+### Match
 
-When a candlestick pattern is recognized, it produces a signal.  In some cases, an intrinsic confirmation is also available.  In cases where previous bars were used to identify a pattern, they are indicates as the basis for the signal.  This `enum` can also be referenced as an `int` value.  [Documentation for each candlestick pattern]({{site.baseurl}}/indicators/#candlestick-pattern) will indicate whether confirmation and/or basis information is produced.
+When a candlestick pattern is recognized, it produces a matching signal.  In some cases, an intrinsic confirmation is also available.  In cases where previous bars were used to identify a pattern, they are indicates as the basis for the signal.  This `enum` can also be referenced as an `int` value.  [Documentation for each candlestick pattern]({{site.baseurl}}/indicators/#candlestick-pattern) will indicate whether confirmation and/or basis information is produced.
 
 | type | int | description
 |-- |--: |--
-| `Signal.BullConfirmed` | 200 | Confirmation of a prior bull signal
-| `Signal.BullSignal` | 100 | Matching bullish pattern
-| `Signal.BullBasis` | 10 | Bars supporting a bullish signal
-| `Signal.Neutral` | 1 | Matching for non-directional patterns
-| `Signal.None` | 0 | No match
-| `Signal.BearBasis` | -10 | Bars supporting a bearish signal
-| `Signal.BearSignal` | -100 | Matching bearish pattern
-| `Signal.BearConfirmed` | -200 | Confirmation of a prior bear signal
+| `Match.BullConfirmed` | 200 | Confirmation of a prior bull signal
+| `Match.BullSignal` | 100 | Matching bullish pattern
+| `Match.BullBasis` | 10 | Bars supporting a bullish signal
+| `Match.Neutral` | 1 | Matching for non-directional patterns
+| `Match.None` | 0 | No match
+| `Match.BearBasis` | -10 | Bars supporting a bearish signal
+| `Match.BearSignal` | -100 | Matching bearish pattern
+| `Match.BearConfirmed` | -200 | Confirmation of a prior bear signal
 
 ### Candle
 

--- a/src/_common/Candles/Candles.cs
+++ b/src/_common/Candles/Candles.cs
@@ -6,7 +6,7 @@ public static class Candlesticks
         this IEnumerable<CandleResult> candleResults)
     {
         return candleResults
-            .Where(candle => candle.Signal != Signal.None)
+            .Where(candle => candle.Match != Match.None)
             .ToList();
     }
 
@@ -19,7 +19,7 @@ public static class Candlesticks
             .Select(x => new CandleResult
             {
                 Date = x.Date,
-                Signal = Signal.None,
+                Match = Match.None,
                 Candle = new CandleProperties
                 {
                     Date = x.Date,

--- a/src/_common/Candles/Models.cs
+++ b/src/_common/Candles/Models.cs
@@ -26,6 +26,6 @@ public class CandleProperties : Quote
 public class CandleResult : ResultBase
 {
     public decimal? Price { get; set; }
-    public Signal Signal { get; set; }
+    public Match Match { get; set; }
     public CandleProperties Candle { get; set; }
 }

--- a/src/_common/Enums.cs
+++ b/src/_common/Enums.cs
@@ -54,7 +54,7 @@ public enum PeriodSize
     OneMinute
 }
 
-public enum Signal
+public enum Match
 {
     BullConfirmed = 200,
     BullSignal = 100,

--- a/src/a-d/Doji/Doji.cs
+++ b/src/a-d/Doji/Doji.cs
@@ -7,7 +7,7 @@ public static partial class Indicator
     ///
     public static IEnumerable<CandleResult> GetDoji<TQuote>(
         this IEnumerable<TQuote> quotes,
-        double maxPriceChangePercent = 0.001)
+        double maxPriceChangePercent = 0.1)
         where TQuote : IQuote
     {
         // check parameter arguments
@@ -15,6 +15,7 @@ public static partial class Indicator
 
         // initialize
         List<CandleResult> results = quotes.ToCandleResults();
+        maxPriceChangePercent /= 100;
         int length = results.Count;
 
         // roll through candles
@@ -41,10 +42,10 @@ public static partial class Indicator
         double maxPriceChangePercent)
     {
         // check parameter arguments
-        if (maxPriceChangePercent is < 0 or > 0.005)
+        if (maxPriceChangePercent is < 0 or > 0.5)
         {
             throw new ArgumentOutOfRangeException(nameof(maxPriceChangePercent), maxPriceChangePercent,
-                "Maximum Percent Change must be between 0 and 0.005 for Doji (0% to 0.5%).");
+                "Maximum Percent Change must be between 0 and 0.5 for Doji (0% to 0.5%).");
         }
     }
 }

--- a/src/a-d/Doji/Doji.cs
+++ b/src/a-d/Doji/Doji.cs
@@ -29,7 +29,7 @@ public static partial class Indicator
                 if (Math.Abs((double)(r.Candle.Close / r.Candle.Open) - 1d) <= maxPriceChangePercent)
                 {
                     r.Price = r.Candle.Close;
-                    r.Signal = Signal.Neutral;
+                    r.Match = Match.Neutral;
                 }
             }
         }

--- a/src/a-d/Doji/info.xml
+++ b/src/a-d/Doji/info.xml
@@ -2,7 +2,7 @@
 
 <indicator>
   <summary>
-    (preview) Doji is a single candlestick pattern where open and close price are virtually identical, representing market indecision.
+    Doji is a single candlestick pattern where open and close price are virtually identical, representing market indecision.
     <para>
       See
       <see href="https://daveskender.github.io/Stock.Indicators/indicators/Patterns/Doji/#content">documentation</see>

--- a/src/a-d/Doji/info.xml
+++ b/src/a-d/Doji/info.xml
@@ -11,7 +11,7 @@
   </summary>
   <typeparam name="TQuote">Configurable Quote type.  See Guide for more information.</typeparam>
   <param name="quotes">Historical price quotes.</param>
-  <param name="maxPriceChangePercent">Optional.  Maximum absolute decimalized percent difference in open and close price.</param>
+  <param name="maxPriceChangePercent">Optional.  Maximum absolute percent difference in open and close price.</param>
   <returns>Time series of Doji values.</returns>
   <exception cref="ArgumentOutOfRangeException">Invalid parameter value provided.</exception>
 </indicator>

--- a/src/m-r/Marubozu/Marubozu.cs
+++ b/src/m-r/Marubozu/Marubozu.cs
@@ -7,7 +7,7 @@ public static partial class Indicator
     ///
     public static IEnumerable<CandleResult> GetMarubozu<TQuote>(
         this IEnumerable<TQuote> quotes,
-        double minBodyPercent = 0.95)
+        double minBodyPercent = 95)
         where TQuote : IQuote
     {
         // check parameter arguments
@@ -15,6 +15,7 @@ public static partial class Indicator
 
         // initialize
         List<CandleResult> results = quotes.ToCandleResults();
+        minBodyPercent /= 100;
         int length = results.Count;
 
         // roll through candles
@@ -38,16 +39,16 @@ public static partial class Indicator
         double minBodyPercent)
     {
         // check parameter arguments
-        if (minBodyPercent > 1)
+        if (minBodyPercent > 100)
         {
             throw new ArgumentOutOfRangeException(nameof(minBodyPercent), minBodyPercent,
-                "Minimum Body Percent must be less than 1 for Marubozu (<=100%).");
+                "Minimum Body Percent must be less than 100 for Marubozu (<=100%).");
         }
 
-        if (minBodyPercent < 0.8)
+        if (minBodyPercent < 80)
         {
             throw new ArgumentOutOfRangeException(nameof(minBodyPercent), minBodyPercent,
-                "Minimum Body Percent must at least 0.8 (80%) for Marubozu and is usually greater than 0.9 (90%).");
+                "Minimum Body Percent must at least 80 (80%) for Marubozu and is usually greater than 90 (90%).");
         }
     }
 }

--- a/src/m-r/Marubozu/Marubozu.cs
+++ b/src/m-r/Marubozu/Marubozu.cs
@@ -27,7 +27,7 @@ public static partial class Indicator
             if (r.Candle.BodyPct >= minBodyPercent)
             {
                 r.Price = r.Candle.Close;
-                r.Signal = r.Candle.IsBullish ? Signal.BullSignal : Signal.BearSignal;
+                r.Match = r.Candle.IsBullish ? Match.BullSignal : Match.BearSignal;
             }
         }
 

--- a/src/m-r/Marubozu/info.xml
+++ b/src/m-r/Marubozu/info.xml
@@ -2,7 +2,7 @@
 
 <indicator>
   <summary>
-    (preview) Marubozu is a single candlestick pattern that has no wicks, representing consistent directional movement.
+    Marubozu is a single candlestick pattern that has no wicks, representing consistent directional movement.
     <para>
       See
       <see href="https://daveskender.github.io/Stock.Indicators/indicators/Patterns/Marubozu/#content">documentation</see>

--- a/src/m-r/Marubozu/info.xml
+++ b/src/m-r/Marubozu/info.xml
@@ -11,7 +11,7 @@
   </summary>
   <typeparam name="TQuote">Configurable Quote type.  See Guide for more information.</typeparam>
   <param name="quotes">Historical price quotes.</param>
-  <param name="minBodyPercent">Optional.  Minimum candle body size as decimalized percentage.</param>
+  <param name="minBodyPercent">Optional.  Minimum candle body size as percentage.</param>
   <returns>Time series of Marubozu values.</returns>
   <exception cref="ArgumentOutOfRangeException">Invalid parameter value provided.</exception>
 </indicator>

--- a/tests/indicators/a-d/Doji/Doji.Tests.cs
+++ b/tests/indicators/a-d/Doji/Doji.Tests.cs
@@ -9,7 +9,7 @@ public class Doji : TestBase
     [TestMethod]
     public void Standard()
     {
-        List<CandleResult> results = quotes.GetDoji(0.001).ToList();
+        List<CandleResult> results = quotes.GetDoji(0.1).ToList();
 
         // assertions
 
@@ -64,7 +64,7 @@ public class Doji : TestBase
     public void Condense()
     {
         IEnumerable<CandleResult> r =
-            quotes.GetDoji(0.001).Condense();
+            quotes.GetDoji(0.1).Condense();
 
         Assert.AreEqual(112, r.Count());
     }
@@ -77,6 +77,6 @@ public class Doji : TestBase
             Indicator.GetDoji(quotes, -0.00001));
 
         Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
-            Indicator.GetDoji(quotes, 0.0050001));
+            Indicator.GetDoji(quotes, 0.50001));
     }
 }

--- a/tests/indicators/a-d/Doji/Doji.Tests.cs
+++ b/tests/indicators/a-d/Doji/Doji.Tests.cs
@@ -15,32 +15,32 @@ public class Doji : TestBase
 
         // should always be the same number of results as there is quotes
         Assert.AreEqual(502, results.Count);
-        Assert.AreEqual(112, results.Where(x => x.Signal != Signal.None).Count());
+        Assert.AreEqual(112, results.Where(x => x.Match != Match.None).Count());
 
         // sample values
         CandleResult r1 = results[1];
         Assert.AreEqual(null, r1.Price);
-        Assert.AreEqual(0, (int)r1.Signal);
+        Assert.AreEqual(0, (int)r1.Match);
 
         CandleResult r23 = results[23];
         Assert.AreEqual(216.28m, r23.Price);
-        Assert.AreEqual(Signal.Neutral, r23.Signal);
+        Assert.AreEqual(Match.Neutral, r23.Match);
 
         CandleResult r46 = results[46];
         Assert.AreEqual(null, r46.Price);
-        Assert.AreEqual(Signal.None, r46.Signal);
+        Assert.AreEqual(Match.None, r46.Match);
 
         CandleResult r392 = results[392];
         Assert.AreEqual(null, r392.Price);
-        Assert.AreEqual(Signal.None, r392.Signal);
+        Assert.AreEqual(Match.None, r392.Match);
 
         CandleResult r451 = results[451];
         Assert.AreEqual(273.64m, r451.Price);
-        Assert.AreEqual(1, (int)r451.Signal);
+        Assert.AreEqual(1, (int)r451.Match);
 
         CandleResult r477 = results[477];
         Assert.AreEqual(256.86m, r477.Price);
-        Assert.AreEqual(Signal.Neutral, r477.Signal);
+        Assert.AreEqual(Match.Neutral, r477.Match);
     }
 
     [TestMethod]

--- a/tests/indicators/m-r/Marubozu/Marubozu.Tests.cs
+++ b/tests/indicators/m-r/Marubozu/Marubozu.Tests.cs
@@ -9,7 +9,7 @@ public class Marubozu : TestBase
     [TestMethod]
     public void Standard()
     {
-        List<CandleResult> results = quotes.GetMarubozu(0.95).ToList();
+        List<CandleResult> results = quotes.GetMarubozu(95).ToList();
 
         // assertions
 
@@ -64,7 +64,7 @@ public class Marubozu : TestBase
     public void Condense()
     {
         IEnumerable<CandleResult> r =
-            quotes.GetMarubozu(0.95).Condense();
+            quotes.GetMarubozu(95).Condense();
 
         Assert.AreEqual(6, r.Count());
     }
@@ -74,9 +74,9 @@ public class Marubozu : TestBase
     {
         // bad minimum body percent values
         Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
-            Indicator.GetMarubozu(quotes, 0.799));
+            Indicator.GetMarubozu(quotes, 79.9));
 
         Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
-            Indicator.GetMarubozu(quotes, 1.001));
+            Indicator.GetMarubozu(quotes, 100.1));
     }
 }

--- a/tests/indicators/m-r/Marubozu/Marubozu.Tests.cs
+++ b/tests/indicators/m-r/Marubozu/Marubozu.Tests.cs
@@ -15,32 +15,32 @@ public class Marubozu : TestBase
 
         // should always be the same number of results as there is quotes
         Assert.AreEqual(502, results.Count);
-        Assert.AreEqual(6, results.Where(x => x.Signal != Signal.None).Count());
+        Assert.AreEqual(6, results.Where(x => x.Match != Match.None).Count());
 
         // sample values
         CandleResult r31 = results[31];
         Assert.AreEqual(null, r31.Price);
-        Assert.AreEqual(0, (int)r31.Signal);
+        Assert.AreEqual(0, (int)r31.Match);
 
         CandleResult r32 = results[32];
         Assert.AreEqual(222.10m, r32.Price);
-        Assert.AreEqual(Signal.BullSignal, r32.Signal);
+        Assert.AreEqual(Match.BullSignal, r32.Match);
 
         CandleResult r33 = results[33];
         Assert.AreEqual(null, r33.Price);
-        Assert.AreEqual(Signal.None, r33.Signal);
+        Assert.AreEqual(Match.None, r33.Match);
 
         CandleResult r34 = results[34];
         Assert.AreEqual(null, r34.Price);
-        Assert.AreEqual(Signal.None, r34.Signal);
+        Assert.AreEqual(Match.None, r34.Match);
 
         CandleResult r274 = results[274];
         Assert.AreEqual(null, r274.Price);
-        Assert.AreEqual(Signal.None, r274.Signal);
+        Assert.AreEqual(Match.None, r274.Match);
 
         CandleResult r277 = results[277];
         Assert.AreEqual(248.13m, r277.Price);
-        Assert.AreEqual(Signal.BearSignal, r277.Signal);
+        Assert.AreEqual(Match.BearSignal, r277.Match);
     }
 
     [TestMethod]


### PR DESCRIPTION
### Description - breaking changes of Preview features

Standardizing on using non-decimalized percentage parameter arguments to be consistent with other indicators.  In other words, 5% is entered as 5, not 0.05.  Also renaming enum `Signal` to `Match` to avoid naming collisions.

### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my own code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings and running code analysis does not produce any issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
