### PR TITLE
refactor: internal indices

### DIFF
--- a/src/a-d/BollingerBands/BollingerBands.Series.cs
+++ b/src/a-d/BollingerBands/BollingerBands.Series.cs
@@ -12,25 +12,26 @@ public static partial class Indicator
         ValidateBollingerBands(lookbackPeriods, standardDeviations);
 
         // initialize
-        List<BollingerBandsResult> results = new(tpList.Count);
+        int length = tpList.Count;
+        List<BollingerBandsResult> results = new(length);
 
         // roll through quotes
-        for (int i = 0; i < tpList.Count; i++)
+        for (int i = 1; i <= tpList.Count; i++)
         {
-            (DateTime date, double value) = tpList[i];
+            (DateTime date, double value) = tpList[i - 1];
 
             BollingerBandsResult r = new()
             {
                 Date = date
             };
 
-            if (i + 1 >= lookbackPeriods)
+            if (i >= lookbackPeriods)
             {
                 double[] window = new double[lookbackPeriods];
                 double sum = 0;
                 int n = 0;
 
-                for (int p = i + 1 - lookbackPeriods; p <= i; p++)
+                for (int p = i - lookbackPeriods; p < i; p++)
                 {
                     (DateTime _, double pValue) = tpList[p];
                     window[n] = pValue;


### PR DESCRIPTION
### Description

Resolves #826
and generally improving the readability of internal use of indices.  This is a follow-on to the prior replacement of the unneeded and disliked `index` helper variable.

### To do

- [ ] apply convention consistently to all indicators

### Checklist

- [ ] My code follows the existing style, code structure, and naming taxonomy
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my own code and included any verifying manual calculations
- [ ] I have added or updated unit tests that prove my fix is effective or that my feature works, and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [ ] My changes generate no new warnings and running code analysis does not produce any issues
- [ ] I have added or run the performance tests that depict optimal execution times
- [ ] I have made corresponding changes to the documentation
