### PR TITLE
.ToQuotes for HeikinAshi

### DIFF
--- a/docs/_indicators/HeikinAshi.md
+++ b/docs/_indicators/HeikinAshi.md
@@ -53,6 +53,11 @@ IEnumerable<HeikinAshiResult>
 
 - [.Find(lookupDate)]({{site.baseurl}}/utilities#find-indicator-result-by-date)
 - [.RemoveWarmupPeriods(qty)]({{site.baseurl}}/utilities#remove-warmup-periods)
+- .ToQuotes() to convert to a `Quote` list.  Example:
+
+  ```csharp
+  List<Quote> results = quotes.GetHeikinAshi().ToQuotes();
+  ```
 
 See [Utilities and Helpers]({{site.baseurl}}/utilities#utilities-for-indicator-results) for more information.
 

--- a/src/e-k/HeikinAshi/HeikinAshi.Utilities.cs
+++ b/src/e-k/HeikinAshi/HeikinAshi.Utilities.cs
@@ -1,0 +1,20 @@
+namespace Skender.Stock.Indicators;
+
+public static partial class Indicator
+{
+    // convert results to quotes
+    internal static List<Quote> ToQuotes(
+    this IEnumerable<HeikinAshiResult> results)
+      => results
+        .Select(x => new Quote
+        {
+            Date = x.Date,
+            Open = x.Open,
+            High = x.High,
+            Low = x.Low,
+            Close = x.Close,
+            Volume = x.Volume
+        })
+        .OrderBy(x => x.Date)
+        .ToList();
+}

--- a/tests/indicators/e-k/HeikinAshi/HeikinAshi.Tests.cs
+++ b/tests/indicators/e-k/HeikinAshi/HeikinAshi.Tests.cs
@@ -34,6 +34,26 @@ public class HeikinAshi : TestBase
     }
 
     [TestMethod]
+    public void ToQuotes()
+    {
+        List<HeikinAshiResult> results = quotes.GetHeikinAshi().ToList();
+        List<Quote> haQuotes = results.ToQuotes();
+
+        for (int i = 0; i < results.Count; i++)
+        {
+            HeikinAshiResult r = results[i];
+            Quote q = haQuotes[i];
+
+            Assert.AreEqual(r.Date, q.Date);
+            Assert.AreEqual(r.Open, q.Open);
+            Assert.AreEqual(r.High, q.High);
+            Assert.AreEqual(r.Low, q.Low);
+            Assert.AreEqual(r.Close, q.Close);
+            Assert.AreEqual(r.Volume, q.Volume);
+        }
+    }
+
+    [TestMethod]
     public void BadData()
     {
         IEnumerable<HeikinAshiResult> r = Indicator.GetHeikinAshi(badQuotes);


### PR DESCRIPTION
### Description

Minor utility for Heikin-Ashi, for anyone who wants to convert class types to a `Quote` list (optional).  Since `HeikinAshiResult` is based on `IQuote`, this conversion is unnecessary since results from Heikin-Ashi can be used to directly replace normal quotes on all indicators.  However, some users may simply want it in `Quote` syntax.

  ```csharp
  List<Quote> results = quotes.GetHeikinAshi().ToQuotes();
  ```

Implements #872 

### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have put comments in my code, particularly for hard-to-understand areas
- [x] I have performed a self-review of my code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings or other code analysis issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
