### PR TITLE
chore: revert URL in embedded package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![image](https://raw.githubusercontent.com/DaveSkender/Stock.Indicators/main/docs/assets/social-banner.png)](https://dotnet.stockindicators.dev/)
+[![image](https://raw.githubusercontent.com/DaveSkender/Stock.Indicators/main/docs/assets/social-banner.png)](https://daveskender.github.io/Stock.Indicators/)
 
 [![NuGet package](https://img.shields.io/nuget/v/skender.stock.indicators?color=blue&logo=NuGet&label=NuGet%20Package)](https://www.nuget.org/packages/Skender.Stock.Indicators)
 [![Nuget](https://img.shields.io/nuget/dt/skender.stock.indicators?logo=NuGet&label=Downloads)](https://www.nuget.org/packages/Skender.Stock.Indicators)
@@ -8,13 +8,13 @@
 
 **Stock Indicators for .NET** is a C# [library package](https://www.nuget.org/packages/Skender.Stock.Indicators) that produces financial market technical indicators.  Send in historical price quotes and get back desired indicators such as moving averages, Relative Strength Index, Stochastic Oscillator, Parabolic SAR, etc.  Nothing more.
 
-It can be used in any market analysis software using standard [OHLCV price quotes](https://dotnet.stockindicators.dev/guide/#historical-quotes) for equities, commodities, forex, cryptocurrencies, and others.  We had private trading algorithms, machine learning, and charting systems in mind when originally creating this library.
+It can be used in any market analysis software using standard [OHLCV price quotes](https://daveskender.github.io/Stock.Indicators/guide/#historical-quotes) for equities, commodities, forex, cryptocurrencies, and others.  We had private trading algorithms, machine learning, and charting systems in mind when originally creating this library.
 
 Visit our project site for more information:
 
-- [Overview](https://dotnet.stockindicators.dev/)
-- [Indicators and overlays](https://dotnet.stockindicators.dev/indicators/)
-- [Guide and Pro tips](https://dotnet.stockindicators.dev/guide/)
+- [Overview](https://daveskender.github.io/Stock.Indicators/)
+- [Indicators and overlays](https://daveskender.github.io/Stock.Indicators/indicators/)
+- [Guide and Pro tips](https://daveskender.github.io/Stock.Indicators/guide/)
 - [Demo site](https://stock-charts.azurewebsites.net) (a stock chart)
 - [Release notes](https://github.com/DaveSkender/Stock.Indicators/releases)
 - [Discussions](https://github.com/DaveSkender/Stock.Indicators/discussions)

--- a/docs/GemFile.lock
+++ b/docs/GemFile.lock
@@ -230,7 +230,7 @@ GEM
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.16.3)
-    nokogiri (1.13.8-x64-mingw32)
+    nokogiri (1.13.9-x64-mingw32)
       racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)

--- a/src/Indicators.csproj
+++ b/src/Indicators.csproj
@@ -19,7 +19,7 @@
 
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageProjectUrl>https://dotnet.stockindicators.dev</PackageProjectUrl>
+    <PackageProjectUrl>https://daveskender.github.io/Stock.Indicators</PackageProjectUrl>
     <PackageId>Skender.Stock.Indicators</PackageId>
     <PackageTags>
        Indicators;Stock;Market;Technical;Analysis;Algorithmic;Trading;Trade;Trend;Momentum;Finance;Algorithm;Algo;

--- a/src/_common/Quotes/info.xml
+++ b/src/_common/Quotes/info.xml
@@ -6,7 +6,7 @@
       Optionally select which candle part to use in the calculation.
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/indicators/BasicQuote/#candlepart-options">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/indicators/BasicQuote/#candlepart-options">documentation</see>
         for more information.
       </para>
     </summary>
@@ -21,7 +21,7 @@
       Validate historical quotes.
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/utilities/#validate-quote-history">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/utilities/#validate-quote-history">documentation</see>
         for more information.
       </para>
     </summary>
@@ -35,7 +35,7 @@
       Converts historical quotes into larger bar sizes.
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/utilities/#resize-quote-history">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/utilities/#resize-quote-history">documentation</see>
         for more information.
       </para>
     </summary>
@@ -50,7 +50,7 @@
       Converts historical quotes into larger bar sizes.
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/utilities/#resize-quote-history">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/utilities/#resize-quote-history">documentation</see>
         for more information.
       </para>
     </summary>

--- a/src/_common/Results/info.xml
+++ b/src/_common/Results/info.xml
@@ -6,7 +6,7 @@
       Finds indicator values on a specific date.
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/utilities/#find-indicator-result-by-date">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/utilities/#find-indicator-result-by-date">documentation</see>
         for more information.
       </para>
     </summary>
@@ -20,7 +20,7 @@
       Removes non-essential records containing null values.
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/utilities/#condense">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/utilities/#condense">documentation</see>
         for more information.
       </para>
     </summary>
@@ -32,7 +32,7 @@
       Removes non-essential records containing null or NaN values.
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/utilities/#condense">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/utilities/#condense">documentation</see>
         for more information.
       </para>
     </summary>
@@ -45,7 +45,7 @@
       Removes the recommended quantity of results from the beginning of the results list.
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/utilities/#remove-warmup-periods">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/utilities/#remove-warmup-periods">documentation</see>
         for more information.
       </para>
     </summary>
@@ -57,7 +57,7 @@
       Removes a specific quantity of results from the beginning of the results list.
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/utilities/#remove-warmup-periods">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/utilities/#remove-warmup-periods">documentation</see>
         for more information.
       </para>
     </summary>

--- a/src/a-d/Adl/info.xml
+++ b/src/a-d/Adl/info.xml
@@ -5,7 +5,7 @@
     Accumulation/Distribution Line (ADL) is a rolling accumulation of Chaikin Money Flow Volume.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Adl/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Adl/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/a-d/Adx/info.xml
+++ b/src/a-d/Adx/info.xml
@@ -6,7 +6,7 @@
     It includes upward and downward indicators, and is often used to measure strength of trend.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Adx/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Adx/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/a-d/Alligator/info.xml
+++ b/src/a-d/Alligator/info.xml
@@ -7,7 +7,7 @@
     feeding habits when describing market movement.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Alligator/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Alligator/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/a-d/Alma/info.xml
+++ b/src/a-d/Alma/info.xml
@@ -6,7 +6,7 @@
     weighted moving average of price over a lookback window.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Alma/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Alma/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/a-d/Aroon/info.xml
+++ b/src/a-d/Aroon/info.xml
@@ -5,7 +5,7 @@
     Aroon is a simple oscillator view of how long the new high or low price occured over a lookback window.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Aroon/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Aroon/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/a-d/Atr/info.xml
+++ b/src/a-d/Atr/info.xml
@@ -5,7 +5,7 @@
     Average True Range (ATR) is a measure of volatility that captures gaps and limits between periods.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Atr/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Atr/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/a-d/AtrStop/info.xml
+++ b/src/a-d/AtrStop/info.xml
@@ -7,7 +7,7 @@
     trailing stop when the trend changes.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/AtrStop/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/AtrStop/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/a-d/Awesome/info.xml
+++ b/src/a-d/Awesome/info.xml
@@ -5,7 +5,7 @@
     Awesome Oscillator (aka Super AO) is a measure of the gap between a fast and slow period modified moving average.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Awesome/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Awesome/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/a-d/BasicQuote/info.xml
+++ b/src/a-d/BasicQuote/info.xml
@@ -5,7 +5,7 @@
     A simple quote transform.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/BasicQuote/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/BasicQuote/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/a-d/Beta/info.xml
+++ b/src/a-d/Beta/info.xml
@@ -5,7 +5,7 @@
     Beta shows how strongly one stock responds to systemic volatility of the entire market.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Beta/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Beta/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/a-d/BollingerBands/info.xml
+++ b/src/a-d/BollingerBands/info.xml
@@ -5,7 +5,7 @@
     Bollinger Bands&#174; depict volatility as standard deviation boundary lines from a moving average of price.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/BollingerBands/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/BollingerBands/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/a-d/Bop/info.xml
+++ b/src/a-d/Bop/info.xml
@@ -5,7 +5,7 @@
     Balance of Power (aka Balance of Market Power) is a momentum oscillator that depicts the strength of buying and selling pressure.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Bop/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Bop/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/a-d/Cci/info.xml
+++ b/src/a-d/Cci/info.xml
@@ -5,7 +5,7 @@
     Commodity Channel Index (CCI) is an oscillator depicting deviation from typical price range, often used to identify cyclical trends.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Cci/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Cci/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/a-d/ChaikinOsc/info.xml
+++ b/src/a-d/ChaikinOsc/info.xml
@@ -5,7 +5,7 @@
     Chaikin Oscillator is the difference between fast and slow Exponential Moving Averages (EMA) of the Accumulation/Distribution Line (ADL).
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/ChaikinOsc/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/ChaikinOsc/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/a-d/Chandelier/info.xml
+++ b/src/a-d/Chandelier/info.xml
@@ -5,7 +5,7 @@
     Chandelier Exit is typically used for stop-loss and can be computed for both long or short types.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Chandelier/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Chandelier/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/a-d/Chop/info.xml
+++ b/src/a-d/Chop/info.xml
@@ -6,7 +6,7 @@
     on a scale of 0 to 100.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Chop/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Chop/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/a-d/Cmf/info.xml
+++ b/src/a-d/Cmf/info.xml
@@ -5,7 +5,7 @@
     Chaikin Money Flow (CMF) is the simple moving average of Money Flow Volume (MFV).
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Cmf/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Cmf/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/a-d/Cmo/info.xml
+++ b/src/a-d/Cmo/info.xml
@@ -7,7 +7,7 @@
       The Chande Momentum Oscillator is a momentum indicator depicting the weighted percent of higher prices in financial markets.
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/indicators/Cmo/#content">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/indicators/Cmo/#content">documentation</see>
         for more information.
       </para>
     </summary>

--- a/src/a-d/ConnorsRsi/info.xml
+++ b/src/a-d/ConnorsRsi/info.xml
@@ -5,7 +5,7 @@
     ConnorsRSI is a composite oscillator that incorporates RSI, winning/losing streaks, and percentile gain metrics on scale of 0 to 100.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/ConnorsRsi/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/ConnorsRsi/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/a-d/Correlation/info.xml
+++ b/src/a-d/Correlation/info.xml
@@ -5,7 +5,7 @@
     Correlation Coefficient between two quote histories, based on price.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Correlation/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Correlation/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/a-d/Dema/info.xml
+++ b/src/a-d/Dema/info.xml
@@ -5,7 +5,7 @@
     Double Exponential Moving Average (DEMA) of the price.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Dema/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Dema/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/a-d/Doji/info.xml
+++ b/src/a-d/Doji/info.xml
@@ -5,7 +5,7 @@
     Doji is a single candlestick pattern where open and close price are virtually identical, representing market indecision.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Patterns/Doji/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Patterns/Doji/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/a-d/Donchian/info.xml
+++ b/src/a-d/Donchian/info.xml
@@ -5,7 +5,7 @@
     Donchian Channels, also called Price Channels, are derived from highest High and lowest Low values over a lookback window.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Donchian/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Donchian/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/a-d/Dpo/info.xml
+++ b/src/a-d/Dpo/info.xml
@@ -5,7 +5,7 @@
     Detrended Price Oscillator (DPO) depicts the difference between price and an offset simple moving average.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Dpo/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Dpo/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/a-d/Dynamic/info.xml
+++ b/src/a-d/Dynamic/info.xml
@@ -5,7 +5,7 @@
     McGinley Dynamic is a more responsive variant of exponential moving average.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Dynamic/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Dynamic/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/e-k/ElderRay/info.xml
+++ b/src/e-k/ElderRay/info.xml
@@ -5,7 +5,7 @@
     The Elder-ray Index depicts buying and selling pressure, also known as Bull and Bear Power.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/ElderRay/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/ElderRay/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/e-k/Ema/info.xml
+++ b/src/e-k/Ema/info.xml
@@ -6,7 +6,7 @@
       Exponential Moving Average (EMA) of price or any other specified OHLCV element.
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/indicators/Ema/#content">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/indicators/Ema/#content">documentation</see>
         for more information.
       </para>
     </summary>
@@ -21,7 +21,7 @@
       Extablish a streaming base for Exponential Moving Average (EMA).
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/indicators/Ema/#streaming">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/indicators/Ema/#streaming">documentation</see>
         for more information.
       </para>
     </summary>

--- a/src/e-k/Epma/info.xml
+++ b/src/e-k/Epma/info.xml
@@ -5,7 +5,7 @@
     Endpoint Moving Average (EPMA), also known as Least Squares Moving Average (LSMA), plots the projected last point of a linear regression lookback window.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Slope/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Slope/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/e-k/Fcb/info.xml
+++ b/src/e-k/Fcb/info.xml
@@ -5,7 +5,7 @@
     Fractal Chaos Bands outline high and low price channels to depict broad less-chaotic price movements. FCB is a channelized depiction of Williams Fractals.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Fcb/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Fcb/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/e-k/FisherTransform/info.xml
+++ b/src/e-k/FisherTransform/info.xml
@@ -5,7 +5,7 @@
     Ehlers Fisher Transform converts prices into a Gaussian normal distribution.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/FisherTransform/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/FisherTransform/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/e-k/ForceIndex/info.xml
+++ b/src/e-k/ForceIndex/info.xml
@@ -5,7 +5,7 @@
     The Force Index depicts volume-based buying and selling pressure.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/ForceIndex/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/ForceIndex/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/e-k/Fractal/info.xml
+++ b/src/e-k/Fractal/info.xml
@@ -7,7 +7,7 @@
       Williams Fractal is a retrospective price pattern that identifies a central high or low point over a lookback window.
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/indicators/Fractal/#content">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/indicators/Fractal/#content">documentation</see>
         for more information.
       </para>
     </summary>
@@ -24,7 +24,7 @@
       Williams Fractal is a retrospective price pattern that identifies a central high or low point over a lookback window.
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/indicators/Fractal/#content">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/indicators/Fractal/#content">documentation</see>
         for more information.
       </para>
     </summary>

--- a/src/e-k/Gator/info.xml
+++ b/src/e-k/Gator/info.xml
@@ -5,7 +5,7 @@
     Gator Oscillator is an expanded view of Williams Alligator.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Gator/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Gator/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/e-k/HeikinAshi/info.xml
+++ b/src/e-k/HeikinAshi/info.xml
@@ -5,7 +5,7 @@
     Heikin-Ashi is a modified candlestick pattern that uses prior day for smoothing.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/HeikinAshi/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/HeikinAshi/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/e-k/Hma/info.xml
+++ b/src/e-k/Hma/info.xml
@@ -5,7 +5,7 @@
     Hull Moving Average (HMA) is a modified weighted average of price over N lookback periods that reduces lag.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Hma/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Hma/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/e-k/HtTrendline/info.xml
+++ b/src/e-k/HtTrendline/info.xml
@@ -5,7 +5,7 @@
     Hilbert Transform Instantaneous Trendline (HTL) is a 5-period trendline of high/low price that uses signal processing to reduce noise.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/HtTrendline/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/HtTrendline/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/e-k/Hurst/info.xml
+++ b/src/e-k/Hurst/info.xml
@@ -5,7 +5,7 @@
     Hurst Exponent is a measure of randomness, trending, and mean-reverting tendencies of incremental return values.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Hurst/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Hurst/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/e-k/Ichimoku/info.xml
+++ b/src/e-k/Ichimoku/info.xml
@@ -7,7 +7,7 @@
       Ichimoku Cloud, also known as Ichimoku Kinkō Hyō, is a collection of indicators that depict support and resistance, momentum, and trend direction.
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/indicators/Ichimoku/#content">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/indicators/Ichimoku/#content">documentation</see>
         for more information.
       </para>
     </summary>
@@ -25,7 +25,7 @@
       Ichimoku Cloud, also known as Ichimoku Kinkō Hyō, is a collection of indicators that depict support and resistance, momentum, and trend direction.
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/indicators/Ichimoku/#content">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/indicators/Ichimoku/#content">documentation</see>
         for more information.
       </para>
     </summary>
@@ -44,7 +44,7 @@
       Ichimoku Cloud, also known as Ichimoku Kinkō Hyō, is a collection of indicators that depict support and resistance, momentum, and trend direction.
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/indicators/Ichimoku/#content">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/indicators/Ichimoku/#content">documentation</see>
         for more information.
       </para>
     </summary>

--- a/src/e-k/Kama/info.xml
+++ b/src/e-k/Kama/info.xml
@@ -5,7 +5,7 @@
     Kaufman’s Adaptive Moving Average (KAMA) is an volatility adaptive moving average of price over configurable lookback periods.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Kama/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Kama/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/e-k/Keltner/info.xml
+++ b/src/e-k/Keltner/info.xml
@@ -5,7 +5,7 @@
     Keltner Channels are based on an EMA centerline and ATR band widths. See also STARC Bands for an SMA centerline equivalent.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Keltner/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Keltner/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/e-k/Kvo/info.xml
+++ b/src/e-k/Kvo/info.xml
@@ -5,7 +5,7 @@
     Klinger Oscillator depicts volume-based divergence between short and long-term money flow.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Klinger/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Klinger/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/m-r/MaEnvelopes/info.xml
+++ b/src/m-r/MaEnvelopes/info.xml
@@ -5,7 +5,7 @@
     Moving Average Envelopes is a price band overlay that is offset from the moving average of price over a lookback window.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/MaEnvelopes/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/MaEnvelopes/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/m-r/Macd/info.xml
+++ b/src/m-r/Macd/info.xml
@@ -5,7 +5,7 @@
     Moving Average Convergence/Divergence (MACD) is a simple oscillator view of two converging/diverging exponential moving averages.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Macd/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Macd/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/m-r/Mama/info.xml
+++ b/src/m-r/Mama/info.xml
@@ -5,7 +5,7 @@
     MESA Adaptive Moving Average (MAMA) is a 5-period adaptive moving average of high/low price.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Mama/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Mama/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/m-r/Marubozu/info.xml
+++ b/src/m-r/Marubozu/info.xml
@@ -5,7 +5,7 @@
     Marubozu is a single candlestick pattern that has no wicks, representing consistent directional movement.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Patterns/Marubozu/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Patterns/Marubozu/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/m-r/Mfi/info.xml
+++ b/src/m-r/Mfi/info.xml
@@ -5,7 +5,7 @@
     Money Flow Index (MFI) is a price-volume oscillator that shows buying and selling momentum.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Mfi/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Mfi/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/m-r/Obv/info.xml
+++ b/src/m-r/Obv/info.xml
@@ -5,7 +5,7 @@
     On-balance Volume (OBV) is a rolling accumulation of volume based on Close price direction.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Obv/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Obv/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/m-r/ParabolicSar/info.xml
+++ b/src/m-r/ParabolicSar/info.xml
@@ -6,7 +6,7 @@
       Parabolic SAR (stop and reverse) is a price-time based indicator used to determine trend direction and reversals.
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/indicators/ParabolicSar/#content">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/indicators/ParabolicSar/#content">documentation</see>
         for more information.
       </para>
     </summary>
@@ -22,7 +22,7 @@
       Parabolic SAR (stop and reverse) is a price-time based indicator used to determine trend direction and reversals.
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/indicators/ParabolicSar/#content">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/indicators/ParabolicSar/#content">documentation</see>
         for more information.
       </para>
     </summary>

--- a/src/m-r/PivotPoints/info.xml
+++ b/src/m-r/PivotPoints/info.xml
@@ -5,7 +5,7 @@
     Pivot Points depict support and resistance levels, based on the prior lookback window. You can specify window size (e.g. month, week, day, etc).
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/PivotPoints/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/PivotPoints/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/m-r/Pivots/info.xml
+++ b/src/m-r/Pivots/info.xml
@@ -5,7 +5,7 @@
     Pivots is an extended version of Williams Fractal that includes identification of Higher High, Lower Low, Higher Low, and Lower Low trends between pivots in a lookback window.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Pivots/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Pivots/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/m-r/Pmo/info.xml
+++ b/src/m-r/Pmo/info.xml
@@ -5,7 +5,7 @@
     Price Momentum Oscillator (PMO) is double-smoothed ROC based momentum indicator.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Pmo/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Pmo/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/m-r/Prs/info.xml
+++ b/src/m-r/Prs/info.xml
@@ -8,7 +8,7 @@
     this also return relative percent change over the specified periods.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Prs/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Prs/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/m-r/Pvo/info.xml
+++ b/src/m-r/Pvo/info.xml
@@ -5,7 +5,7 @@
     Percentage Volume Oscillator (PVO) is a simple oscillator view of two converging/diverging exponential moving averages of Volume.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Pvo/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Pvo/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/m-r/Renko/info.xml
+++ b/src/m-r/Renko/info.xml
@@ -7,7 +7,7 @@
       Renko Chart is a modified Japanese candlestick pattern that uses time-lapsed bricks.
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/indicators/Renko/#content">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/indicators/Renko/#content">documentation</see>
         for more information.
       </para>
     </summary>
@@ -24,7 +24,7 @@
       The ATR Renko Chart is a modified Japanese candlestick pattern based on Average True Range brick size.
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/indicators/Renko/#content">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/indicators/Renko/#content">documentation</see>
         for more information.
       </para>
     </summary>

--- a/src/m-r/Roc/info.xml
+++ b/src/m-r/Roc/info.xml
@@ -7,7 +7,7 @@
       Rate of Change (ROC), also known as Momentum Oscillator, is the percent change of price over a lookback window.
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/indicators/Roc/#content">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/indicators/Roc/#content">documentation</see>
         for more information.
       </para>
     </summary>

--- a/src/m-r/RocWb/info.xml
+++ b/src/m-r/RocWb/info.xml
@@ -7,7 +7,7 @@
       Rate of Change with Bands (ROCWB) is the percent change of price over a lookback window with standard deviation bands.
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/indicators/Roc/#content">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/indicators/Roc/#content">documentation</see>
         for more information.
       </para>
     </summary>

--- a/src/m-r/RollingPivots/info.xml
+++ b/src/m-r/RollingPivots/info.xml
@@ -6,7 +6,7 @@
     It depicts support and resistance levels, based on a defined rolling window and offset.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/RollingPivots/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/RollingPivots/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/m-r/Rsi/info.xml
+++ b/src/m-r/Rsi/info.xml
@@ -6,7 +6,7 @@
     on a scale of 0 to 100, to depict overbought and oversold conditions.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Rsi/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Rsi/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/s-z/Slope/info.xml
+++ b/src/s-z/Slope/info.xml
@@ -6,7 +6,7 @@
     It can be used to help identify trend strength and direction.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Slope/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Slope/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/s-z/Sma/info.xml
+++ b/src/s-z/Sma/info.xml
@@ -7,7 +7,7 @@
       Simple Moving Average (SMA) of the price.
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/indicators/Sma/#content">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/indicators/Sma/#content">documentation</see>
         for more information.
       </para>
     </summary>
@@ -23,7 +23,7 @@
       Simple Moving Average (SMA) is the average of price over a lookback window.  This extended variant includes mean absolute deviation (MAD), mean square error (MSE), and mean absolute percentage error (MAPE).
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/indicators/Sma/#content">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/indicators/Sma/#content">documentation</see>
         for more information.
       </para>
     </summary>

--- a/src/s-z/Smi/info.xml
+++ b/src/s-z/Smi/info.xml
@@ -7,7 +7,7 @@
       Stochastic Momentum Index is a double-smoothed variant of the Stochastic Oscillator on a scale from -100 to 100.
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/indicators/Smi/#content">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/indicators/Smi/#content">documentation</see>
         for more information.
       </para>
     </summary>

--- a/src/s-z/Smma/info.xml
+++ b/src/s-z/Smma/info.xml
@@ -6,7 +6,7 @@
       Smoothed Moving Average (SMMA) is the average of price over a lookback window using a smoothing method.
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/indicators/Smma/#content">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/indicators/Smma/#content">documentation</see>
         for more information.
       </para>
     </summary>

--- a/src/s-z/StarcBands/info.xml
+++ b/src/s-z/StarcBands/info.xml
@@ -5,7 +5,7 @@
     Stoller Average Range Channel (STARC) Bands, are based on an SMA centerline and ATR band widths.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/StarcBands/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/StarcBands/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/s-z/Stc/info.xml
+++ b/src/s-z/Stc/info.xml
@@ -5,7 +5,7 @@
     Schaff Trend Cycle is a stochastic oscillator view of two converging/diverging exponential moving averages.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Stc/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Stc/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/s-z/StdDev/info.xml
+++ b/src/s-z/StdDev/info.xml
@@ -5,7 +5,7 @@
     Rolling Standard Deviation of price over a lookback window.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/StdDev/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/StdDev/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/s-z/StdDevChannels/info.xml
+++ b/src/s-z/StdDevChannels/info.xml
@@ -5,7 +5,7 @@
     Standard Deviation Channels are based on an linear regression centerline and standard deviations band widths.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/StdDevChannels/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/StdDevChannels/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/s-z/Stoch/info.xml
+++ b/src/s-z/Stoch/info.xml
@@ -8,7 +8,7 @@
       %J is also included for the KDJ Index extension.
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/indicators/Stoch/#content">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/indicators/Stoch/#content">documentation</see>
         for more information.
       </para>
     </summary>
@@ -27,7 +27,7 @@
       %J is also included for the KDJ Index extension.
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/indicators/Stoch/#content">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/indicators/Stoch/#content">documentation</see>
         for more information.
       </para>
     </summary>
@@ -48,7 +48,7 @@
       Stochastic indicator results includes aliases for those who prefer the simpler K,D,J outputs.
       <para>
         See
-        <see href="https://dotnet.stockindicators.dev/indicators/Stoch/#response">documentation</see>
+        <see href="https://daveskender.github.io/Stock.Indicators/indicators/Stoch/#response">documentation</see>
         for more information.
       </para>
     </summary>

--- a/src/s-z/StochRsi/info.xml
+++ b/src/s-z/StochRsi/info.xml
@@ -5,7 +5,7 @@
     Stochastic RSI is a Stochastic interpretation of the Relative Strength Index.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/StochRsi/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/StochRsi/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/s-z/SuperTrend/info.xml
+++ b/src/s-z/SuperTrend/info.xml
@@ -7,7 +7,7 @@
     trailing stop when the trend changes.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/SuperTrend/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/SuperTrend/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/s-z/T3/info.xml
+++ b/src/s-z/T3/info.xml
@@ -5,7 +5,7 @@
     Tillson T3 is a smooth moving average that reduces both lag and overshooting.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/T3/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/T3/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/s-z/Tema/info.xml
+++ b/src/s-z/Tema/info.xml
@@ -5,7 +5,7 @@
     Triple Exponential Moving Average (TEMA) of the price.  Note: TEMA is often confused with the alternative TRIX oscillator.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Tema/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Tema/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/s-z/Tr/info.xml
+++ b/src/s-z/Tr/info.xml
@@ -5,7 +5,7 @@
     True Range (TR) is a measure of volatility that captures gaps and limits between periods.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Atr/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Atr/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/s-z/Trix/info.xml
+++ b/src/s-z/Trix/info.xml
@@ -5,7 +5,7 @@
     Triple EMA Oscillator (TRIX) is the rate of change for a 3 EMA smoothing of the price over a lookback window. TRIX is often confused with TEMA.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Trix/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Trix/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/s-z/Tsi/info.xml
+++ b/src/s-z/Tsi/info.xml
@@ -5,7 +5,7 @@
     True Strength Index (TSI) is a momentum oscillator that depicts trends in price changes.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Tsi/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Tsi/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/s-z/UlcerIndex/info.xml
+++ b/src/s-z/UlcerIndex/info.xml
@@ -5,7 +5,7 @@
     Ulcer Index (UI) is a measure of downside price volatility over a lookback window.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/UlcerIndex/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/UlcerIndex/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/s-z/Ultimate/info.xml
+++ b/src/s-z/Ultimate/info.xml
@@ -5,7 +5,7 @@
     Ultimate Oscillator uses several lookback periods to weigh buying power against True Range price to produce on oversold / overbought oscillator.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Ultimate/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Ultimate/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/s-z/VolatilityStop/info.xml
+++ b/src/s-z/VolatilityStop/info.xml
@@ -5,7 +5,7 @@
     Volatility Stop is an ATR based indicator used to determine trend direction, stops, and reversals.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/VolatilityStop/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/VolatilityStop/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/s-z/Vortex/info.xml
+++ b/src/s-z/Vortex/info.xml
@@ -6,7 +6,7 @@
     It includes positive and negative indicators, and is often used to identify trends and reversals.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Vortex/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Vortex/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/s-z/Vwap/info.xml
+++ b/src/s-z/Vwap/info.xml
@@ -5,7 +5,7 @@
     Volume Weighted Average Price (VWAP) is a Volume weighted average of price, typically used on intraday data.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Vwap/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Vwap/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/s-z/Vwma/info.xml
+++ b/src/s-z/Vwma/info.xml
@@ -5,7 +5,7 @@
     Volume Weighted Moving Average is the volume adjusted average price over a lookback window.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Vwma/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Vwma/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/s-z/WilliamsR/info.xml
+++ b/src/s-z/WilliamsR/info.xml
@@ -5,7 +5,7 @@
     Williams %R momentum indicator is a stochastic oscillator with scale of -100 to 0. It is exactly the same as the Fast variant of Stochastic Oscillator, but with a different scaling.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/WilliamsR/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/WilliamsR/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/s-z/Wma/info.xml
+++ b/src/s-z/Wma/info.xml
@@ -5,7 +5,7 @@
     Weighted Moving Average (WMA) is the linear weighted average of price over N lookback periods. This also called Linear Weighted Moving Average (LWMA).
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/Wma/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/Wma/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/src/s-z/ZigZag/info.xml
+++ b/src/s-z/ZigZag/info.xml
@@ -5,7 +5,7 @@
     Zig Zag is a price chart overlay that simplifies the up and down movements and transitions based on a percent change smoothing threshold.
     <para>
       See
-      <see href="https://dotnet.stockindicators.dev/indicators/ZigZag/#content">documentation</see>
+      <see href="https://daveskender.github.io/Stock.Indicators/indicators/ZigZag/#content">documentation</see>
       for more information.
     </para>
   </summary>

--- a/tests/external/Tests.Other.csproj
+++ b/tests/external/Tests.Other.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/tests/indicators/Tests.Indicators.csproj
+++ b/tests/indicators/Tests.Indicators.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="coverlet.collector" Version="3.1.2">


### PR DESCRIPTION
### Description

Reverting to using default GitHub Pages URL in packaged software for future-proofing.  We'll keep the new URL in the documentation site as it is easy to change.  Packages are unchangeable after release.

### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have put comments in my code, particularly for hard-to-understand areas
- [x] I have performed a self-review of my code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings or other code analysis issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
