### PR TITLE
refactor ToTuple()

### DIFF
--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -32,7 +32,7 @@ var results = quotes
 
 ### Using tuple quotes
 
-`quotes.ToBasicTuple()` is a method for converting any `TQuote` collection to a simple [tuple](https://docs.microsoft.com/dotnet/csharp/language-reference/builtin-types/value-tuples) `(DateTime, double)` formatted `List`.  Most indicators in our library will accept this tuple format.  With that said, there are many indicators that also require the full OHLCV quote format, so it cannot be used universally.
+`quotes.ToTuple()` is a method for converting any `TQuote` collection to a simple [tuple](https://docs.microsoft.com/dotnet/csharp/language-reference/builtin-types/value-tuples) `(DateTime, double)` formatted `List`.  Most indicators in our library will accept this tuple format.  With that said, there are many indicators that also require the full OHLCV quote format, so it cannot be used universally.
 
 ### Sort quotes
 
@@ -154,11 +154,24 @@ See [individual indicator pages]({{site.baseurl}}/indicators/#content) for infor
 
 > :information_source: **Note**: `.RemoveWarmupPeriods()` is not available on some indicators; however, you can still do a custom pruning by using the customizable `.RemoveWarmupPeriods(removePeriods)`.
 
-> :warning: **Warning**: Without a specified `removePeriods` value, this utility will reverse-engineer the pruning amount.  When there are unusual results or when chaining multiple indicators, there will be an erroneous increase in the amount of pruning.  If you want more certainty, use a specific number for `removePeriods`.  Using this method on chained indicators without `removePeriods` is strongly discouraged.
+> :warning: **Warning**: without a specified `removePeriods` value, this utility will reverse-engineer the pruning amount.  When there are unusual results or when chaining multiple indicators, there will be an erroneous increase in the amount of pruning.  If you want more certainty, use a specific number for `removePeriods`.  Using this method on chained indicators without `removePeriods` is strongly discouraged.
 
 ### Using tuple results
 
-`results.ToBasicTuple()` is a method for converting results collections with a primary return value to a simple `(DateTime Date, double Value)` formatted [tuple](https://docs.microsoft.com/dotnet/csharp/language-reference/builtin-types/value-tuples) `List`.  Chainable indicators in our library will accept this tuple format as a replacement for `quotes`.  This conversion is not required for normal use; however, it may be useful for users who create [custom indicators]({{site.baseurl}}/custom-indicators/#content);
+`results.ToTuple(nullTo)` is a method for converting results collections to a simpler `(DateTime Date, double? Value)` formatted [tuple](https://docs.microsoft.com/dotnet/csharp/language-reference/builtin-types/value-tuples) `List`.
+
+This is not required in normal use; however, the last option may be useful for users who create [custom indicators]({{site.baseurl}}/custom-indicators/#content).
+
+A few options to consider:
+
+- Use a `nullTo` value of `NullTo.Null` if you want to persist `null` values
+- Use a `nullTo` value of `NullTo.NaN` if you want `null` values converted to nullable `double.NaN`
+- Omit the `nullTo` value entirely if you want a format that is compatible with chaining:
+  - warmup `null` values removed,
+  - `null` values as `double.NaN`, and
+  - all values as non-nullable `double`
+
+> :warning: **Warning**: warmup periods are pruned when omitting a `nullTo` value, resulting in fewer records.
 
 ### Sort results
 

--- a/src/GlobalSuppressions.cs
+++ b/src/GlobalSuppressions.cs
@@ -39,3 +39,10 @@ using System.Diagnostics.CodeAnalysis;
     Justification = "Not really an issue.",
     Scope = "member",
     Target = "~F:Skender.Stock.Indicators.ChandelierType.Short")]
+
+[assembly: SuppressMessage(
+    "StyleCop.CSharp.SpacingRules",
+    "SA1008:Opening parenthesis should be spaced correctly",
+    Justification = "Not compatible with `or` statement (Microsoft bug)",
+    Scope = "member",
+    Target = "~M:Skender.Stock.Indicators.Indicator.Condense``1(System.Collections.Generic.IEnumerable{``0})~System.Collections.Generic.IEnumerable{``0}")]

--- a/src/_common/Enums.cs
+++ b/src/_common/Enums.cs
@@ -50,6 +50,12 @@ public enum MaType
     WMA
 }
 
+public enum NullTo
+{
+    NaN,
+    Null
+}
+
 public enum PeriodSize
 {
     Month,

--- a/src/_common/NullMath.cs
+++ b/src/_common/NullMath.cs
@@ -6,17 +6,17 @@ namespace Skender.Stock.Indicators;
 // we're building nullable equivalents here.
 public static class NullMath
 {
-    public static double? Abs(double? value)
+    public static double? Abs(this double? value)
         => (value is null)
         ? null
         : value < 0 ? (double)-value : (double)value;
 
-    public static decimal? Round(decimal? value, int digits)
+    public static decimal? Round(this decimal? value, int digits)
         => (value is null)
         ? null
         : Math.Round((decimal)value, digits);
 
-    public static double? Round(double? value, int digits)
+    public static double? Round(this double? value, int digits)
         => (value is null)
         ? null
         : Math.Round((double)value, digits);

--- a/src/_common/ObsoleteV2.cs
+++ b/src/_common/ObsoleteV2.cs
@@ -5,14 +5,18 @@ namespace Skender.Stock.Indicators;
 // OBSOLETE IN v2.0.0
 public static partial class Indicator
 {
-    // placeholder, example of a renamed method
-
-    /*
+    // 2.4.1
     [ExcludeFromCodeCoverage]
-    [Obsolete("Rename 'GetTripleEma(..)' to 'GetTema(..)' to fix.", true)]
-    public static IEnumerable<TemaResult> GetTripleEma<TQuote>(
-    this IEnumerable<TQuote> quotes,
-    int lookbackPeriods)
-    where TQuote : IQuote => quotes.GetTema(lookbackPeriods);
-    */
+    [Obsolete("Rename 'ToBasicTuple(..)' to 'ToTuple(..)' to fix.", false)]
+    public static List<(DateTime, double)> ToBasicTuple<TQuote>(
+        this IEnumerable<TQuote> quotes,
+        CandlePart candlePart)
+        where TQuote : IQuote
+        => quotes.ToTuple(candlePart);
+
+    [ExcludeFromCodeCoverage]
+    [Obsolete("Rename 'ToResultTuple(..)' to 'ToTuple(..)' to fix.", false)]
+    public static List<(DateTime Date, double Value)> ToResultTuple(
+        this IEnumerable<IReusableResult> basicData)
+        => basicData.ToTuple();
 }

--- a/src/_common/Quotes/Quote.Converters.cs
+++ b/src/_common/Quotes/Quote.Converters.cs
@@ -17,7 +17,7 @@ public static partial class QuoteUtility
         this IEnumerable<TQuote> quotes,
         CandlePart candlePart = CandlePart.Close)
         where TQuote : IQuote => quotes
-            .Select(x => x.ToBasicTuple(candlePart));
+            .Select(x => x.ToTuple(candlePart));
 
     // sort quotes
     public static List<TQuote> ToSortedList<TQuote>(
@@ -29,12 +29,12 @@ public static partial class QuoteUtility
     // TUPLE QUOTES
 
     // convert quotes to tuple list
-    public static List<(DateTime, double)> ToBasicTuple<TQuote>(
+    public static List<(DateTime, double)> ToTuple<TQuote>(
         this IEnumerable<TQuote> quotes,
         CandlePart candlePart)
         where TQuote : IQuote => quotes
             .OrderBy(x => x.Date)
-            .Select(x => x.ToBasicTuple(candlePart))
+            .Select(x => x.ToTuple(candlePart))
             .ToList();
 
     // convert tuples to list, with sorting
@@ -62,17 +62,17 @@ public static partial class QuoteUtility
             .ToList();
 
     // convert quoteD list to tuples
-    internal static List<(DateTime, double)> ToBasicTuple(
+    internal static List<(DateTime, double)> ToTuple(
         this List<QuoteD> qdList,
         CandlePart candlePart) => qdList
             .OrderBy(x => x.Date)
-            .Select(x => x.ToBasicTuple(candlePart))
+            .Select(x => x.ToTuple(candlePart))
             .ToList();
 
     /* ELEMENTS */
 
     // convert TQuote element to basic tuple
-    internal static (DateTime date, double value) ToBasicTuple<TQuote>(
+    internal static (DateTime date, double value) ToTuple<TQuote>(
         this TQuote q,
         CandlePart candlePart)
         where TQuote : IQuote => candlePart switch
@@ -110,7 +110,7 @@ public static partial class QuoteUtility
         };
 
     // convert quoteD element to basic tuple
-    internal static (DateTime, double) ToBasicTuple(
+    internal static (DateTime, double) ToTuple(
         this QuoteD q,
         CandlePart candlePart) => candlePart switch
         {

--- a/src/a-d/Alligator/Alligator.Api.cs
+++ b/src/a-d/Alligator/Alligator.Api.cs
@@ -15,7 +15,7 @@ public static partial class Indicator
         int lipsPeriods = 5,
         int lipsOffset = 3)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.HL2)
+            .ToTuple(CandlePart.HL2)
             .CalcAlligator(
                 jawPeriods,
                 jawOffset,
@@ -33,7 +33,7 @@ public static partial class Indicator
         int teethOffset = 5,
         int lipsPeriods = 5,
         int lipsOffset = 3) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcAlligator(
                 jawPeriods,
                 jawOffset,

--- a/src/a-d/Alma/Alma.Api.cs
+++ b/src/a-d/Alma/Alma.Api.cs
@@ -12,7 +12,7 @@ public static partial class Indicator
         double offset = 0.85,
         double sigma = 6)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcAlma(lookbackPeriods, offset, sigma);
 
     // SERIES, from CHAIN
@@ -21,7 +21,7 @@ public static partial class Indicator
         int lookbackPeriods = 9,
         double offset = 0.85,
         double sigma = 6) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcAlma(lookbackPeriods, offset, sigma)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/a-d/Awesome/Awesome.Api.cs
+++ b/src/a-d/Awesome/Awesome.Api.cs
@@ -11,7 +11,7 @@ public static partial class Indicator
         int fastPeriods = 5,
         int slowPeriods = 34)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.HL2)
+            .ToTuple(CandlePart.HL2)
             .CalcAwesome(fastPeriods, slowPeriods);
 
     // SERIES, from CHAIN
@@ -19,7 +19,7 @@ public static partial class Indicator
         this IEnumerable<IReusableResult> results,
         int fastPeriods = 5,
         int slowPeriods = 34) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcAwesome(fastPeriods, slowPeriods)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/a-d/Beta/Beta.Api.cs
+++ b/src/a-d/Beta/Beta.Api.cs
@@ -14,10 +14,10 @@ public static partial class Indicator
         where TQuote : IQuote
     {
         List<(DateTime, double)> tpListEval
-            = quotesEval.ToBasicTuple(CandlePart.Close);
+            = quotesEval.ToTuple(CandlePart.Close);
 
         List<(DateTime, double)> tpListMrkt
-            = quotesMarket.ToBasicTuple(CandlePart.Close);
+            = quotesMarket.ToTuple(CandlePart.Close);
 
         // to enable typical 'this' extension
         return CalcBeta(tpListEval, tpListMrkt, lookbackPeriods, type);

--- a/src/a-d/BollingerBands/BollingerBands.Api.cs
+++ b/src/a-d/BollingerBands/BollingerBands.Api.cs
@@ -11,7 +11,7 @@ public static partial class Indicator
         int lookbackPeriods = 20,
         double standardDeviations = 2)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcBollingerBands(lookbackPeriods, standardDeviations);
 
     // SERIES, from CHAIN
@@ -19,7 +19,7 @@ public static partial class Indicator
         this IEnumerable<IReusableResult> results,
         int lookbackPeriods = 20,
         double standardDeviations = 2) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcBollingerBands(lookbackPeriods, standardDeviations)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/a-d/Cmf/Cmf.Series.cs
+++ b/src/a-d/Cmf/Cmf.Series.cs
@@ -8,7 +8,7 @@ public static partial class Indicator
         int lookbackPeriods)
     {
         // convert quotes
-        List<(DateTime, double)> tpList = qdList.ToBasicTuple(CandlePart.Volume);
+        List<(DateTime, double)> tpList = qdList.ToTuple(CandlePart.Volume);
 
         // check parameter arguments
         ValidateCmf(lookbackPeriods);

--- a/src/a-d/Cmo/Cmo.Api.cs
+++ b/src/a-d/Cmo/Cmo.Api.cs
@@ -10,14 +10,14 @@ public static partial class Indicator
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcCmo(lookbackPeriods);
 
     // SERIES, from CHAIN
     public static IEnumerable<CmoResult> GetCmo(
         this IEnumerable<IReusableResult> results,
         int lookbackPeriods) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcCmo(lookbackPeriods)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/a-d/ConnorsRsi/ConnorsRsi.Api.cs
+++ b/src/a-d/ConnorsRsi/ConnorsRsi.Api.cs
@@ -12,7 +12,7 @@ public static partial class Indicator
         int streakPeriods = 2,
         int rankPeriods = 100)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcConnorsRsi(rsiPeriods, streakPeriods, rankPeriods);
 
     // SERIES, from CHAIN
@@ -21,7 +21,7 @@ public static partial class Indicator
         int rsiPeriods = 3,
         int streakPeriods = 2,
         int rankPeriods = 100) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcConnorsRsi(rsiPeriods, streakPeriods, rankPeriods)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/a-d/Correlation/Correlation.Api.cs
+++ b/src/a-d/Correlation/Correlation.Api.cs
@@ -13,10 +13,10 @@ public static partial class Indicator
         where TQuote : IQuote
     {
         List<(DateTime, double)> tpListA
-            = quotesA.ToBasicTuple(CandlePart.Close);
+            = quotesA.ToTuple(CandlePart.Close);
 
         List<(DateTime, double)> tpListB
-            = quotesB.ToBasicTuple(CandlePart.Close);
+            = quotesB.ToTuple(CandlePart.Close);
 
         return CalcCorrelation(tpListA, tpListB, lookbackPeriods);
     }

--- a/src/a-d/Dema/Dema.Api.cs
+++ b/src/a-d/Dema/Dema.Api.cs
@@ -10,14 +10,14 @@ public static partial class Indicator
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcDema(lookbackPeriods);
 
     // SERIES, from CHAIN
     public static IEnumerable<DemaResult> GetDema(
         this IEnumerable<IReusableResult> results,
         int lookbackPeriods) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcDema(lookbackPeriods)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/a-d/Dpo/Dpo.Api.cs
+++ b/src/a-d/Dpo/Dpo.Api.cs
@@ -10,14 +10,14 @@ public static partial class Indicator
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcDpo(lookbackPeriods);
 
     // SERIES, from CHAIN
     public static IEnumerable<DpoResult> GetDpo(
         this IEnumerable<IReusableResult> results,
         int lookbackPeriods) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcDpo(lookbackPeriods)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/a-d/Dynamic/Dynamic.Api.cs
+++ b/src/a-d/Dynamic/Dynamic.Api.cs
@@ -11,7 +11,7 @@ public static partial class Indicator
         int lookbackPeriods,
         double kFactor = 0.6)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcDynamic(lookbackPeriods, kFactor);
 
     // SERIES, from CHAIN
@@ -19,7 +19,7 @@ public static partial class Indicator
         this IEnumerable<IReusableResult> results,
         int lookbackPeriods,
         double kFactor = 0.6) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcDynamic(lookbackPeriods, kFactor)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/e-k/ElderRay/ElderRay.Series.cs
+++ b/src/e-k/ElderRay/ElderRay.Series.cs
@@ -12,7 +12,7 @@ public static partial class Indicator
 
         // initialize with EMA
         List<ElderRayResult> results = qdList
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcEma(lookbackPeriods)
             .Select(x => new ElderRayResult(x.Date)
             {

--- a/src/e-k/Ema/Ema.Api.cs
+++ b/src/e-k/Ema/Ema.Api.cs
@@ -10,14 +10,14 @@ public static partial class Indicator
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcEma(lookbackPeriods);
 
     // SERIES, from CHAIN
     public static IEnumerable<EmaResult> GetEma(
         this IEnumerable<IReusableResult> results,
         int lookbackPeriods) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcEma(lookbackPeriods)
             .SyncIndex(results, SyncType.Prepend);
 
@@ -38,7 +38,7 @@ public static partial class Indicator
     {
         // convert quotes
         List<(DateTime, double)> tpList
-            = quotes.ToBasicTuple(CandlePart.Close);
+            = quotes.ToTuple(CandlePart.Close);
 
         return new EmaBase(tpList, lookbackPeriods);
     }
@@ -50,7 +50,7 @@ public static partial class Indicator
     {
         // convert results
         List<(DateTime, double)> tpList
-            = results.ToResultTuple();
+            = results.ToTuple();
 
         return new EmaBase(tpList, lookbackPeriods);
     }

--- a/src/e-k/Ema/Ema.Stream.cs
+++ b/src/e-k/Ema/Ema.Stream.cs
@@ -29,7 +29,7 @@ internal class EmaBase
             throw new InvalidQuotesException(nameof(quote), quote, "No quote provided.");
         }
 
-        (DateTime Date, double Value) tuple = quote.ToBasicTuple(candlePart);
+        (DateTime Date, double Value) tuple = quote.ToTuple(candlePart);
         return Add(tuple);
     }
 

--- a/src/e-k/Epma/Epma.Api.cs
+++ b/src/e-k/Epma/Epma.Api.cs
@@ -10,14 +10,14 @@ public static partial class Indicator
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcEpma(lookbackPeriods);
 
     // SERIES, from CHAIN
     public static IEnumerable<EpmaResult> GetEpma(
         this IEnumerable<IReusableResult> results,
         int lookbackPeriods) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcEpma(lookbackPeriods)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/e-k/FisherTransform/FisherTransform.Api.cs
+++ b/src/e-k/FisherTransform/FisherTransform.Api.cs
@@ -10,14 +10,14 @@ public static partial class Indicator
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods = 10)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.HL2)
+            .ToTuple(CandlePart.HL2)
             .CalcFisherTransform(lookbackPeriods);
 
     // SERIES, from CHAIN
     public static IEnumerable<FisherTransformResult> GetFisherTransform(
         this IEnumerable<IReusableResult> results,
         int lookbackPeriods) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcFisherTransform(lookbackPeriods)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/e-k/Gator/Gator.Api.cs
+++ b/src/e-k/Gator/Gator.Api.cs
@@ -9,7 +9,7 @@ public static partial class Indicator
     public static IEnumerable<GatorResult> GetGator<TQuote>(
         this IEnumerable<TQuote> quotes)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.HL2)
+            .ToTuple(CandlePart.HL2)
             .GetAlligator()
             .ToList()
             .CalcGator();
@@ -23,7 +23,7 @@ public static partial class Indicator
     // SERIES, from CHAIN
     public static IEnumerable<GatorResult> GetGator(
         this IEnumerable<IReusableResult> results) => results
-            .ToResultTuple()
+            .ToTuple()
             .GetAlligator()
             .ToList()
             .CalcGator()

--- a/src/e-k/Hma/Hma.Api.cs
+++ b/src/e-k/Hma/Hma.Api.cs
@@ -10,14 +10,14 @@ public static partial class Indicator
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcHma(lookbackPeriods);
 
     // SERIES, from CHAIN
     public static IEnumerable<HmaResult> GetHma(
         this IEnumerable<IReusableResult> results,
         int lookbackPeriods) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcHma(lookbackPeriods)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/e-k/HtTrendline/HtTrendline.Api.cs
+++ b/src/e-k/HtTrendline/HtTrendline.Api.cs
@@ -9,13 +9,13 @@ public static partial class Indicator
     public static IEnumerable<HtlResult> GetHtTrendline<TQuote>(
         this IEnumerable<TQuote> quotes)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.HL2)
+            .ToTuple(CandlePart.HL2)
             .CalcHtTrendline();
 
     // SERIES, from CHAIN
     public static IEnumerable<HtlResult> GetHtTrendline(
         this IEnumerable<IReusableResult> results) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcHtTrendline()
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/e-k/Hurst/Hurst.Api.cs
+++ b/src/e-k/Hurst/Hurst.Api.cs
@@ -9,14 +9,14 @@ public static partial class Indicator
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods = 100)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcHurst(lookbackPeriods);
 
     // SERIES, from CHAIN
     public static IEnumerable<HurstResult> GetHurst(
         this IEnumerable<IReusableResult> results,
         int lookbackPeriods) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcHurst(lookbackPeriods)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/e-k/Kama/Kama.Api.cs
+++ b/src/e-k/Kama/Kama.Api.cs
@@ -11,7 +11,7 @@ public static partial class Indicator
         int fastPeriods = 2,
         int slowPeriods = 30)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcKama(erPeriods, fastPeriods, slowPeriods);
 
     // SERIES, from CHAIN
@@ -20,7 +20,7 @@ public static partial class Indicator
         int erPeriods = 10,
         int fastPeriods = 2,
         int slowPeriods = 30) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcKama(erPeriods, fastPeriods, slowPeriods)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/e-k/Keltner/Keltner.Series.cs
+++ b/src/e-k/Keltner/Keltner.Series.cs
@@ -17,7 +17,7 @@ public static partial class Indicator
         List<KeltnerResult> results = new(length);
 
         List<EmaResult> emaResults = qdList
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcEma(emaPeriods)
             .ToList();
 

--- a/src/m-r/MaEnvelopes/MaEnvelopes.Api.cs
+++ b/src/m-r/MaEnvelopes/MaEnvelopes.Api.cs
@@ -12,7 +12,7 @@ public static partial class Indicator
         double percentOffset = 2.5,
         MaType movingAverageType = MaType.SMA)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcMaEnvelopes(lookbackPeriods, percentOffset, movingAverageType);
 
     // SERIES, from CHAIN
@@ -21,7 +21,7 @@ public static partial class Indicator
         int lookbackPeriods,
         double percentOffset = 2.5,
         MaType movingAverageType = MaType.SMA) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcMaEnvelopes(lookbackPeriods, percentOffset, movingAverageType)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/m-r/Macd/MacdApi.cs
+++ b/src/m-r/Macd/MacdApi.cs
@@ -12,7 +12,7 @@ public static partial class Indicator
         int slowPeriods = 26,
         int signalPeriods = 9)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcMacd(fastPeriods, slowPeriods, signalPeriods);
 
     // SERIES, from CHAIN
@@ -21,7 +21,7 @@ public static partial class Indicator
         int fastPeriods = 12,
         int slowPeriods = 26,
         int signalPeriods = 9) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcMacd(fastPeriods, slowPeriods, signalPeriods)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/m-r/Mama/Mama.Api.cs
+++ b/src/m-r/Mama/Mama.Api.cs
@@ -11,7 +11,7 @@ public static partial class Indicator
         double fastLimit = 0.5,
         double slowLimit = 0.05)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.HL2)
+            .ToTuple(CandlePart.HL2)
             .CalcMama(fastLimit, slowLimit);
 
     // SERIES, from CHAIN
@@ -19,7 +19,7 @@ public static partial class Indicator
         this IEnumerable<IReusableResult> results,
         double fastLimit = 0.5,
         double slowLimit = 0.05) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcMama(fastLimit, slowLimit)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/m-r/Pmo/Pmo.Api.cs
+++ b/src/m-r/Pmo/Pmo.Api.cs
@@ -12,7 +12,7 @@ public static partial class Indicator
         int smoothPeriods = 20,
         int signalPeriods = 10)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcPmo(timePeriods, smoothPeriods, signalPeriods);
 
     // SERIES, from CHAIN
@@ -21,7 +21,7 @@ public static partial class Indicator
         int timePeriods = 35,
         int smoothPeriods = 20,
         int signalPeriods = 10) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcPmo(timePeriods, smoothPeriods, signalPeriods)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/m-r/Prs/Prs.Api.cs
+++ b/src/m-r/Prs/Prs.Api.cs
@@ -14,9 +14,9 @@ public static partial class Indicator
         where TQuote : IQuote
     {
         List<(DateTime, double)> tpListBase = quotesBase
-            .ToBasicTuple(CandlePart.Close);
+            .ToTuple(CandlePart.Close);
         List<(DateTime, double)> tpListEval = quotesEval
-            .ToBasicTuple(CandlePart.Close);
+            .ToTuple(CandlePart.Close);
 
         return CalcPrs(tpListEval, tpListBase, lookbackPeriods, smaPeriods);
     }

--- a/src/m-r/Pvo/Pvo.Api.cs
+++ b/src/m-r/Pvo/Pvo.Api.cs
@@ -12,7 +12,7 @@ public static partial class Indicator
         int slowPeriods = 26,
         int signalPeriods = 9)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Volume)
+            .ToTuple(CandlePart.Volume)
             .CalcPvo(fastPeriods, slowPeriods, signalPeriods);
 
     // given that this is volume-based, other chaining is moot

--- a/src/m-r/Roc/Roc.Api.cs
+++ b/src/m-r/Roc/Roc.Api.cs
@@ -11,7 +11,7 @@ public static partial class Indicator
         int lookbackPeriods,
         int? smaPeriods = null)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcRoc(lookbackPeriods, smaPeriods);
 
     // SERIES, from CHAIN
@@ -19,7 +19,7 @@ public static partial class Indicator
         this IEnumerable<IReusableResult> results,
         int lookbackPeriods,
         int? smaPeriods = null) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcRoc(lookbackPeriods, smaPeriods)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/m-r/RocWb/RocWb.Api.cs
+++ b/src/m-r/RocWb/RocWb.Api.cs
@@ -12,7 +12,7 @@ public static partial class Indicator
         int emaPeriods,
         int stdDevPeriods)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcRocWb(lookbackPeriods, emaPeriods, stdDevPeriods);
 
     // SERIES, from CHAIN
@@ -21,7 +21,7 @@ public static partial class Indicator
         int lookbackPeriods,
         int emaPeriods,
         int stdDevPeriods) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcRocWb(lookbackPeriods, emaPeriods, stdDevPeriods)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/m-r/Rsi/Rsi.Api.cs
+++ b/src/m-r/Rsi/Rsi.Api.cs
@@ -10,14 +10,14 @@ public static partial class Indicator
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods = 14)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcRsi(lookbackPeriods);
 
     // SERIES, from CHAIN
     public static IEnumerable<RsiResult> GetRsi(
         this IEnumerable<IReusableResult> results,
         int lookbackPeriods) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcRsi(lookbackPeriods)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/s-z/Slope/Slope.Api.cs
+++ b/src/s-z/Slope/Slope.Api.cs
@@ -10,14 +10,14 @@ public static partial class Indicator
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcSlope(lookbackPeriods);
 
     // SERIES, from CHAIN
     public static IEnumerable<SlopeResult> GetSlope(
         this IEnumerable<IReusableResult> results,
         int lookbackPeriods) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcSlope(lookbackPeriods)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/s-z/Sma/Sma.Api.cs
+++ b/src/s-z/Sma/Sma.Api.cs
@@ -10,14 +10,14 @@ public static partial class Indicator
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcSma(lookbackPeriods);
 
     // SERIES, from CHAIN
     public static IEnumerable<SmaResult> GetSma(
         this IEnumerable<IReusableResult> results,
         int lookbackPeriods) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcSma(lookbackPeriods)
             .SyncIndex(results, SyncType.Prepend);
 
@@ -35,14 +35,14 @@ public static partial class Indicator
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcSmaAnalysis(lookbackPeriods);
 
     // ANALYSIS, from CHAIN
     public static IEnumerable<SmaAnalysis> GetSmaAnalysis(
         this IEnumerable<IReusableResult> results,
         int lookbackPeriods) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcSmaAnalysis(lookbackPeriods)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/s-z/Smma/Smma.Api.cs
+++ b/src/s-z/Smma/Smma.Api.cs
@@ -10,14 +10,14 @@ public static partial class Indicator
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcSmma(lookbackPeriods);
 
     // SERIES, from CHAIN
     public static IEnumerable<SmmaResult> GetSmma(
         this IEnumerable<IReusableResult> results,
         int lookbackPeriods) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcSmma(lookbackPeriods)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/s-z/StarcBands/StarcBands.Series.cs
+++ b/src/s-z/StarcBands/StarcBands.Series.cs
@@ -16,7 +16,7 @@ public static partial class Indicator
         List<AtrResult> atrResults = qdList.CalcAtr(atrPeriods);
 
         List<StarcBandsResult> results = qdList
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcSma(smaPeriods)
             .Select(x => new StarcBandsResult(x.Date)
             {

--- a/src/s-z/Stc/Stc.Api.cs
+++ b/src/s-z/Stc/Stc.Api.cs
@@ -12,7 +12,7 @@ public static partial class Indicator
         int fastPeriods = 23,
         int slowPeriods = 50)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcStc(cyclePeriods, fastPeriods, slowPeriods);
 
     // SERIES, from CHAIN
@@ -21,7 +21,7 @@ public static partial class Indicator
         int cyclePeriods = 10,
         int fastPeriods = 23,
         int slowPeriods = 50) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcStc(cyclePeriods, fastPeriods, slowPeriods)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/s-z/StdDev/StdDev.Api.cs
+++ b/src/s-z/StdDev/StdDev.Api.cs
@@ -11,7 +11,7 @@ public static partial class Indicator
         int lookbackPeriods,
         int? smaPeriods = null)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcStdDev(lookbackPeriods, smaPeriods);
 
     // SERIES, from CHAIN
@@ -19,7 +19,7 @@ public static partial class Indicator
         this IEnumerable<IReusableResult> results,
         int lookbackPeriods,
         int? smaPeriods = null) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcStdDev(lookbackPeriods, smaPeriods)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/s-z/StdDevChannels/StdDevChannels.Api.cs
+++ b/src/s-z/StdDevChannels/StdDevChannels.Api.cs
@@ -11,7 +11,7 @@ public static partial class Indicator
         int? lookbackPeriods = 20,
         double stdDeviations = 2)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcStdDevChannels(lookbackPeriods, stdDeviations);
 
     // SERIES, from CHAIN
@@ -19,7 +19,7 @@ public static partial class Indicator
         this IEnumerable<IReusableResult> results,
         int? lookbackPeriods = 20,
         double stdDeviations = 2) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcStdDevChannels(lookbackPeriods, stdDeviations)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/s-z/Stoch/Stoch.Series.cs
+++ b/src/s-z/Stoch/Stoch.Series.cs
@@ -54,7 +54,7 @@ public static partial class Indicator
                     : 0;
 
                 // reclaim nulls from NaNs
-                r.Oscillator = NullMath.NaN2Null(r.Oscillator);
+                r.Oscillator = r.Oscillator.NaN2Null();
             }
         }
 

--- a/src/s-z/StochRsi/StochRsi.Api.cs
+++ b/src/s-z/StochRsi/StochRsi.Api.cs
@@ -13,7 +13,7 @@ public static partial class Indicator
         int signalPeriods,
         int smoothPeriods = 1)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcStochRsi(
                 rsiPeriods,
                 stochPeriods,
@@ -27,7 +27,7 @@ public static partial class Indicator
         int stochPeriods,
         int signalPeriods,
         int smoothPeriods) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcStochRsi(
                 rsiPeriods,
                 stochPeriods,

--- a/src/s-z/T3/T3.Api.cs
+++ b/src/s-z/T3/T3.Api.cs
@@ -11,7 +11,7 @@ public static partial class Indicator
         int lookbackPeriods = 5,
         double volumeFactor = 0.7)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcT3(lookbackPeriods, volumeFactor);
 
     // SERIES, from CHAIN
@@ -19,7 +19,7 @@ public static partial class Indicator
         this IEnumerable<IReusableResult> results,
         int lookbackPeriods = 5,
         double volumeFactor = 0.7) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcT3(lookbackPeriods, volumeFactor)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/s-z/Tema/Tema.Api.cs
+++ b/src/s-z/Tema/Tema.Api.cs
@@ -10,14 +10,14 @@ public static partial class Indicator
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcTema(lookbackPeriods);
 
     // SERIES, from CHAIN
     public static IEnumerable<TemaResult> GetTema(
         this IEnumerable<IReusableResult> results,
         int lookbackPeriods) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcTema(lookbackPeriods)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/s-z/Trix/Trix.Api.cs
+++ b/src/s-z/Trix/Trix.Api.cs
@@ -11,7 +11,7 @@ public static partial class Indicator
         int lookbackPeriods,
         int? signalPeriods = null)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcTrix(lookbackPeriods, signalPeriods);
 
     // SERIES, from CHAIN
@@ -19,7 +19,7 @@ public static partial class Indicator
         this IEnumerable<IReusableResult> results,
         int lookbackPeriods,
         int? signalPeriods = null) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcTrix(lookbackPeriods, signalPeriods)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/s-z/Tsi/Tsi.Api.cs
+++ b/src/s-z/Tsi/Tsi.Api.cs
@@ -12,7 +12,7 @@ public static partial class Indicator
         int smoothPeriods = 13,
         int signalPeriods = 7)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcTsi(lookbackPeriods, smoothPeriods, signalPeriods);
 
     // SERIES, from CHAIN
@@ -21,7 +21,7 @@ public static partial class Indicator
         int lookbackPeriods = 25,
         int smoothPeriods = 13,
         int signalPeriods = 7) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcTsi(lookbackPeriods, smoothPeriods, signalPeriods)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/s-z/UlcerIndex/UlcerIndex.Api.cs
+++ b/src/s-z/UlcerIndex/UlcerIndex.Api.cs
@@ -10,14 +10,14 @@ public static partial class Indicator
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods = 14)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcUlcerIndex(lookbackPeriods);
 
     // SERIES, from CHAIN
     public static IEnumerable<UlcerIndexResult> GetUlcerIndex(
         this IEnumerable<IReusableResult> results,
         int lookbackPeriods) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcUlcerIndex(lookbackPeriods)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/src/s-z/VolatilityStop/VolatilityStop.Series.cs
+++ b/src/s-z/VolatilityStop/VolatilityStop.Series.cs
@@ -10,7 +10,7 @@ public static partial class Indicator
     {
         // convert quotes
         List<(DateTime, double)> tpList = qdList
-            .ToBasicTuple(CandlePart.Close);
+            .ToTuple(CandlePart.Close);
 
         // check parameter arguments
         ValidateVolatilityStop(lookbackPeriods, multiplier);

--- a/src/s-z/Wma/Wma.Api.cs
+++ b/src/s-z/Wma/Wma.Api.cs
@@ -10,14 +10,14 @@ public static partial class Indicator
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods)
         where TQuote : IQuote => quotes
-            .ToBasicTuple(CandlePart.Close)
+            .ToTuple(CandlePart.Close)
             .CalcWma(lookbackPeriods);
 
     // SERIES, from CHAIN
     public static IEnumerable<WmaResult> GetWma(
         this IEnumerable<IReusableResult> results,
         int lookbackPeriods) => results
-            .ToResultTuple()
+            .ToTuple()
             .CalcWma(lookbackPeriods)
             .SyncIndex(results, SyncType.Prepend);
 

--- a/tests/indicators/_common/Test.Candles.cs
+++ b/tests/indicators/_common/Test.Candles.cs
@@ -50,9 +50,9 @@ public class Candles : TestBase
         Assert.AreEqual(0.19m, r0.Candle.Body);
         Assert.AreEqual(0.55m, r0.Candle.UpperWick);
         Assert.AreEqual(1.09m, r0.Candle.LowerWick);
-        Assert.AreEqual(0.10383, NullMath.Round(r0.Candle.BodyPct, 5));
-        Assert.AreEqual(0.30055, NullMath.Round(r0.Candle.UpperWickPct, 5));
-        Assert.AreEqual(0.59563, NullMath.Round(r0.Candle.LowerWickPct, 5));
+        Assert.AreEqual(0.10383, r0.Candle.BodyPct.Round(5));
+        Assert.AreEqual(0.30055, r0.Candle.UpperWickPct.Round(5));
+        Assert.AreEqual(0.59563, r0.Candle.LowerWickPct.Round(5));
         Assert.IsTrue(r0.Candle.IsBullish);
         Assert.IsFalse(r0.Candle.IsBearish);
 
@@ -61,9 +61,9 @@ public class Candles : TestBase
         Assert.AreEqual(0m, r351.Candle.Body);
         Assert.AreEqual(0.69m, r351.Candle.UpperWick);
         Assert.AreEqual(0.55m, r351.Candle.LowerWick);
-        Assert.AreEqual(0, NullMath.Round(r351.Candle.BodyPct, 5));
-        Assert.AreEqual(0.55645, NullMath.Round(r351.Candle.UpperWickPct, 5));
-        Assert.AreEqual(0.44355, NullMath.Round(r351.Candle.LowerWickPct, 5));
+        Assert.AreEqual(0, r351.Candle.BodyPct.Round(5));
+        Assert.AreEqual(0.55645, r351.Candle.UpperWickPct.Round(5));
+        Assert.AreEqual(0.44355, r351.Candle.LowerWickPct.Round(5));
         Assert.IsFalse(r351.Candle.IsBullish);
         Assert.IsFalse(r351.Candle.IsBearish);
 
@@ -72,9 +72,9 @@ public class Candles : TestBase
         Assert.AreEqual(0.36m, r501.Candle.Body);
         Assert.AreEqual(0.26m, r501.Candle.UpperWick);
         Assert.AreEqual(2.05m, r501.Candle.LowerWick);
-        Assert.AreEqual(0.13483, NullMath.Round(r501.Candle.BodyPct, 5));
-        Assert.AreEqual(0.09738, NullMath.Round(r501.Candle.UpperWickPct, 5));
-        Assert.AreEqual(0.76779, NullMath.Round(r501.Candle.LowerWickPct, 5));
+        Assert.AreEqual(0.13483, r501.Candle.BodyPct.Round(5));
+        Assert.AreEqual(0.09738, r501.Candle.UpperWickPct.Round(5));
+        Assert.AreEqual(0.76779, r501.Candle.LowerWickPct.Round(5));
         Assert.IsTrue(r501.Candle.IsBullish);
         Assert.IsFalse(r501.Candle.IsBearish);
     }

--- a/tests/indicators/_common/Test.QuoteUtility.cs
+++ b/tests/indicators/_common/Test.QuoteUtility.cs
@@ -7,7 +7,7 @@ namespace Internal.Tests;
 public class QuoteUtility : TestBase
 {
     [TestMethod]
-    public void QuoteToBasicTuple()
+    public void QuoteToTuple()
     {
         DateTime d = DateTime.Parse("5/5/2055", EnglishCulture);
 
@@ -34,38 +34,38 @@ public class QuoteUtility : TestBase
 
         Assert.AreEqual(
             NullMath.Round((double)o, 10),
-            NullMath.Round(q.ToBasicTuple(CandlePart.Open).Item2, 10));
+            NullMath.Round(q.ToTuple(CandlePart.Open).value, 10));
         Assert.AreEqual(
             NullMath.Round((double)h, 10),
-            NullMath.Round(q.ToBasicTuple(CandlePart.High).Item2, 10));
+            NullMath.Round(q.ToTuple(CandlePart.High).value, 10));
         Assert.AreEqual(
             NullMath.Round((double)l, 10),
-            NullMath.Round(q.ToBasicTuple(CandlePart.Low).Item2, 10));
+            NullMath.Round(q.ToTuple(CandlePart.Low).value, 10));
         Assert.AreEqual(
             NullMath.Round((double)c, 10),
-            NullMath.Round(q.ToBasicTuple(CandlePart.Close).Item2, 10));
+            NullMath.Round(q.ToTuple(CandlePart.Close).value, 10));
         Assert.AreEqual(
             NullMath.Round((double)v, 10),
-            NullMath.Round(q.ToBasicTuple(CandlePart.Volume).Item2, 10));
+            NullMath.Round(q.ToTuple(CandlePart.Volume).value, 10));
         Assert.AreEqual(
             NullMath.Round((double)hl2, 10),
-            NullMath.Round(q.ToBasicTuple(CandlePart.HL2).Item2, 10));
+            NullMath.Round(q.ToTuple(CandlePart.HL2).value, 10));
         Assert.AreEqual(
             NullMath.Round((double)hlc3, 10),
-            NullMath.Round(q.ToBasicTuple(CandlePart.HLC3).Item2, 10));
+            NullMath.Round(q.ToTuple(CandlePart.HLC3).value, 10));
         Assert.AreEqual(
             NullMath.Round((double)oc2, 10),
-            NullMath.Round(q.ToBasicTuple(CandlePart.OC2).Item2, 10));
+            NullMath.Round(q.ToTuple(CandlePart.OC2).value, 10));
         Assert.AreEqual(
             NullMath.Round((double)ohl3, 10),
-            NullMath.Round(q.ToBasicTuple(CandlePart.OHL3).Item2, 10));
+            NullMath.Round(q.ToTuple(CandlePart.OHL3).value, 10));
         Assert.AreEqual(
             NullMath.Round((double)ohlc4, 10),
-            NullMath.Round(q.ToBasicTuple(CandlePart.OHLC4).Item2, 10));
+            NullMath.Round(q.ToTuple(CandlePart.OHLC4).value, 10));
 
         // bad argument
         Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
-            q.ToBasicTuple((CandlePart)999));
+            q.ToTuple((CandlePart)999));
 
         // bad argument
         Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
@@ -135,7 +135,7 @@ public class QuoteUtility : TestBase
     }
 
     [TestMethod]
-    public void QuoteDToBasicTuple()
+    public void QuoteDToTuple()
     {
         DateTime d = DateTime.Parse("5/5/2055", EnglishCulture);
 
@@ -162,37 +162,37 @@ public class QuoteUtility : TestBase
 
         Assert.AreEqual(
             NullMath.Round((double)o, 10),
-            NullMath.Round(q.ToBasicTuple(CandlePart.Open).Item2, 10));
+            NullMath.Round(q.ToTuple(CandlePart.Open).Item2, 10));
         Assert.AreEqual(
             NullMath.Round((double)h, 10),
-            NullMath.Round(q.ToBasicTuple(CandlePart.High).Item2, 10));
+            NullMath.Round(q.ToTuple(CandlePart.High).Item2, 10));
         Assert.AreEqual(
             NullMath.Round((double)l, 10),
-            NullMath.Round(q.ToBasicTuple(CandlePart.Low).Item2, 10));
+            NullMath.Round(q.ToTuple(CandlePart.Low).Item2, 10));
         Assert.AreEqual(
             NullMath.Round((double)c, 10),
-            NullMath.Round(q.ToBasicTuple(CandlePart.Close).Item2, 10));
+            NullMath.Round(q.ToTuple(CandlePart.Close).Item2, 10));
         Assert.AreEqual(
             NullMath.Round((double)v, 10),
-            NullMath.Round(q.ToBasicTuple(CandlePart.Volume).Item2, 10));
+            NullMath.Round(q.ToTuple(CandlePart.Volume).Item2, 10));
         Assert.AreEqual(
             NullMath.Round((double)hl2, 10),
-            NullMath.Round(q.ToBasicTuple(CandlePart.HL2).Item2, 10));
+            NullMath.Round(q.ToTuple(CandlePart.HL2).Item2, 10));
         Assert.AreEqual(
             NullMath.Round((double)hlc3, 10),
-            NullMath.Round(q.ToBasicTuple(CandlePart.HLC3).Item2, 10));
+            NullMath.Round(q.ToTuple(CandlePart.HLC3).Item2, 10));
         Assert.AreEqual(
             NullMath.Round((double)oc2, 10),
-            NullMath.Round(q.ToBasicTuple(CandlePart.OC2).Item2, 10));
+            NullMath.Round(q.ToTuple(CandlePart.OC2).Item2, 10));
         Assert.AreEqual(
             NullMath.Round((double)ohl3, 10),
-            NullMath.Round(q.ToBasicTuple(CandlePart.OHL3).Item2, 10));
+            NullMath.Round(q.ToTuple(CandlePart.OHL3).Item2, 10));
         Assert.AreEqual(
             NullMath.Round((double)ohlc4, 10),
-            NullMath.Round(q.ToBasicTuple(CandlePart.OHLC4).Item2, 10));
+            NullMath.Round(q.ToTuple(CandlePart.OHLC4).Item2, 10));
 
         // bad argument
         Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
-            q.ToBasicTuple((CandlePart)999));
+            q.ToTuple((CandlePart)999));
     }
 }

--- a/tests/performance/Perf.Helpers.cs
+++ b/tests/performance/Perf.Helpers.cs
@@ -31,7 +31,7 @@ public class HelperPerformance
     public object Aggregate() => i.Aggregate(PeriodSize.FifteenMinutes);
 
     [Benchmark]
-    public object ToBasicTuple() => h.ToBasicTuple(CandlePart.Close);
+    public object ToTuple() => h.ToTuple(CandlePart.Close);
 
     [Benchmark]
     public object ToCandleResults() => h.ToCandleResults();


### PR DESCRIPTION
Some minor refactoring to rename `ToBasicTuple()` to `ToTuple()` for simpler terminology, comparable to others in the library.

:warning: breaking change to the public interface, but gracefully handled backward compatibility and a deprecation warning.

### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have put comments in my code, particularly for hard-to-understand areas
- [x] I have performed a self-review of my code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings or other code analysis issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
