### PR TITLE
chore: fix doc img size, nav chip styles

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -78,6 +78,7 @@
     "Klinger",
     "Kouzis",
     "Kroll",
+    "lazyload",
     "Legoux",
     "Levshin",
     "Loukas",

--- a/docs/GemFile.lock
+++ b/docs/GemFile.lock
@@ -31,7 +31,7 @@ GEM
     ethon (0.16.0)
       ffi (>= 1.15.0)
     execjs (2.8.1)
-    faraday (2.6.0)
+    faraday (2.7.1)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ Explore more information:
 
 ## Samples
 
-<img data-src="examples.webp" height="1591" width="1443" alt="sample indicators shown in chart" class="lazyload" />
+<img data-src="examples.webp" alt="sample indicators shown in chart" class="lazyload" style="aspect-ratio:1443/1591;" />
 
 ### Basic usage
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ Explore more information:
 
 ## Samples
 
-<img data-src="examples.webp" alt="sample indicators shown in chart" class="lazyload" />
+<img data-src="examples.webp" height="1591" width="1443" alt="sample indicators shown in chart" class="lazyload" />
 
 ### Basic usage
 

--- a/docs/_layouts/base.html
+++ b/docs/_layouts/base.html
@@ -5,7 +5,7 @@
 <meta charset="UTF-8">
 
 <!-- pre-connections -->
-<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.googleapis.com/css?family=Open+Sans:400,700">
 {% if page.dir == '/' %}
 <link rel="preconnect" href="https://github.githubassets.com">
 <link rel="preconnect" href="https://img.shields.io">

--- a/docs/_layouts/base.html
+++ b/docs/_layouts/base.html
@@ -4,6 +4,13 @@
 <head>
 <meta charset="UTF-8">
 
+<!-- pre-connections -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+{% if page.dir == '/' %}
+<link rel="preconnect" href="https://github.githubassets.com">
+<link rel="preconnect" href="https://img.shields.io">
+{% endif %}
+
 {% if site.github.source.branch != "main" or page.noindex == true %}
 <!-- exclude from search indexing -->
 <meta name="robots" content="noindex, nofollow">
@@ -21,6 +28,7 @@
 <link rel="icon" type="image/png" sizes="16x16" href="{{ '/assets/icons/favicon-16x16.png' | relative_url }}">
 <link rel="apple-touch-icon" sizes="180x180" href="{{ '/assets/icons/apple-touch-icon.png' | relative_url }}">
 <link rel="mask-icon" href="{{ '/assets/icons/safari-pinned-tab.svg' | relative_url }}" color="#424242">
+
 <script src="/assets/js/lazysizes.min.js" async=""></script>
 
 {% if site.ga_tag and site.github.source.branch == 'main' %}

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -398,22 +398,24 @@ h5 {
     white-space: nowrap;
     font-size: 1em;
 
-    border-style: solid;
-    border-width: 2.5px;
-    border-radius: 0.25em;
-    border-color: $border-color;
-    padding: 0.25em 0.5em;
-
     margin: 0.5em 0.25em;
 
-    &:hover {
-      box-shadow:
-        0px 5px 5px -3px rgba(0, 0, 0, 0.2),
-        0px 8px 10px 1px rgba(0, 0, 0, 0.14),
-        0px 3px 14px 2px rgba(0, 0, 0, 0.12);
-      background-color: $code-bg-color;
-      text-decoration: none !important;
-      cursor: pointer;
+    a {
+      border-style: solid;
+      border-width: 2.5px;
+      border-radius: 0.25em;
+      border-color: $border-color;
+      padding: 0.25em 0.5em;
+
+      &:hover {
+        box-shadow:
+          0px 5px 5px -3px rgba(0, 0, 0, 0.2),
+          0px 8px 10px 1px rgba(0, 0, 0, 0.14),
+          0px 3px 14px 2px rgba(0, 0, 0, 0.12);
+        background-color: $code-bg-color;
+        text-decoration: none !important;
+        cursor: pointer;
+      }
     }
   }
 }

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -30,6 +30,7 @@ $mobile-breakpoint: 24em; // custom
     @content;
   }
 }
+
 // Headers
 $header-heading-color: $color-primary-light;
 $header-bg-color: $color-primary;
@@ -208,6 +209,10 @@ h5 {
   ol {
     li {
       padding-bottom: 6px;
+
+      @include mobile {
+        padding-top: 2px;
+      }
     }
   }
 
@@ -232,7 +237,7 @@ h5 {
     padding: 1rem 0.5rem 1rem 1rem;
     font-size: 1rem;
 
-    code{
+    code {
       font-size: 1em;
     }
   }
@@ -390,7 +395,7 @@ h5 {
 
 .pipe-list {
   padding-top: 0 !important;
-  line-height: 2.6em;
+  padding-inline-start: 0;
   text-align: center;
 
   li {
@@ -401,6 +406,8 @@ h5 {
     margin: 0.5em 0.25em;
 
     a {
+      line-height: 2.6em;
+
       border-style: solid;
       border-width: 2.5px;
       border-radius: 0.25em;

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -12,17 +12,17 @@ redirect_from:
 
 <nav role="navigation" aria-label="guide page menu">
 <ul class="pipe-list">
-  <a href="#installation-and-setup"><li>Installation and setup</li></a>
-  <a href="#prerequisite-data"><li>Prerequisite data</li></a>
-  <a href="#example-usage"><li>Example usage</li></a>
-  <a href="#historical-quotes"><li>Historical quotes</li></a>
-  <a href="#using-custom-quote-classes"><li>Using custom quote classes</li></a>
-  <a href="#using-custom-results-classes"><li>Using custom results classes</li></a>
-  <a href="#generating-indicator-of-indicators"><li>Generating indicator of indicators</li></a>
-  <a href="#candlestick-patterns"><li>Candlestick patterns</li></a>
-  <a href="{{site.baseurl}}/custom-indicators/#content"><li>Creating custom indicators</li></a>
-  <a href="{{site.baseurl}}/utilities/#content"><li>Utilities and helper functions</li></a>
-  <a href="{{site.baseurl}}/contributing/#content"><li>Contributing guidelines</li></a>
+  <li><a href="#installation-and-setup">Installation and setup</a></li>
+  <li><a href="#prerequisite-data">Prerequisite data</a></li>
+  <li><a href="#example-usage">Example usage</a></li>
+  <li><a href="#historical-quotes">Historical quotes</a></li>
+  <li><a href="#using-custom-quote-classes">Using custom quote classes</a></li>
+  <li><a href="#using-custom-results-classes">Using custom results classes</a></li>
+  <li><a href="#generating-indicator-of-indicators">Generating indicator of indicators</a></li>
+  <li><a href="#candlestick-patterns">Candlestick patterns</a></li>
+  <li><a href="{{site.baseurl}}/custom-indicators/#content">Creating custom indicators</a></li>
+  <li><a href="{{site.baseurl}}/utilities/#content">Utilities and helper functions</a></li>
+  <li><a href="{{site.baseurl}}/contributing/#content">Contributing guidelines</a></li>
 </ul>
 </nav>
 

--- a/docs/indicators.html
+++ b/docs/indicators.html
@@ -13,11 +13,11 @@ redirect_from:
 <nav role="navigation" aria-label="indicator category page menu">
   <ul class="pipe-list">
     {% for c in site.data.categories %}
-    <a href="{{site.baseurl}}{{page.permalink}}#{{c.type}}">
-      <li>
+    <li>
+      <a href="{{site.baseurl}}{{page.permalink}}#{{c.type}}">
         {{ c.name }}
-      </li>
-    </a>
+      </a>
+    </li>
     {% endfor %}
   </ul>
 </nav>


### PR DESCRIPTION
### Description

Optimize various page styles for core web vitals

- [x] update and review all nav chip elements to put `a` in `li`
- [x] add explicit `height` and `width` for images based native image size
- [x] preload all fonts

### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have put comments in my code, particularly for hard-to-understand areas
- [x] I have performed a self-review of my code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings or other code analysis issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation
