### PR TITLE
adjust PSAR validation

### DIFF
--- a/docs/_indicators/ParabolicSar.md
+++ b/docs/_indicators/ParabolicSar.md
@@ -30,7 +30,7 @@ IEnumerable<ParabolicSarResult> results =
 
 **`maxAccelerationFactor`** _`double`_ - Maximum factor limit.  Must be greater than `accelerationStep`.  Default is 0.2
 
-**`initialFactor`** _`double`_ - Optional.  Initial Acceleration Factor.  Must be greater than 0.  Default is `accelerationStep`.
+**`initialFactor`** _`double`_ - Optional.  Initial Acceleration Factor.  Must be greater than 0 and not larger than `maxAccelerationFactor`.  Default is `accelerationStep`.
 
 ### Historical quotes requirements
 

--- a/src/m-r/ParabolicSar/ParabolicSar.Series.cs
+++ b/src/m-r/ParabolicSar/ParabolicSar.Series.cs
@@ -183,16 +183,16 @@ public static partial class Indicator
         {
             string message = string.Format(
                 EnglishCulture,
-                "Acceleration Step must be smaller than provided Max Acceleration Factor ({0}) for Parabolic SAR.",
+                "Acceleration Step cannot be larger than the Max Acceleration Factor ({0}) for Parabolic SAR.",
                 maxAccelerationFactor);
 
             throw new ArgumentOutOfRangeException(nameof(accelerationStep), accelerationStep, message);
         }
 
-        if (initialFactor <= 0 || initialFactor >= maxAccelerationFactor)
+        if (initialFactor <= 0 || initialFactor > maxAccelerationFactor)
         {
             throw new ArgumentOutOfRangeException(nameof(initialFactor), initialFactor,
-                "Initial Step must be greater than 0 and less than Max Acceleration Factor for Parabolic SAR.");
+                "Initial Factor must be greater than 0 and not larger than Max Acceleration Factor for Parabolic SAR.");
         }
     }
 }

--- a/tests/indicators/m-r/ParabolicSar/ParabolicSar.Tests.cs
+++ b/tests/indicators/m-r/ParabolicSar/ParabolicSar.Tests.cs
@@ -114,7 +114,7 @@ public class ParabolicSarTests : TestBase
     public void BadData()
     {
         List<ParabolicSarResult> r = badQuotes
-            .GetParabolicSar()
+            .GetParabolicSar(0.2, 0.2, 0.2)
             .ToList();
 
         Assert.AreEqual(502, r.Count);


### PR DESCRIPTION
Relaxing the validation rules for Parabolic SAR.  Inspired by #1028