### PR TITLE
Remove default value for StarcBands

### DIFF
--- a/src/_common/ObsoleteV2.cs
+++ b/src/_common/ObsoleteV2.cs
@@ -28,8 +28,8 @@ public static partial class Indicator
     [Obsolete("Rename 'ToTupleCollection(..)' to 'ToTupleChainable(..)' to fix.", false)]
     public static Collection<(DateTime Date, double Value)> ToTupleCollection(
     this IEnumerable<IReusableResult> reusable)
-    => reusable
-        .ToTupleChainable();
+        => reusable
+            .ToTupleChainable();
 
     [ExcludeFromCodeCoverage]
     [Obsolete("Rename 'ToTupleCollection(NullTo..)' to either 'ToTupleNaN(..)' or 'ToTupleNull(..)' to fix.", false)]
@@ -49,6 +49,14 @@ public static partial class Indicator
 
         return results;
     }
+
+    // v2.4.10
+    [ExcludeFromCodeCoverage]
+    [Obsolete("Change 'GetStarcBands()' to 'GetStarcBands(20)' to fix.", false)]
+    public static IEnumerable<StarcBandsResult> GetStarcBands<TQuote>(
+        this IEnumerable<TQuote> quotes)
+        where TQuote : IQuote
+        => quotes.GetStarcBands(20);
 
 #pragma warning restore CA1002 // Do not expose generic lists
 }

--- a/src/s-z/StarcBands/StarcBands.Api.cs
+++ b/src/s-z/StarcBands/StarcBands.Api.cs
@@ -8,7 +8,7 @@ public static partial class Indicator
     ///
     public static IEnumerable<StarcBandsResult> GetStarcBands<TQuote>(
         this IEnumerable<TQuote> quotes,
-        int smaPeriods = 20,
+        int smaPeriods,
         double multiplier = 2,
         int atrPeriods = 10)
         where TQuote : IQuote => quotes

--- a/tests/indicators/s-z/StarcBands/StarcBands.Tests.cs
+++ b/tests/indicators/s-z/StarcBands/StarcBands.Tests.cs
@@ -66,13 +66,13 @@ public class StarcBandsTests : TestBase
     public void NoQuotes()
     {
         List<StarcBandsResult> r0 = noquotes
-            .GetStarcBands()
+            .GetStarcBands(10)
             .ToList();
 
         Assert.AreEqual(0, r0.Count);
 
         List<StarcBandsResult> r1 = onequote
-            .GetStarcBands()
+            .GetStarcBands(10)
             .ToList();
 
         Assert.AreEqual(1, r1.Count);

--- a/tests/performance/Perf.Indicators.cs
+++ b/tests/performance/Perf.Indicators.cs
@@ -262,7 +262,7 @@ public class IndicatorPerformance
     public object GetSmma() => h.GetSmma(10);
 
     [Benchmark]
-    public object GetStarcBands() => h.GetStarcBands();
+    public object GetStarcBands() => h.GetStarcBands(10);
 
     [Benchmark]
     public object GetStc() => h.GetStc();


### PR DESCRIPTION
### Description

Remove default value for **_smaPeriods_** argument for StarcBands indicator. Previous 20 was too high and there is no general default value so force users to provide some.

See https://github.com/DaveSkender/Stock.Indicators/discussions/1045