### PR TITLE
fix: stoch SMMA init bug

### DIFF
--- a/src/s-z/Stoch/Stoch.Series.cs
+++ b/src/s-z/Stoch/Stoch.Series.cs
@@ -73,7 +73,7 @@ public static partial class Indicator
 
         // signal (%D) and %J
         int signalIndex = lookbackPeriods + smoothPeriods + signalPeriods - 2;
-        double? s = results[lookbackPeriods - 1].Oscillator;
+        double? s = null;
 
         for (int i = lookbackPeriods - 1; i < length; i++)
         {
@@ -102,7 +102,7 @@ public static partial class Indicator
             // SMMA case
             else if (i >= lookbackPeriods - 1 && movingAverageType is MaType.SMMA)
             {
-                s ??= results[i].Oscillator; // reset if null
+                s ??= results[i].Oscillator; // set initial or reset if null
 
                 s = ((s * (signalPeriods - 1)) + results[i].Oscillator) / signalPeriods;
                 r.Signal = s;

--- a/tests/indicators/s-z/Stc/Stc.Tests.cs
+++ b/tests/indicators/s-z/Stc/Stc.Tests.cs
@@ -119,6 +119,20 @@ public class StcTests : TestBase
     }
 
     [TestMethod]
+    public void Issue1107()
+    {
+        // stochastic SMMA variant initialization bug
+
+        RandomGbm quotes = new(58);
+
+        List<StcResult> results = quotes
+            .GetStc(10, 23, 50)
+            .ToList();
+
+        Assert.AreEqual(58, results.Count);
+    }
+
+    [TestMethod]
     public void Removed()
     {
         int cyclePeriods = 9;


### PR DESCRIPTION
### Description

When using a specific quote history size with STC, it attempts to initialize the SMMA variant of the underlying Stoch indicator, which is entirely unnecessary.  We've removed the superfluous initialization.

Fixes #1107

### Checklist

- [x] My code follows the existing style, code structure, and naming taxonomy
- [x] I have put comments in my code, particularly for hard-to-understand areas
- [x] I have performed a self-review of my code and included any verifying manual calculations
- [x] I have added or updated unit tests that prove my fix is effective or that my feature works and achieves sufficient code coverage.  New and existing unit tests pass locally and in the build (below) with my changes
- [x] My changes generate no new warnings or other code analysis issues
- [x] I have added or run the performance tests that depict optimal execution times
- [x] I have made corresponding changes to the documentation

@MhAllan, thank you for reporting.