### PR TITLE
add default param value for RSI chainee

### DIFF
--- a/src/m-r/Rsi/Rsi.Api.cs
+++ b/src/m-r/Rsi/Rsi.Api.cs
@@ -16,7 +16,7 @@ public static partial class Indicator
     // SERIES, from CHAIN
     public static IEnumerable<RsiResult> GetRsi(
         this IEnumerable<IReusableResult> results,
-        int lookbackPeriods) => results
+        int lookbackPeriods = 14) => results
             .ToTuple()
             .CalcRsi(lookbackPeriods)
             .SyncIndex(results, SyncType.Prepend);
@@ -24,7 +24,7 @@ public static partial class Indicator
     // SERIES, from TUPLE
     public static IEnumerable<RsiResult> GetRsi(
         this IEnumerable<(DateTime, double)> priceTuples,
-        int lookbackPeriods) => priceTuples
+        int lookbackPeriods = 14) => priceTuples
             .ToSortedList()
             .CalcRsi(lookbackPeriods);
 }


### PR DESCRIPTION
Adds default value for chainable RSI.  Fixes #1133 

Workaround is to simply add the default value yourself:

```csharp
// chained
IEnumerable<RsiResult> results = quotes
    .GetObv()
    .GetRsi(14);   //  <-- must provide value for RSI param
```

https://dotnetfiddle.net/mYKSJX