### PR TITLE
fix: Restore package assets

### DIFF
--- a/src/Indicators.csproj
+++ b/src/Indicators.csproj
@@ -59,15 +59,19 @@
   <ItemGroup>
     <None Include="..\README.md">
       <Pack>True</Pack>
+      <PackagePath></PackagePath>
     </None>
     <None Include="..\LICENSE">
       <Pack>True</Pack>
+      <PackagePath></PackagePath>
     </None>
     <None Include="..\NOTICE">
       <Pack>True</Pack>
+      <PackagePath></PackagePath>
     </None>
     <None Include="icon.png">
       <Pack>True</Pack>
+      <PackagePath></PackagePath>
     </None>
   </ItemGroup>
 


### PR DESCRIPTION
I’d mistakenly removed empty path assignments for package assets, restoring these will unblock packaging in deployment.  Ref: [broken deploy](https://github.com/DaveSkender/Stock.Indicators/actions/runs/7681764761)