### PR TITLE
fix: Heikin-Ashi docs

### DIFF
--- a/docs/_indicators/HeikinAshi.md
+++ b/docs/_indicators/HeikinAshi.md
@@ -35,7 +35,6 @@ IEnumerable<HeikinAshiResult>
 - This method returns a time series of all available indicator values for the `quotes` provided.
 - It always returns the same number of elements as there are in the historical quotes.
 - It does not return a single incremental indicator value.
-- The first period will have `null` values since there's not enough data to calculate.
 - `HeikinAshiResult` is based on `IQuote`, so it can be used as a direct replacement for `quotes`.
 
 ### HeikinAshiResult

--- a/src/e-k/HeikinAshi/HeikinAshi.Series.cs
+++ b/src/e-k/HeikinAshi/HeikinAshi.Series.cs
@@ -14,6 +14,13 @@ public static partial class Indicator
         decimal prevOpen = decimal.MinValue;
         decimal prevClose = decimal.MinValue;
 
+        if (length > 0)
+        {
+            TQuote q = quotesList[0];
+            prevOpen = q.Open;
+            prevClose = q.Close;
+        }
+
         // roll through quotes
         for (int i = 0; i < length; i++)
         {
@@ -23,15 +30,14 @@ public static partial class Indicator
             decimal close = (q.Open + q.High + q.Low + q.Close) / 4;
 
             // open
-            decimal open = (prevOpen == decimal.MinValue) ? (q.Open + q.Close) / 2
-                : (prevOpen + prevClose) / 2;
+            decimal open = (prevOpen + prevClose) / 2;
 
             // high
-            decimal[] arrH = { q.High, open, close };
+            decimal[] arrH = [q.High, open, close];
             decimal high = arrH.Max();
 
             // low
-            decimal[] arrL = { q.Low, open, close };
+            decimal[] arrL = [q.Low, open, close];
             decimal low = arrL.Min();
 
             HeikinAshiResult r = new(q.Date)


### PR DESCRIPTION
During evaluation of #1160 I found an error in our Heikin-Ashi documentation.  The first set of values is no longer `null` as there is a reasonable starting result based on the initial candle value.

To do:

- [x] remove reference that indicates the first period would be `null`
- [x] refactor code to only evaluate first period once.  This should provide a slightly better performance.