### PR TITLE
feat: Use `IReadOnlyList` as primary output type

### DIFF
--- a/docs/_indicators/Adl.md
+++ b/docs/_indicators/Adl.md
@@ -16,7 +16,7 @@ Created by Marc Chaikin, the [Accumulation/Distribution Line/Index](https://en.w
 
 ```csharp
 // C# usage syntax
-IEnumerable<AdlResult> results =
+IReadOnlyList<AdlResult> results =
   quotes.GetAdl();
 ```
 
@@ -29,7 +29,7 @@ You must have at least two historical quotes to cover the warmup periods; howeve
 ## Response
 
 ```csharp
-IEnumerable<AdlResult>
+IReadOnlyList<AdlResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Adx.md
+++ b/docs/_indicators/Adx.md
@@ -16,7 +16,7 @@ Created by J. Welles Wilder, the Directional Movement Index (DMI) and [Average D
 
 ```csharp
 // C# usage syntax
-IEnumerable<AdxResult> results =
+IReadOnlyList<AdxResult> results =
   quotes.GetAdx(lookbackPeriods);
 ```
 
@@ -33,7 +33,7 @@ You must have at least `2×N+100` periods of `quotes` to allow for smoothing con
 ## Response
 
 ```csharp
-IEnumerable<AdxResult>
+IReadOnlyList<AdxResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Alligator.md
+++ b/docs/_indicators/Alligator.md
@@ -16,7 +16,7 @@ Created by Bill Williams, Alligator is a depiction of three smoothed moving aver
 
 ```csharp
 // C# usage syntax
-IEnumerable<AlligatorResult> results =
+IReadOnlyList<AlligatorResult> results =
   quotes.GetAlligator(jawPeriods,jawOffset,teethPeriods,teethOffset,lipsPeriods,lipsOffset);
 ```
 
@@ -43,7 +43,7 @@ You must have at least `JP+JO+100` periods of `quotes` to cover the convergence 
 ## Response
 
 ```csharp
-IEnumerable<AlligatorResult>
+IReadOnlyList<AlligatorResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Alma.md
+++ b/docs/_indicators/Alma.md
@@ -16,7 +16,7 @@ Created by Arnaud Legoux and Dimitrios Kouzis-Loukas, [ALMA]({{site.github.repos
 
 ```csharp
 // C# usage syntax
-IEnumerable<AlmaResult> results =
+IReadOnlyList<AlmaResult> results =
   quotes.GetAlma(lookbackPeriods, offset, sigma);
 ```
 
@@ -37,7 +37,7 @@ You must have at least `N` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<AlmaResult>
+IReadOnlyList<AlmaResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Aroon.md
+++ b/docs/_indicators/Aroon.md
@@ -16,7 +16,7 @@ Created by Tushar Chande, [Aroon](https://school.stockcharts.com/doku.php?id=tec
 
 ```csharp
 // C# usage syntax
-IEnumerable<AroonResult> results =
+IReadOnlyList<AroonResult> results =
   quotes.GetAroon(lookbackPeriods);
 ```
 
@@ -33,7 +33,7 @@ You must have at least `N` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<AroonResult>
+IReadOnlyList<AroonResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Atr.md
+++ b/docs/_indicators/Atr.md
@@ -16,15 +16,15 @@ Created by J. Welles Wilder, True Range and [Average True Range](https://en.wiki
 
 ```csharp
 // C# usage syntax
-IEnumerable<AtrResult> results =
+IReadOnlyList<AtrResult> results =
   quotes.GetAtr(lookbackPeriods);
 
 // ATR with custom moving average
-IEnumerable<SmmaResult> results =
+IReadOnlyList<SmmaResult> results =
   quotes.GetTr().GetSmma(lookbackPeriods);
 
 // raw True Range (TR) only
-IEnumerable<TrResult> results =
+IReadOnlyList<TrResult> results =
   quote.GetTr();
 ```
 
@@ -41,7 +41,7 @@ You must have at least `N+100` periods of `quotes` to cover the convergence peri
 ## Response
 
 ```csharp
-IEnumerable<AtrResult>
+IReadOnlyList<AtrResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/AtrStop.md
+++ b/docs/_indicators/AtrStop.md
@@ -16,7 +16,7 @@ Created by Welles Wilder, the ATR Trailing Stop indicator attempts to determine 
 
 ```csharp
 // C# usage syntax
-IEnumerable<AtrStopResult> results =
+IReadOnlyList<AtrStopResult> results =
   quotes.GetAtrStop(lookbackPeriods, multiplier, endType);
 ```
 
@@ -43,7 +43,7 @@ You must have at least `N+100` periods of `quotes` to cover the convergence peri
 ## Response
 
 ```csharp
-IEnumerable<AtrStopResult>
+IReadOnlyList<AtrStopResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Awesome.md
+++ b/docs/_indicators/Awesome.md
@@ -16,7 +16,7 @@ Created by Bill Williams, the Awesome Oscillator (aka Super AO) is a measure of 
 
 ```csharp
 // C# usage syntax
-IEnumerable<AwesomeResult> results =
+IReadOnlyList<AwesomeResult> results =
   quotes.GetAwesome(fastPeriods, slowPeriods);
 ```
 
@@ -35,7 +35,7 @@ You must have at least `S` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<AwesomeResult>
+IReadOnlyList<AwesomeResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Beta.md
+++ b/docs/_indicators/Beta.md
@@ -16,7 +16,7 @@ layout: indicator
 
 ```csharp
 // C# usage syntax
-IEnumerable<BetaResult> results = quotesEval
+IReadOnlyList<BetaResult> results = quotesEval
   .GetBeta(quotesMarket, lookbackPeriods, type);
 ```
 
@@ -51,7 +51,7 @@ You must have at least `N` periods of `quotesEval` to cover the warmup periods. 
 ## Response
 
 ```csharp
-IEnumerable<BetaResult>
+IReadOnlyList<BetaResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/BollingerBands.md
+++ b/docs/_indicators/BollingerBands.md
@@ -16,7 +16,7 @@ Created by John Bollinger, [Bollinger Bands](https://en.wikipedia.org/wiki/Bolli
 
 ```csharp
 // C# usage syntax
-IEnumerable<BollingerBandsResult> results =
+IReadOnlyList<BollingerBandsResult> results =
   quotes.GetBollingerBands(lookbackPeriods, standardDeviations);
 ```
 
@@ -35,7 +35,7 @@ You must have at least `N` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<BollingerBandsResult>
+IReadOnlyList<BollingerBandsResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Bop.md
+++ b/docs/_indicators/Bop.md
@@ -16,7 +16,7 @@ Created by Igor Levshin, the [Balance of Power](https://school.stockcharts.com/d
 
 ```csharp
 // C# usage syntax
-IEnumerable<BopResult> results =
+IReadOnlyList<BopResult> results =
   quotes.GetBop(smoothPeriods);
 ```
 
@@ -33,7 +33,7 @@ You must have at least `N` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<BopResult>
+IReadOnlyList<BopResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Cci.md
+++ b/docs/_indicators/Cci.md
@@ -16,7 +16,7 @@ Created by Donald Lambert, the [Commodity Channel Index](https://en.wikipedia.or
 
 ```csharp
 // C# usage syntax
-IEnumerable<CciResult> results =
+IReadOnlyList<CciResult> results =
   quotes.GetCci(lookbackPeriods);
 ```
 
@@ -33,7 +33,7 @@ You must have at least `N+1` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<CciResult>
+IReadOnlyList<CciResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/ChaikinOsc.md
+++ b/docs/_indicators/ChaikinOsc.md
@@ -16,7 +16,7 @@ Created by Marc Chaikin, the [Chaikin Oscillator](https://en.wikipedia.org/wiki/
 
 ```csharp
 // C# usage syntax
-IEnumerable<ChaikinOscResult> results =
+IReadOnlyList<ChaikinOscResult> results =
   quotes.GetChaikinOsc(fastPeriods, slowPeriods);
 ```
 
@@ -35,7 +35,7 @@ You must have at least `2×S` or `S+100` periods of `quotes`, whichever is more,
 ## Response
 
 ```csharp
-IEnumerable<ChaikinOscResult>
+IReadOnlyList<ChaikinOscResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Chandelier.md
+++ b/docs/_indicators/Chandelier.md
@@ -17,7 +17,7 @@ Created by Charles Le Beau, the [Chandelier Exit](https://school.stockcharts.com
 
 ```csharp
 // C# usage syntax
-IEnumerable<ChandelierResult> results =
+IReadOnlyList<ChandelierResult> results =
   quotes.GetChandelier(lookbackPeriods, multiplier, type);
 ```
 
@@ -44,7 +44,7 @@ You must have at least `N+1` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<ChandelierResult>
+IReadOnlyList<ChandelierResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Chop.md
+++ b/docs/_indicators/Chop.md
@@ -15,7 +15,7 @@ Created by E.W. Dreiss, the Choppiness Index measures the trendiness or choppine
 
 ```csharp
 // C# usage syntax
-IEnumerable<ChopResult> results =
+IReadOnlyList<ChopResult> results =
   quotes.GetChop(lookbackPeriods);
 ```
 
@@ -32,7 +32,7 @@ You must have at least `N+1` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<ChopResult>
+IReadOnlyList<ChopResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Cmf.md
+++ b/docs/_indicators/Cmf.md
@@ -16,7 +16,7 @@ Created by Marc Chaikin, [Chaikin Money Flow](https://en.wikipedia.org/wiki/Chai
 
 ```csharp
 // C# usage syntax
-IEnumerable<CmfResult> results =
+IReadOnlyList<CmfResult> results =
   quotes.GetCmf(lookbackPeriods);
 ```
 
@@ -33,7 +33,7 @@ You must have at least `N+1` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<CmfResult>
+IReadOnlyList<CmfResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Cmo.md
+++ b/docs/_indicators/Cmo.md
@@ -16,7 +16,7 @@ Created by Tushar Chande, the [Chande Momentum Oscillator](https://www.investope
 
 ```csharp
 // C# usage syntax
-IEnumerable<CmoResult> results =
+IReadOnlyList<CmoResult> results =
   quotes.GetCmo(lookbackPeriods);
 ```
 
@@ -33,7 +33,7 @@ You must have at least `N+1` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<CmoResult>
+IReadOnlyList<CmoResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/ConnorsRsi.md
+++ b/docs/_indicators/ConnorsRsi.md
@@ -16,7 +16,7 @@ Created by Laurence Connors, the [ConnorsRSI](https://alvarezquanttrading.com/wp
 
 ```csharp
 // C# usage syntax
-IEnumerable<ConnorsRsiResult> results =
+IReadOnlyList<ConnorsRsiResult> results =
   quotes.GetConnorsRsi(rsiPeriods, streakPeriods, rankPeriods);
 ```
 
@@ -37,7 +37,7 @@ IEnumerable<ConnorsRsiResult> results =
 ## Response
 
 ```csharp
-IEnumerable<ConnorsRsiResult>
+IReadOnlyList<ConnorsRsiResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Correlation.md
+++ b/docs/_indicators/Correlation.md
@@ -16,13 +16,13 @@ Created by Karl Pearson, the [Correlation Coefficient](https://en.wikipedia.org/
 
 ```csharp
 // C# usage syntax
-IEnumerable<CorrResult> results =
+IReadOnlyList<CorrResult> results =
   quotesA.GetCorrelation(quotesB, lookbackPeriods);
 ```
 
 ## Parameters
 
-**`quotesB`** _`IEnumerable<TQuote>`_ - [Historical quotes]({{site.baseurl}}/guide/#historical-quotes) (B) must have at least the same matching date elements of `quotesA`.
+**`quotesB`** _`IReadOnlyList<TQuote>`_ - [Historical quotes]({{site.baseurl}}/guide/#historical-quotes) (B) must have at least the same matching date elements of `quotesA`.
 
 **`lookbackPeriods`** _`int`_ - Number of periods (`N`) in the lookback period.  Must be greater than 0 to calculate; however we suggest a larger period for statistically appropriate sample size.
 
@@ -35,7 +35,7 @@ You must have at least `N` periods for both versions of `quotes` to cover the wa
 ## Response
 
 ```csharp
-IEnumerable<CorrResult>
+IReadOnlyList<CorrResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Dema.md
+++ b/docs/_indicators/Dema.md
@@ -18,7 +18,7 @@ Created by Patrick G. Mulloy, the [Double exponential moving average](https://en
 
 ```csharp
 // C# usage syntax
-IEnumerable<DemaResult> results =
+IReadOnlyList<DemaResult> results =
   quotes.GetDema(lookbackPeriods);
 ```
 
@@ -35,7 +35,7 @@ You must have at least `3×N` or `2×N+100` periods of `quotes`, whichever is mo
 ## Response
 
 ```csharp
-IEnumerable<DemaResult>
+IReadOnlyList<DemaResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Doji.md
+++ b/docs/_indicators/Doji.md
@@ -16,7 +16,7 @@ type: candlestick-pattern
 
 ```csharp
 // C# usage syntax
-IEnumerable<CandleResult> results =
+IReadOnlyList<CandleResult> results =
   quotes.GetDoji(maxPriceChangePercent);
 ```
 
@@ -33,7 +33,7 @@ You must have at least one historical quote; however, more is typically provided
 ## Response
 
 ```csharp
-IEnumerable<CandleResult>
+IReadOnlyList<CandleResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Donchian.md
+++ b/docs/_indicators/Donchian.md
@@ -17,7 +17,7 @@ Created by Richard Donchian, [Donchian Channels](https://en.wikipedia.org/wiki/D
 
 ```csharp
 // C# usage syntax
-IEnumerable<DonchianResult> results =
+IReadOnlyList<DonchianResult> results =
   quotes.GetDonchian(lookbackPeriods);
 ```
 
@@ -34,7 +34,7 @@ You must have at least `N+1` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<DonchianResult>
+IReadOnlyList<DonchianResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Dpo.md
+++ b/docs/_indicators/Dpo.md
@@ -16,7 +16,7 @@ layout: indicator
 
 ```csharp
 // C# usage syntax
-IEnumerable<DpoResult> results =
+IReadOnlyList<DpoResult> results =
   quotes.GetDpo(lookbackPeriods);
 ```
 
@@ -33,7 +33,7 @@ You must have at least `N` historical quotes to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<DpoResult>
+IReadOnlyList<DpoResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Dynamic.md
+++ b/docs/_indicators/Dynamic.md
@@ -16,7 +16,7 @@ Created by John R. McGinley, the [McGinley Dynamic](https://www.investopedia.com
 
 ```csharp
 // C# usage syntax (with Close price)
-IEnumerable<DynamicResult> results =
+IReadOnlyList<DynamicResult> results =
   quotes.GetDynamic(lookbackPeriods, kFactor);
 ```
 
@@ -41,7 +41,7 @@ You must have at least `2` periods of `quotes`, to cover the initialization peri
 ## Response
 
 ```csharp
-IEnumerable<DynamicResult>
+IReadOnlyList<DynamicResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/ElderRay.md
+++ b/docs/_indicators/ElderRay.md
@@ -16,7 +16,7 @@ Created by Alexander Elder, the [Elder-ray Index](https://www.investopedia.com/t
 
 ```csharp
 // C# usage syntax
-IEnumerable<ElderRayResult> results =
+IReadOnlyList<ElderRayResult> results =
   quotes.GetElderRay(lookbackPeriods);
 ```
 
@@ -33,7 +33,7 @@ You must have at least `2×N` or `N+100` periods of `quotes`, whichever is more,
 ## Response
 
 ```csharp
-IEnumerable<ElderRayResult>
+IReadOnlyList<ElderRayResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Ema.md
+++ b/docs/_indicators/Ema.md
@@ -16,7 +16,7 @@ layout: indicator
 
 ```csharp
 // C# usage syntax (with Close price)
-IEnumerable<EmaResult> results =
+IReadOnlyList<EmaResult> results =
   quotes.GetEma(lookbackPeriods);
 ```
 
@@ -33,7 +33,7 @@ You must have at least `2×N` or `N+100` periods of `quotes`, whichever is more,
 ## Response
 
 ```csharp
-IEnumerable<EmaResult>
+IReadOnlyList<EmaResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Epma.md
+++ b/docs/_indicators/Epma.md
@@ -16,7 +16,7 @@ Endpoint Moving Average (EPMA), also known as Least Squares Moving Average (LSMA
 
 ```csharp
 // C# usage syntax
-IEnumerable<EpmaResult> results =
+IReadOnlyList<EpmaResult> results =
   quotes.GetEpma(lookbackPeriods);
 ```
 
@@ -33,7 +33,7 @@ You must have at least `N` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<EpmaResult>
+IReadOnlyList<EpmaResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Fcb.md
+++ b/docs/_indicators/Fcb.md
@@ -16,7 +16,7 @@ Created by Edward William Dreiss, Fractal Chaos Bands outline high and low price
 
 ```csharp
 // C# usage syntax
-IEnumerable<FcbResult> results =
+IReadOnlyList<FcbResult> results =
   quotes.GetFcb(windowSpan);
 ```
 
@@ -35,7 +35,7 @@ You must have at least `2×S+1` periods of `quotes` to cover the warmup periods;
 ## Response
 
 ```csharp
-IEnumerable<FcbResult>
+IReadOnlyList<FcbResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/FisherTransform.md
+++ b/docs/_indicators/FisherTransform.md
@@ -16,7 +16,7 @@ Created by John Ehlers, the [Fisher Transform](https://www.investopedia.com/term
 
 ```csharp
 // C# usage syntax
-IEnumerable<FisherTransformResult> results =
+IReadOnlyList<FisherTransformResult> results =
   quotes.GetFisherTransform(lookbackPeriods);
 ```
 
@@ -33,7 +33,7 @@ You must have at least `N` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<FisherTransformResult>
+IReadOnlyList<FisherTransformResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/ForceIndex.md
+++ b/docs/_indicators/ForceIndex.md
@@ -16,7 +16,7 @@ Created by Alexander Elder, the [Force Index](https://en.wikipedia.org/wiki/Forc
 
 ```csharp
 // C# usage syntax
-IEnumerable<ForceIndexResult> results =
+IReadOnlyList<ForceIndexResult> results =
   quotes.GetForceIndex(lookbackPeriods);
 ```
 
@@ -33,7 +33,7 @@ You must have at least `N+100` for `2×N` periods of `quotes`, whichever is more
 ## Response
 
 ```csharp
-IEnumerable<ForceIndexResult>
+IReadOnlyList<ForceIndexResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Fractal.md
+++ b/docs/_indicators/Fractal.md
@@ -16,7 +16,7 @@ Created by Larry Williams, [Fractal](https://www.investopedia.com/terms/f/fracta
 
 ```csharp
 // C# usage syntax
-IEnumerable<FractalResult> results =
+IReadOnlyList<FractalResult> results =
   quotes.GetFractal(windowSpan);
 ```
 
@@ -43,7 +43,7 @@ You must have at least `2×S+1` periods of `quotes` to cover the warmup periods;
 ## Response
 
 ```csharp
-IEnumerable<FractalResult>
+IReadOnlyList<FractalResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Gator.md
+++ b/docs/_indicators/Gator.md
@@ -16,11 +16,11 @@ Created by Bill Williams, the Gator Oscillator is an expanded oscillator view of
 
 ```csharp
 // C# usage syntax
-IEnumerable<GatorResult> results =
+IReadOnlyList<GatorResult> results =
   quotes.GetGator();
 
 // with custom Alligator configuration
-IEnumerable<GatorResult> results = quotes
+IReadOnlyList<GatorResult> results = quotes
   .GetAlligator([see Alligator docs])
   .GetGator();
 ```
@@ -34,7 +34,7 @@ If using default settings, you must have at least 121 periods of `quotes`. Since
 ## Response
 
 ```csharp
-IEnumerable<GatorResult>
+IReadOnlyList<GatorResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/HeikinAshi.md
+++ b/docs/_indicators/HeikinAshi.md
@@ -16,7 +16,7 @@ Created by Munehisa Homma, [Heikin-Ashi](https://en.wikipedia.org/wiki/Candlesti
 
 ```csharp
 // C# usage syntax
-IEnumerable<HeikinAshiResult> results =
+IReadOnlyList<HeikinAshiResult> results =
   quotes.GetHeikinAshi();
 ```
 
@@ -29,7 +29,7 @@ You must have at least two periods of `quotes` to cover the warmup periods; howe
 ## Response
 
 ```csharp
-IEnumerable<HeikinAshiResult>
+IReadOnlyList<HeikinAshiResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.
@@ -58,7 +58,7 @@ IEnumerable<HeikinAshiResult>
 - .ToQuotes() to convert to a `Quote` collection.  Example:
 
   ```csharp
-  IEnumerable<Quote> results = quotes
+  IReadOnlyList<Quote> results = quotes
     .GetHeikinAshi()
     .ToQuotes();
   ```

--- a/docs/_indicators/Hma.md
+++ b/docs/_indicators/Hma.md
@@ -16,7 +16,7 @@ Created by Alan Hull, the [Hull Moving Average](https://alanhull.com/hull-moving
 
 ```csharp
 // C# usage syntax
-IEnumerable<HmaResult> results =
+IReadOnlyList<HmaResult> results =
   quotes.GetHma(lookbackPeriods);
 ```
 
@@ -33,7 +33,7 @@ You must have at least `N+(integer of SQRT(N))-1` periods of `quotes` to cover t
 ## Response
 
 ```csharp
-IEnumerable<HmaResult>
+IReadOnlyList<HmaResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/HtTrendline.md
+++ b/docs/_indicators/HtTrendline.md
@@ -16,7 +16,7 @@ Created by John Ehlers, the Hilbert Transform Instantaneous Trendline is a 5-per
 
 ```csharp
 // C# usage syntax
-IEnumerable<HtlResult> results =
+IReadOnlyList<HtlResult> results =
   quotes.GetHtTrendline();
 ```
 
@@ -29,7 +29,7 @@ You must have at least `100` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<HtlResult>
+IReadOnlyList<HtlResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Hurst.md
+++ b/docs/_indicators/Hurst.md
@@ -16,7 +16,7 @@ The [Hurst Exponent](https://en.wikipedia.org/wiki/Hurst_exponent) (`H`) is part
 
 ```csharp
 // C# usage syntax
-IEnumerable<HurstResult> results =
+IReadOnlyList<HurstResult> results =
   quotes.GetHurst(lookbackPeriods);
 ```
 
@@ -33,7 +33,7 @@ You must have at least `N+1` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<HurstResult>
+IReadOnlyList<HurstResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Ichimoku.md
+++ b/docs/_indicators/Ichimoku.md
@@ -16,15 +16,15 @@ Created by Goichi Hosoda (細田悟一, Hosoda Goichi), [Ichimoku Cloud](https:/
 
 ```csharp
 // C# usage syntax
-IEnumerable<IchimokuResult> results =
+IReadOnlyList<IchimokuResult> results =
   quotes.GetIchimoku(tenkanPeriods, kijunPeriods, senkouBPeriods);
 
 // usage with custom offset
-IEnumerable<IchimokuResult> results =
+IReadOnlyList<IchimokuResult> results =
   quotes.GetIchimoku(tenkanPeriods, kijunPeriods, senkouBPeriods, offsetPeriods);
 
 // usage with different custom offsets
-IEnumerable<IchimokuResult> results =
+IReadOnlyList<IchimokuResult> results =
   quotes.GetIchimoku(tenkanPeriods, kijunPeriods, senkouBPeriods, senkouOffset, chikouOffset);
 ```
 
@@ -53,7 +53,7 @@ You must have at least the greater of `T`,`K`, `S`, and offset periods for `quot
 ## Response
 
 ```csharp
-IEnumerable<IchimokuResult>
+IReadOnlyList<IchimokuResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Kama.md
+++ b/docs/_indicators/Kama.md
@@ -16,7 +16,7 @@ Created by Perry Kaufman, [KAMA](https://school.stockcharts.com/doku.php?id=tech
 
 ```csharp
 // C# usage syntax
-IEnumerable<KamaResult> results =
+IReadOnlyList<KamaResult> results =
   quotes.GetKama(erPeriods, fastPeriods, slowPeriods);
 ```
 
@@ -37,7 +37,7 @@ You must have at least `6×E` or `E+100` periods of `quotes`, whichever is more,
 ## Response
 
 ```csharp
-IEnumerable<KamaResult>
+IReadOnlyList<KamaResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Keltner.md
+++ b/docs/_indicators/Keltner.md
@@ -16,7 +16,7 @@ Created by Chester W. Keltner, [Keltner Channels](https://en.wikipedia.org/wiki/
 
 ```csharp
 // C# usage syntax
-IEnumerable<KeltnerResult> results =
+IReadOnlyList<KeltnerResult> results =
   quotes.GetKeltner(emaPeriods, multiplier, atrPeriods);
 ```
 
@@ -37,7 +37,7 @@ You must have at least `2×N` or `N+100` periods of `quotes`, whichever is more,
 ## Response
 
 ```csharp
-IEnumerable<KeltnerResult>
+IReadOnlyList<KeltnerResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Kvo.md
+++ b/docs/_indicators/Kvo.md
@@ -16,7 +16,7 @@ Created by Stephen Klinger, the [Klinger Volume Oscillator](https://www.investop
 
 ```csharp
 // C# usage syntax
-IEnumerable<KvoResult> results =
+IReadOnlyList<KvoResult> results =
   quotes.GetKvo(shortPeriods, longPeriods, signalPeriods);
 ```
 
@@ -37,7 +37,7 @@ You must have at least `L+100` periods of `quotes` to cover the warmup periods. 
 ## Response
 
 ```csharp
-IEnumerable<KvoResult>
+IReadOnlyList<KvoResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/MaEnvelopes.md
+++ b/docs/_indicators/MaEnvelopes.md
@@ -16,7 +16,7 @@ layout: indicator
 
 ```csharp
 // C# usage syntax
-IEnumerable<MaEnvelopeResult> results =
+IReadOnlyList<MaEnvelopeResult> results =
   quotes.GetMaEnvelopes(lookbackPeriods, percentOffset, movingAverageType);
 ```
 
@@ -61,7 +61,7 @@ These are the supported moving average types:
 ## Response
 
 ```csharp
-IEnumerable<MaEnvelopeResult>
+IReadOnlyList<MaEnvelopeResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Macd.md
+++ b/docs/_indicators/Macd.md
@@ -16,7 +16,7 @@ Created by Gerald Appel, [MACD](https://en.wikipedia.org/wiki/MACD) is a simple 
 
 ```csharp
 // C# usage syntax (with Close price)
-IEnumerable<MacdResult> results =
+IReadOnlyList<MacdResult> results =
   quotes.GetMacd(fastPeriods, slowPeriods, signalPeriods);
 ```
 
@@ -37,7 +37,7 @@ You must have at least `2×(S+P)` or `S+P+100` worth of `quotes`, whichever is m
 ## Response
 
 ```csharp
-IEnumerable<MacdResult>
+IReadOnlyList<MacdResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Mama.md
+++ b/docs/_indicators/Mama.md
@@ -16,7 +16,7 @@ Created by John Ehlers, the [MAMA](https://mesasoftware.com/papers/MAMA.pdf) ind
 
 ```csharp
 // C# usage syntax
-IEnumerable<MamaResult> results =
+IReadOnlyList<MamaResult> results =
   quotes.GetMama(fastLimit, slowLimit);
 ```
 
@@ -35,7 +35,7 @@ You must have at least `50` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<MamaResult>
+IReadOnlyList<MamaResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Marubozu.md
+++ b/docs/_indicators/Marubozu.md
@@ -16,7 +16,7 @@ type: candlestick-pattern
 
 ```csharp
 // C# usage syntax
-IEnumerable<CandleResult> results =
+IReadOnlyList<CandleResult> results =
   quotes.GetMarubozu(minBodyPercent);
 ```
 
@@ -33,7 +33,7 @@ You must have at least one historical quote; however, more is typically provided
 ## Response
 
 ```csharp
-IEnumerable<CandleResult>
+IReadOnlyList<CandleResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Mfi.md
+++ b/docs/_indicators/Mfi.md
@@ -16,7 +16,7 @@ Created by Quong and Soudack, the [Money Flow Index](https://en.wikipedia.org/wi
 
 ```csharp
 // C# usage syntax
-IEnumerable<MfiResult> results =
+IReadOnlyList<MfiResult> results =
   quotes.GetMfi(lookbackPeriods);
 ```
 
@@ -33,7 +33,7 @@ You must have at least `N+1` historical quotes to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<MfiResult>
+IReadOnlyList<MfiResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Obv.md
+++ b/docs/_indicators/Obv.md
@@ -16,7 +16,7 @@ Popularized by Joseph Granville, [On-balance Volume](https://en.wikipedia.org/wi
 
 ```csharp
 // C# usage syntax
-IEnumerable<ObvResult> results =
+IReadOnlyList<ObvResult> results =
   quotes.GetObv();
 ```
 
@@ -29,7 +29,7 @@ You must have at least two historical quotes to cover the warmup periods; howeve
 ## Response
 
 ```csharp
-IEnumerable<ObvResult>
+IReadOnlyList<ObvResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/ParabolicSar.md
+++ b/docs/_indicators/ParabolicSar.md
@@ -16,11 +16,11 @@ Created by J. Welles Wilder, [Parabolic SAR](https://en.wikipedia.org/wiki/Parab
 
 ```csharp
 // C# usage syntax (standard)
-IEnumerable<ParabolicSarResult> results =
+IReadOnlyList<ParabolicSarResult> results =
   quotes.GetParabolicSar(accelerationStep, maxAccelerationFactor);
 
 // alternate usage with custom initial Factor
-IEnumerable<ParabolicSarResult> results =
+IReadOnlyList<ParabolicSarResult> results =
   quotes.GetParabolicSar(accelerationStep, maxAccelerationFactor, initialFactor);
 ```
 
@@ -41,7 +41,7 @@ You must have at least two historical quotes to cover the warmup periods; howeve
 ## Response
 
 ```csharp
-IEnumerable<ParabolicSarResult>
+IReadOnlyList<ParabolicSarResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/PivotPoints.md
+++ b/docs/_indicators/PivotPoints.md
@@ -17,7 +17,7 @@ layout: indicator
 
 ```csharp
 // C# usage syntax
-IEnumerable<PivotPointsResult> results =
+IReadOnlyList<PivotPointsResult> results =
   quotes.GetPivotPoints(windowSize, pointType);
 ```
 
@@ -58,7 +58,7 @@ You must have at least `2` windows of `quotes` to cover the warmup periods.  For
 ## Response
 
 ```csharp
-IEnumerable<PivotPointsResult>
+IReadOnlyList<PivotPointsResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Pivots.md
+++ b/docs/_indicators/Pivots.md
@@ -16,7 +16,7 @@ Pivots is an extended customizable version of <a href="{{site.baseurl}}/indicato
 
 ```csharp
 // C# usage syntax
-IEnumerable<PivotsResult> results =
+IReadOnlyList<PivotsResult> results =
   quotes.GetPivots(leftSpan, rightSpan, maxTrendPeriods, endType);
 ```
 
@@ -47,7 +47,7 @@ You must have at least `L+R+1` periods of `quotes` to cover the warmup periods; 
 ## Response
 
 ```csharp
-IEnumerable<PivotsResult>
+IReadOnlyList<PivotsResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Pmo.md
+++ b/docs/_indicators/Pmo.md
@@ -16,7 +16,7 @@ Created by Carl Swenlin, the DecisionPoint [Price Momentum Oscillator](https://s
 
 ```csharp
 // C# usage syntax
-IEnumerable<PmoResult> results =
+IReadOnlyList<PmoResult> results =
   quotes.GetPmo(timePeriods, smoothPeriods, signalPeriods);
 ```
 
@@ -37,7 +37,7 @@ You must have at least `N` periods of `quotes`, where `N` is the greater of `T+S
 ## Response
 
 ```csharp
-IEnumerable<PmoResult>
+IReadOnlyList<PmoResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Prs.md
+++ b/docs/_indicators/Prs.md
@@ -16,13 +16,13 @@ layout: indicator
 
 ```csharp
 // C# usage syntax
-IEnumerable<PrsResult> results =
+IReadOnlyList<PrsResult> results =
   quotesEval.GetPrs(quotesBase);
 ```
 
 ## Parameters
 
-**`quotesBase`** _`IEnumerable<TQuote>`_ - [Historical quotes]({{site.baseurl}}/guide/#historical-quotes) used as the basis for comparison.  This is usually market index data.  You must have the same number of periods as `quotesEval`.
+**`quotesBase`** _`IReadOnlyList<TQuote>`_ - [Historical quotes]({{site.baseurl}}/guide/#historical-quotes) used as the basis for comparison.  This is usually market index data.  You must have the same number of periods as `quotesEval`.
 
 **`lookbackPeriods`** _`int`_ - Optional.  Number of periods (`N`) to lookback to compute % difference.  Must be greater than 0 if specified or `null`.
 
@@ -30,12 +30,12 @@ IEnumerable<PrsResult> results =
 
 You must have at least `N` periods of `quotesEval` to calculate `PrsPercent` if `lookbackPeriods` is specified; otherwise, you must specify at least `S+1` periods.  More than the minimum is typically specified.  For this indicator, the elements must match (e.g. the `n`th elements must be the same date).  An `Exception` will be thrown for mismatch dates.  Historical price quotes should have a consistent frequency (day, hour, minute, etc).
 
-`quotesEval` is an `IEnumerable<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
+`quotesEval` is an `IReadOnlyList<TQuote>` collection of historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 
 ## Response
 
 ```csharp
-IEnumerable<PrsResult>
+IReadOnlyList<PrsResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Pvo.md
+++ b/docs/_indicators/Pvo.md
@@ -16,7 +16,7 @@ The [Percentage Volume Oscillator](https://school.stockcharts.com/doku.php?id=te
 
 ```csharp
 // C# usage syntax
-IEnumerable<PvoResult> results =
+IReadOnlyList<PvoResult> results =
   quotes.GetPvo(fastPeriods, slowPeriods, signalPeriods);
 ```
 
@@ -37,7 +37,7 @@ You must have at least `2×(S+P)` or `S+P+100` worth of `quotes`, whichever is m
 ## Response
 
 ```csharp
-IEnumerable<PvoResult>
+IReadOnlyList<PvoResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Renko.md
+++ b/docs/_indicators/Renko.md
@@ -16,7 +16,7 @@ The [Renko Chart](https://en.m.wikipedia.org/wiki/Renko_chart) is a Japanese pri
 
 ```csharp
 // C# usage syntax
-IEnumerable<RenkoResult> results =
+IReadOnlyList<RenkoResult> results =
   quotes.GetRenko(brickSize, endType);
 ```
 
@@ -54,7 +54,7 @@ This indicator must be generated from `quotes` and **cannot** be generated from 
 ## Response
 
 ```csharp
-IEnumerable<RenkoResult>
+IReadOnlyList<RenkoResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.
@@ -94,7 +94,7 @@ See [Utilities and helpers]({{site.baseurl}}/utilities#utilities-for-indicator-r
 
 ```csharp
 // C# usage syntax
-IEnumerable<RenkoResult> results =
+IReadOnlyList<RenkoResult> results =
   quotes.GetRenkoAtr(atrPeriods, endType);
 ```
 
@@ -113,7 +113,7 @@ You must have at least `A+100` periods of `quotes`.
 ## Response for ATR
 
 ```csharp
-IEnumerable<RenkoResult>
+IReadOnlyList<RenkoResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Roc.md
+++ b/docs/_indicators/Roc.md
@@ -16,7 +16,7 @@ layout: indicator
 
 ```csharp
 // C# usage syntax
-IEnumerable<RocResult> results =
+IReadOnlyList<RocResult> results =
   quotes.GetRoc(lookbackPeriods);
 ```
 
@@ -33,7 +33,7 @@ You must have at least `N+1` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<RocResult>
+IReadOnlyList<RocResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/RocWb.md
+++ b/docs/_indicators/RocWb.md
@@ -17,7 +17,7 @@ Rate of Change (ROC) with Bands, created by Vitali Apirine, is a volatility band
 
 ```csharp
 // C# usage syntax
-IEnumerable<RocWbResult> results =
+IReadOnlyList<RocWbResult> results =
   quotes.GetRocWb(lookbackPeriods, emaPeriods, stdDevPeriods);
 ```
 
@@ -38,7 +38,7 @@ You must have at least `N+1` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<RocWbResult>
+IReadOnlyList<RocWbResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/RollingPivots.md
+++ b/docs/_indicators/RollingPivots.md
@@ -16,7 +16,7 @@ Created by Dave Skender, Rolling Pivot Points is a modern update to traditional 
 
 ```csharp
 // C# usage syntax
-IEnumerable<RollingPivotsResult> results =
+IReadOnlyList<RollingPivotsResult> results =
   quotes.GetRollingPivots(windowPeriods, offsetPeriods, pointType);
 ```
 
@@ -51,7 +51,7 @@ You must have at least `W+F` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<RollingPivotsResult>
+IReadOnlyList<RollingPivotsResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Rsi.md
+++ b/docs/_indicators/Rsi.md
@@ -16,7 +16,7 @@ Created by J. Welles Wilder, the [Relative Strength Index](https://en.wikipedia.
 
 ```csharp
 // C# usage syntax
-IEnumerable<RsiResult> results =
+IReadOnlyList<RsiResult> results =
   quotes.GetRsi(lookbackPeriods);
 ```
 
@@ -33,7 +33,7 @@ You must have at least `N+100` periods of `quotes` to cover the convergence peri
 ## Response
 
 ```csharp
-IEnumerable<RsiResult>
+IReadOnlyList<RsiResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Slope.md
+++ b/docs/_indicators/Slope.md
@@ -17,7 +17,7 @@ layout: indicator
 
 ```csharp
 // C# usage syntax
-IEnumerable<SlopeResult> results =
+IReadOnlyList<SlopeResult> results =
   quotes.GetSlope(lookbackPeriods);
 ```
 
@@ -34,7 +34,7 @@ You must have at least `N` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<SlopeResult>
+IReadOnlyList<SlopeResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Sma.md
+++ b/docs/_indicators/Sma.md
@@ -16,7 +16,7 @@ layout: indicator
 
 ```csharp
 // C# usage syntax (with Close price)
-IEnumerable<SmaResult> results =
+IReadOnlyList<SmaResult> results =
   quotes.GetSma(lookbackPeriods);
 ```
 
@@ -33,7 +33,7 @@ You must have at least `N` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<SmaResult>
+IReadOnlyList<SmaResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Smi.md
+++ b/docs/_indicators/Smi.md
@@ -16,7 +16,7 @@ Created by William Blau, the Stochastic Momentum Index (SMI) oscillator is a dou
 
 ```csharp
 // C# usage syntax (standard)
-IEnumerable<SmiResult> results =
+IReadOnlyList<SmiResult> results =
   quotes.GetSmi(lookbackPeriods, firstSmoothPeriods,
                  secondSmoothPeriods, signalPeriods);
 ```
@@ -40,7 +40,7 @@ You must have at least `N+100` periods of `quotes` to cover the convergence peri
 ## Response
 
 ```csharp
-IEnumerable<SmiResult>
+IReadOnlyList<SmiResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Smma.md
+++ b/docs/_indicators/Smma.md
@@ -16,7 +16,7 @@ layout: indicator
 
 ```csharp
 // C# usage syntax
-IEnumerable<SmmaResult> results =
+IReadOnlyList<SmmaResult> results =
   quotes.GetSmma(lookbackPeriods);
 ```
 
@@ -33,7 +33,7 @@ You must have at least `2×N` or `N+100` periods of `quotes`, whichever is more,
 ## Response
 
 ```csharp
-IEnumerable<SmmaResult>
+IReadOnlyList<SmmaResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/StarcBands.md
+++ b/docs/_indicators/StarcBands.md
@@ -16,7 +16,7 @@ Created by Manning Stoller, the [Stoller Average Range Channel (STARC) Bands](ht
 
 ```csharp
 // C# usage syntax
-IEnumerable<StarcBandsResult> results =
+IReadOnlyList<StarcBandsResult> results =
   quotes.GetStarcBands(smaPeriods, multiplier, atrPeriods);
 ```
 
@@ -37,7 +37,7 @@ You must have at least `S` or `A+100` periods of `quotes`, whichever is more, to
 ## Response
 
 ```csharp
-IEnumerable<StarcBandsResult>
+IReadOnlyList<StarcBandsResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Stc.md
+++ b/docs/_indicators/Stc.md
@@ -16,7 +16,7 @@ Created by Doug Schaff, the [Schaff Trend Cycle](https://www.investopedia.com/ar
 
 ```csharp
 // C# usage syntax
-IEnumerable<StcResult> results =
+IReadOnlyList<StcResult> results =
   quotes.GetStc(cyclePeriods, fastPeriods, slowPeriods);
 ```
 
@@ -37,7 +37,7 @@ You must have at least `2×(S+C)` or `S+C+100` worth of `quotes`, whichever is m
 ## Response
 
 ```csharp
-IEnumerable<StcResult>
+IReadOnlyList<StcResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/StdDev.md
+++ b/docs/_indicators/StdDev.md
@@ -16,11 +16,11 @@ layout: indicator
 
 ```csharp
 // C# usage syntax
-IEnumerable<StdDevResult> results =
+IReadOnlyList<StdDevResult> results =
   quotes.GetStdDev(lookbackPeriods);
 
 // usage with optional SMA of SD (shown above)
-IEnumerable<StdDevResult> results =
+IReadOnlyList<StdDevResult> results =
   quotes.GetStdDev(lookbackPeriods, smaPeriods);
 ```
 
@@ -37,7 +37,7 @@ You must have at least `N` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<StdDevResult>
+IReadOnlyList<StdDevResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/StdDevChannels.md
+++ b/docs/_indicators/StdDevChannels.md
@@ -16,7 +16,7 @@ Standard Deviation Channels are prices ranges based on an linear regression cent
 
 ```csharp
 // C# usage syntax
-IEnumerable<StdDevChannelsResult> results =
+IReadOnlyList<StdDevChannelsResult> results =
   quotes.GetStdDevChannels(lookbackPeriods, stdDeviations);
 ```
 
@@ -35,7 +35,7 @@ You must have at least `N` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<StdDevChannelsResult>
+IReadOnlyList<StdDevChannelsResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Stoch.md
+++ b/docs/_indicators/Stoch.md
@@ -16,11 +16,11 @@ Created by George Lane, the [Stochastic Oscillator](https://en.wikipedia.org/wik
 
 ```csharp
 // C# usage syntax (standard)
-IEnumerable<StochResult> results =
+IReadOnlyList<StochResult> results =
   quotes.GetStoch(lookbackPeriods, signalPeriods, smoothPeriods);
 
 // advanced customization
-IEnumerable<StochResult> results =
+IReadOnlyList<StochResult> results =
   quotes.GetStoch(lookbackPeriods, signalPeriods, smoothPeriods,
                   kFactor, dFactor, movingAverageType);
 ```
@@ -56,7 +56,7 @@ These are the supported moving average types:
 ## Response
 
 ```csharp
-IEnumerable<StochResult>
+IReadOnlyList<StochResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/StochRsi.md
+++ b/docs/_indicators/StochRsi.md
@@ -17,7 +17,7 @@ Created by by Tushar Chande and Stanley Kroll, [Stochastic RSI](https://school.s
 
 ```csharp
 // C# usage syntax
-IEnumerable<StochRsiResult> results =
+IReadOnlyList<StochRsiResult> results =
   quotes.GetStochRsi(rsiPeriods, stochPeriods, signalPeriods, smoothPeriods);
 ```
 
@@ -42,7 +42,7 @@ You must have at least `N` periods of `quotes`, where `N` is the greater of `R+S
 ## Response
 
 ```csharp
-IEnumerable<StochRsiResult>
+IReadOnlyList<StochRsiResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/SuperTrend.md
+++ b/docs/_indicators/SuperTrend.md
@@ -16,7 +16,7 @@ Created by Oliver Seban, the SuperTrend indicator attempts to determine the prim
 
 ```csharp
 // C# usage syntax
-IEnumerable<SuperTrendResult> results =
+IReadOnlyList<SuperTrendResult> results =
   quotes.GetSuperTrend(lookbackPeriods, multiplier);
 ```
 
@@ -35,7 +35,7 @@ You must have at least `N+100` periods of `quotes` to cover the convergence peri
 ## Response
 
 ```csharp
-IEnumerable<SuperTrendResult>
+IReadOnlyList<SuperTrendResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/T3.md
+++ b/docs/_indicators/T3.md
@@ -16,7 +16,7 @@ Created by Tim Tillson, the [T3](https://www.forexfactory.com/attachment.php/845
 
 ```csharp
 // C# usage syntax
-IEnumerable<T3Result> results =
+IReadOnlyList<T3Result> results =
   quotes.GetT3(lookbackPeriods, volumeFactor);
 ```
 
@@ -35,7 +35,7 @@ You must have at least `6×(N-1)+100` periods of `quotes` to cover the convergen
 ## Response
 
 ```csharp
-IEnumerable<T3Result>
+IReadOnlyList<T3Result>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Tema.md
+++ b/docs/_indicators/Tema.md
@@ -18,7 +18,7 @@ Created by Patrick G. Mulloy, the [Triple exponential moving average](https://en
 
 ```csharp
 // C# usage syntax
-IEnumerable<TemaResult> results =
+IReadOnlyList<TemaResult> results =
   quotes.GetTema(lookbackPeriods);
 ```
 
@@ -35,7 +35,7 @@ You must have at least `4×N` or `3×N+100` periods of `quotes`, whichever is mo
 ## Response
 
 ```csharp
-IEnumerable<TemaResult>
+IReadOnlyList<TemaResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Trix.md
+++ b/docs/_indicators/Trix.md
@@ -16,7 +16,7 @@ Created by Jack Hutson, [TRIX](https://en.wikipedia.org/wiki/Trix_(technical_ana
 
 ```csharp
 // C# usage syntax for Trix
-IEnumerable<TrixResult> results =
+IReadOnlyList<TrixResult> results =
   quotes.GetTrix(lookbackPeriods);
 ```
 
@@ -33,7 +33,7 @@ You must have at least `4×N` or `3×N+100` periods of `quotes`, whichever is mo
 ## Response
 
 ```csharp
-IEnumerable<TrixResult>
+IReadOnlyList<TrixResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Tsi.md
+++ b/docs/_indicators/Tsi.md
@@ -17,7 +17,7 @@ Created by William Blau, the [True Strength Index](https://en.wikipedia.org/wiki
 
 ```csharp
 // C# usage syntax
-IEnumerable<TsiResult> results =
+IReadOnlyList<TsiResult> results =
   quotes.GetTsi(lookbackPeriods, smoothPeriods, signalPeriods);
 ```
 
@@ -38,7 +38,7 @@ You must have at least `N+M+100` periods of `quotes` to cover the convergence pe
 ## Response
 
 ```csharp
-IEnumerable<TsiResult>
+IReadOnlyList<TsiResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/UlcerIndex.md
+++ b/docs/_indicators/UlcerIndex.md
@@ -16,7 +16,7 @@ Created by Peter Martin, the [Ulcer Index](https://en.wikipedia.org/wiki/Ulcer_i
 
 ```csharp
 // C# usage syntax
-IEnumerable<UlcerIndexResult> results =
+IReadOnlyList<UlcerIndexResult> results =
   quotes.GetUlcerIndex(lookbackPeriods);
 ```
 
@@ -33,7 +33,7 @@ You must have at least `N` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<UlcerIndexResult>
+IReadOnlyList<UlcerIndexResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Ultimate.md
+++ b/docs/_indicators/Ultimate.md
@@ -16,7 +16,7 @@ Created by Larry Williams, the [Ultimate Oscillator](https://en.wikipedia.org/wi
 
 ```csharp
 // C# usage syntax
-IEnumerable<UltimateResult> results =
+IReadOnlyList<UltimateResult> results =
   quotes.GetUltimate(shortPeriods, middlePeriods, longPeriods);
 ```
 
@@ -37,7 +37,7 @@ You must have at least `L+1` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<UltimateResult>
+IReadOnlyList<UltimateResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Use.md
+++ b/docs/_indicators/Use.md
@@ -12,7 +12,7 @@ Returns a reusable (chainable) basic quote transform (e.g. HL2, OHL3, etc.) by i
 
 ```csharp
 // C# usage syntax
-IEnumerable<QuotePart> results =
+IReadOnlyList<QuotePart> results =
   quotes.Use(candlePart);
 ```
 
@@ -31,7 +31,7 @@ You must have at least 1 period of `quotes`.
 ## Response
 
 ```csharp
-IEnumerable<QuotePart>
+IReadOnlyList<QuotePart>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/VolatilityStop.md
+++ b/docs/_indicators/VolatilityStop.md
@@ -16,7 +16,7 @@ Created by J. Welles Wilder, [Volatility Stop](https://archive.org/details/newco
 
 ```csharp
 // C# usage syntax
-IEnumerable<VolatilityStopResult> results =
+IReadOnlyList<VolatilityStopResult> results =
   quotes.GetVolatilityStop(lookbackPeriods, multiplier);
 ```
 
@@ -35,7 +35,7 @@ You must have at least `N+100` periods of `quotes` to cover the convergence peri
 ## Response
 
 ```csharp
-IEnumerable<VolatilityStopResult>
+IReadOnlyList<VolatilityStopResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Vortex.md
+++ b/docs/_indicators/Vortex.md
@@ -16,7 +16,7 @@ Created by Etienne Botes and Douglas Siepman, the [Vortex Indicator](https://en.
 
 ```csharp
 // C# usage syntax
-IEnumerable<VortexResult> results =
+IReadOnlyList<VortexResult> results =
   quotes.GetVortex(lookbackPeriods);
 ```
 
@@ -33,7 +33,7 @@ You must have at least `N+1` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<VortexResult>
+IReadOnlyList<VortexResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Vwap.md
+++ b/docs/_indicators/Vwap.md
@@ -16,11 +16,11 @@ The [Volume Weighted Average Price](https://en.wikipedia.org/wiki/Volume-weighte
 
 ```csharp
 // C# usage syntax
-IEnumerable<VwapResult> results =
+IReadOnlyList<VwapResult> results =
   quotes.GetVwap();
 
 // usage with optional anchored start date
-IEnumerable<VwapResult> results =
+IReadOnlyList<VwapResult> results =
   quotes.GetVwap(startDate);
 ```
 
@@ -37,7 +37,7 @@ You must have at least one historical quote to calculate; however, more is often
 ## Response
 
 ```csharp
-IEnumerable<VwapResult>
+IReadOnlyList<VwapResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Vwma.md
+++ b/docs/_indicators/Vwma.md
@@ -16,7 +16,7 @@ Volume Weighted Moving Average is the volume adjusted average price over a lookb
 
 ```csharp
 // C# usage syntax
-IEnumerable<VwmaResult> results =
+IReadOnlyList<VwmaResult> results =
   quotes.GetVwma(lookbackPeriods);
 ```
 
@@ -33,7 +33,7 @@ You must have at least `N` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<VwmaResult>
+IReadOnlyList<VwmaResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/WilliamsR.md
+++ b/docs/_indicators/WilliamsR.md
@@ -16,7 +16,7 @@ Created by Larry Williams, the [Williams %R](https://en.wikipedia.org/wiki/Willi
 
 ```csharp
 // C# usage syntax
-IEnumerable<WilliamsResult> results =
+IReadOnlyList<WilliamsResult> results =
   quotes.GetWilliamsR(lookbackPeriods);
 ```
 
@@ -33,7 +33,7 @@ You must have at least `N` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<WilliamsResult>
+IReadOnlyList<WilliamsResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/Wma.md
+++ b/docs/_indicators/Wma.md
@@ -16,7 +16,7 @@ layout: indicator
 
 ```csharp
 // C# usage syntax (with Close price)
-IEnumerable<WmaResult> results =
+IReadOnlyList<WmaResult> results =
   quotes.GetWma(lookbackPeriods);
 ```
 
@@ -33,7 +33,7 @@ You must have at least `N` periods of `quotes` to cover the warmup periods.
 ## Response
 
 ```csharp
-IEnumerable<WmaResult>
+IReadOnlyList<WmaResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/_indicators/ZigZag.md
+++ b/docs/_indicators/ZigZag.md
@@ -16,7 +16,7 @@ layout: indicator
 
 ```csharp
 // C# usage syntax
-IEnumerable<ZigZagResult> results =
+IReadOnlyList<ZigZagResult> results =
   quotes.GetZigZag(endType, percentChange);
 ```
 
@@ -41,7 +41,7 @@ You must have at least two periods of `quotes` to cover the warmup periods, but 
 ## Response
 
 ```csharp
-IEnumerable<ZigZagResult>
+IReadOnlyList<ZigZagResult>
 ```
 
 - This method returns a time series of all available indicator values for the `quotes` provided.

--- a/docs/examples/Backtest/Program.cs
+++ b/docs/examples/Backtest/Program.cs
@@ -23,11 +23,11 @@ public static class Program
          */
 
         // fetch historical quotes from data provider
-        List<Quote> quotesList = [.. GetQuotesFromFeed()];
+        IReadOnlyList<Quote> quotes = GetQuotesFromFeed();
 
         // calculate Stochastic RSI
-        List<StochRsiResult> resultsList =
-            quotesList
+        IReadOnlyList<StochRsiResult> resultsList =
+            quotes
                 .GetStochRsi(14, 14, 3)
                 .ToList();
 
@@ -40,9 +40,9 @@ public static class Program
         Console.WriteLine("-------------------------------------------------------");
 
         // roll through source values
-        for (int i = 1; i < quotesList.Count; i++)
+        for (int i = 1; i < quotes.Count; i++)
         {
-            Quote q = quotesList[i];
+            Quote q = quotes[i];
 
             StochRsiResult e = resultsList[i]; // evaluation period
             StochRsiResult l = resultsList[i - 1]; // last (prior) period
@@ -105,7 +105,7 @@ public static class Program
          See https://github.com/DaveSkender/Stock.Indicators/discussions/579
          for free or inexpensive market data providers and examples.
 
-         The return type of IEnumerable<Quote> can also be List<Quote>
+         The return type of IReadOnlyList<Quote> can also be List<Quote>
          or ICollection<Quote> or other IEnumerable compatible types.
 
          ************************************************************/

--- a/docs/examples/ConsoleApp/Program.cs
+++ b/docs/examples/ConsoleApp/Program.cs
@@ -10,7 +10,7 @@ public static class Program
     public static void Main()
     {
         // fetch historical quotes from data provider
-        IEnumerable<Quote> quotes = GetQuotesFromFeed();
+        IReadOnlyList<Quote> quotes = GetQuotesFromFeed();
 
         // calculate 10-period SMA
         IEnumerable<SmaResult> results = quotes.GetSma(10);
@@ -47,23 +47,20 @@ public static class Program
           with the same ordinal position.
          ************************************************************/
 
-        List<Quote> quotesList = quotes
-            .ToList();
+        IReadOnlyList<SmaResult> resultsList
+            = results.ToList();
 
-        List<SmaResult> resultsList = results
-            .ToList();
-
-        for (int i = quotesList.Count - 25; i < quotesList.Count; i++)
+        for (int i = quotes.Count - 25; i < quotes.Count; i++)
         {
             // only showing ~25 records for brevity
 
-            Quote q = quotesList[i];
+            Quote q = quotes[i];
             SmaResult r = resultsList[i];
 
             bool isBullish = (double)q.Close > r.Sma;
 
             Console.WriteLine($"SMA on {r.Date:u} was ${r.Sma:N3}"
-                              + $" and Bullishness is {isBullish}");
+                            + $" and Bullishness is {isBullish}");
         }
     }
 
@@ -80,7 +77,7 @@ public static class Program
          See https://github.com/DaveSkender/Stock.Indicators/discussions/579
          for free or inexpensive market data providers and examples.
 
-         The return type of IEnumerable<Quote> can also be List<Quote>
+         The return type of IReadOnlyList<Quote> can also be List<Quote>
          or ICollection<Quote> or other IEnumerable compatible types.
 
          ************************************************************/

--- a/docs/examples/CustomIndicators/AtrWma.cs
+++ b/docs/examples/CustomIndicators/AtrWma.cs
@@ -1,37 +1,36 @@
-using System.Collections.ObjectModel;
 using Skender.Stock.Indicators;
 
 namespace Custom.Stock.Indicators;
 
 // Custom results class
 // This inherits many of the extension methods, like .RemoveWarmupPeriods()
-public sealed class AtrWmaResult : ResultBase, IReusable
+public sealed class AtrWmaResult : ResultBase, IReusableResult
 {
     // date property is inherited here,
     // so you only need to add custom items
     public double? AtrWma { get; set; }
 
     // to enable further chaining
-    double? IReusable.Value => AtrWma;
+    double? IReusableResult.Value => AtrWma;
 }
 
 public static class CustomIndicators
 {
     // Custom ATR WMA calculation
-    public static IEnumerable<AtrWmaResult> GetAtrWma<TQuote>(
+    public static IReadOnlyList<AtrWmaResult> GetAtrWma<TQuote>(
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods)
         where TQuote : IQuote
     {
         // sort quotes and convert to collection or list
-        Collection<TQuote> quotesList = quotes
+        IReadOnlyList<TQuote> quotesList = quotes
             .ToSortedCollection();
 
         // initialize results
         List<AtrWmaResult> results = new(quotesList.Count);
 
         // perform pre-requisite calculations to get ATR values
-        List<AtrResult> atrResults = quotes
+        IReadOnlyList<AtrResult> atrResults = quotes
             .GetAtr(lookbackPeriods)
             .ToList();
 

--- a/docs/examples/CustomIndicators/README.md
+++ b/docs/examples/CustomIndicators/README.md
@@ -44,8 +44,8 @@ namespace Custom.Stock.Indicators;
 public static class CustomIndicator
 {
   // Custom ATR WMA calculation
-  public static IEnumerable<AtrWmaResult> GetAtrWma<TQuote>(
-    this IEnumerable<TQuote> quotes,
+  public static IReadOnlyList<AtrWmaResult> GetAtrWma<TQuote>(
+    this IReadOnlyList<TQuote> quotes,
     int lookbackPeriods)
     where TQuote : IQuote
   {
@@ -107,10 +107,10 @@ using Custom.Stock.Indicators; // your custom library
 [..]
 
 // fetch historical quotes from your feed (your method)
-IEnumerable<Quote> quotes = GetQuotesFromFeed("MSFT");
+IReadOnlyList<Quote> quotes = GetQuotesFromFeed("MSFT");
 
 // calculate 10-period ATR WMA
-IEnumerable<AtrWmaResult> results = quotes.GetAtrWma(10);
+IReadOnlyList<AtrWmaResult> results = quotes.GetAtrWma(10);
 
 // use results as needed for your use case (example only)
 foreach (AtrWmaResult r in results)

--- a/docs/examples/CustomIndicatorsUsage/Program.cs
+++ b/docs/examples/CustomIndicatorsUsage/Program.cs
@@ -13,10 +13,10 @@ public static class Program
     public static void Main()
     {
         // fetch historical quotes from data provider
-        IEnumerable<Quote> quotes = GetQuotesFromFeed();
+        IReadOnlyList<Quote> quotes = GetQuotesFromFeed();
 
         // calculate 10-period custom AtrWma
-        IEnumerable<AtrWmaResult> results = quotes
+        IReadOnlyList<AtrWmaResult> results = quotes
             .GetAtrWma(10);
 
         // show results

--- a/docs/examples/ObserveStream/Program.cs
+++ b/docs/examples/ObserveStream/Program.cs
@@ -40,7 +40,7 @@ internal class Program
         }
 
         // initialize our quote provider and a few subscribers
-        QuoteHub<Quote> provider = new();
+        QuoteProvider provider = new();
 
         SmaObserver sma = provider.GetSma(3);
         EmaObserver ema = provider.GetEma(5);

--- a/docs/examples/UseQuoteApi/Program.cs
+++ b/docs/examples/UseQuoteApi/Program.cs
@@ -10,7 +10,7 @@ internal class Program
         string symbol = "AAPL";
 
         // fetch historical quotes from data provider
-        IEnumerable<Quote> quotes = await GetQuotesFromFeed(symbol);
+        IReadOnlyList<Quote> quotes = await GetQuotesFromFeed(symbol);
 
         // calculate 10-period SMA
         IEnumerable<SmaResult> results = quotes.GetSma(10);
@@ -42,27 +42,24 @@ internal class Program
           with the same ordinal position.
          ************************************************************/
 
-        List<Quote> quotesList = quotes
-            .ToList();
-
         List<SmaResult> resultsList = results
             .ToList();
 
-        for (int i = quotesList.Count - 25; i < quotesList.Count; i++)
+        for (int i = quotes.Count - 25; i < quotes.Count; i++)
         {
             // only showing ~25 records for brevity
 
-            Quote q = quotesList[i];
+            Quote q = quotes[i];
             SmaResult r = resultsList[i];
 
             bool isBullish = (double)q.Close > r.Sma;
 
             Console.WriteLine($"SMA on {r.Date:u} was ${r.Sma:N3}"
-                              + $" and Bullishness is {isBullish}");
+                            + $" and Bullishness is {isBullish}");
         }
     }
 
-    private static async Task<IEnumerable<Quote>> GetQuotesFromFeed(string symbol)
+    private static async Task<IReadOnlyList<Quote>> GetQuotesFromFeed(string symbol)
     {
         /************************************************************
 
@@ -113,7 +110,7 @@ internal class Program
         IPage<IBar> barSet = await client.ListHistoricalBarsAsync(request);
 
         // convert library compatible quotes
-        IEnumerable<Quote> quotes = barSet
+        List<Quote> quotes = barSet
             .Items
             .Select(bar => new Quote
             {
@@ -124,7 +121,8 @@ internal class Program
                 Close = bar.Close,
                 Volume = bar.Volume
             })
-            .OrderBy(x => x.Date); // optional
+            .OrderBy(x => x.Date)
+            .ToList();
 
         return quotes;
     }

--- a/docs/pages/guide.md
+++ b/docs/pages/guide.md
@@ -60,7 +60,7 @@ using Skender.Stock.Indicators;
 IEnumerable<Quote> quotes = GetQuotesFromFeed("MSFT");
 
 // calculate 20-period SMA
-IEnumerable<SmaResult> results = quotes
+IReadOnlyList<SmaResult> results = quotes
   .GetSma(20);
 
 // use results as needed for your use case (example only)
@@ -250,14 +250,14 @@ Example:
 IEnumerable<Quote> quotes = GetQuotesFromFeed("SPY");
 
 // calculate RSI of OBV
-IEnumerable<RsiResult> results
+IReadOnlyList<RsiResult> results
   = quotes
     .GetObv()
     .GetRsi(14);
 
 // or with two separate operations
-IEnumerable<ObvResult> obvResults = quotes.GetObv();
-IEnumerable<RsiResult> rsiOfObv = obvResults.GetRsi(14);
+IReadOnlyList<ObvResult> obvResults = quotes.GetObv();
+IReadOnlyList<RsiResult> rsiOfObv = obvResults.GetRsi(14);
 ```
 
 ## Candlestick patterns

--- a/docs/pages/home.md
+++ b/docs/pages/home.md
@@ -43,7 +43,7 @@ You'll get all of the industry standard indicators out-of-the-box.  Additionally
 
 ```csharp
 // example: get 20-period simple moving average
-IEnumerable<SmaResult> results = quotes.GetSma(20);
+IReadOnlyList<SmaResult> results = quotes.GetSma(20);
 ```
 
 See more [usage examples]({{site.baseurl}}/guide/#example-usage).
@@ -54,13 +54,13 @@ Optional chaining enables advanced uses cases; such as, indicator of indicators,
 
 ```csharp
 // example: advanced chaining (RSI of OBV)
-IEnumerable<RsiResult> results
+IReadOnlyList<RsiResult> results
   = quotes
     .GetObv()
     .GetRsi(14);
 
 // example: use any candle variant
-IEnumerable<EmaResult> results
+IReadOnlyList<EmaResult> results
   = quotes
     .Use(CandlePart.HL2)
     .GetEma(20);

--- a/docs/pages/utilities.md
+++ b/docs/pages/utilities.md
@@ -76,14 +76,14 @@ IEnumerable<Quote> dayBarQuotes =
 CandleProperties candle = quote.ToCandle();
 
 // collection of quotes
-IEnumerable<CandleProperties> candles = quotes.ToCandles();
+IReadOnlyList<CandleProperties> candles = quotes.ToCandles();
 ```
 
 {% include candle-properties.md %}
 
 ### Validate quote history
 
-`quotes.Validate()` is an advanced check of your `IEnumerable<TQuote> quotes`.  It will check for duplicate dates and other bad data and will throw an `InvalidQuotesException` if validation fails.  This comes at a small performance cost, so we did not automatically add these advanced checks in the indicator methods.  Of course, you can and should do your own validation of `quotes` prior to using it in this library.  Bad historical quotes can produce unexpected results.
+`quotes.Validate()` is an advanced check of your `IReadOnlyList<TQuote> quotes`.  It will check for duplicate dates and other bad data and will throw an `InvalidQuotesException` if validation fails.  This comes at a small performance cost, so we did not automatically add these advanced checks in the indicator methods.  Of course, you can and should do your own validation of `quotes` prior to using it in this library.  Bad historical quotes can produce unexpected results.
 
 ```csharp
 // advanced validation
@@ -104,7 +104,7 @@ var results = quotes
 
 ```csharp
 // example: only show Marubozu signals
-IEnumerable<CandleResult> results
+IReadOnlyList<CandleResult> results
   = quotes.GetMarubozu(..).Condense();
 ```
 
@@ -116,7 +116,7 @@ IEnumerable<CandleResult> results
 
 ```csharp
 // calculate indicator series
-IEnumerable<SmaResult> results = quotes.GetSma(20);
+IReadOnlyList<SmaResult> results = quotes.GetSma(20);
 
 // find result on a specific date
 DateTime lookupDate = [..] // the date you want to find
@@ -131,12 +131,12 @@ SmaResult result = results.Find(lookupDate);
 
 ```csharp
 // auto remove recommended warmup periods
-IEnumerable<AdxResult> results =
+IReadOnlyList<AdxResult> results =
   quotes.GetAdx(14).RemoveWarmupPeriods();
 
 // remove a specific quantity of periods
 int n = 14;
-IEnumerable<AdxResult> results =
+IReadOnlyList<AdxResult> results =
   quotes.GetAdx(n).RemoveWarmupPeriods(n+100);
 ```
 

--- a/src/_common/Candles/Candles.Utilities.cs
+++ b/src/_common/Candles/Candles.Utilities.cs
@@ -2,7 +2,7 @@ namespace Skender.Stock.Indicators;
 
 public static class CandleUtility
 {
-    public static IEnumerable<CandleResult> Condense(
+    public static IReadOnlyList<CandleResult> Condense(
         this IEnumerable<CandleResult> candleResults) => candleResults
             .Where(candle => candle.Match != Match.None)
             .ToList();
@@ -18,7 +18,7 @@ public static class CandleUtility
             Volume: quote.Volume);
 
     // convert/sort quotes into candles list
-    public static IEnumerable<CandleProperties> ToCandles<TQuote>(
+    public static IReadOnlyList<CandleProperties> ToCandles<TQuote>(
         this IEnumerable<TQuote> quotes)
         where TQuote : IQuote => quotes
             .Select(x => x.ToCandle())

--- a/src/_common/Generics/Pruning.cs
+++ b/src/_common/Generics/Pruning.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static class Pruning
 {
     // REMOVE SPECIFIC PERIODS
-    public static IEnumerable<T> RemoveWarmupPeriods<T>(
+    public static IReadOnlyList<T> RemoveWarmupPeriods<T>(
         this IEnumerable<T> series,
         int removePeriods)
         => removePeriods < 0

--- a/src/_common/Quotes/Quote.Aggregates.cs
+++ b/src/_common/Quotes/Quote.Aggregates.cs
@@ -7,7 +7,7 @@ public static partial class QuoteUtility
     // aggregation (quantization)
     /// <include file='./info.xml' path='info/type[@name="Aggregate"]/*' />
     ///
-    public static IEnumerable<Quote> Aggregate<TQuote>(
+    public static IReadOnlyList<Quote> Aggregate<TQuote>(
         this IEnumerable<TQuote> quotes,
         PeriodSize newSize)
         where TQuote : IQuote
@@ -23,7 +23,8 @@ public static partial class QuoteUtility
                     High: x.Max(t => t.High),
                     Low: x.Min(t => t.Low),
                     Close: x.Last().Close,
-                    Volume: x.Sum(t => t.Volume)));
+                    Volume: x.Sum(t => t.Volume)))
+                .ToList();
         }
 
         // parameter conversion
@@ -38,7 +39,7 @@ public static partial class QuoteUtility
     // aggregation (quantization) using TimeSpan
     /// <include file='./info.xml' path='info/type[@name="AggregateTimeSpan"]/*' />
     ///
-    public static IEnumerable<Quote> Aggregate<TQuote>(
+    public static IReadOnlyList<Quote> Aggregate<TQuote>(
         this IEnumerable<TQuote> quotes,
         TimeSpan timeSpan)
         where TQuote : IQuote
@@ -59,6 +60,7 @@ public static partial class QuoteUtility
                 High: x.Max(t => t.High),
                 Low: x.Min(t => t.Low),
                 Close: x.Last().Close,
-                Volume: x.Sum(t => t.Volume)));
+                Volume: x.Sum(t => t.Volume)))
+            .ToList();
     }
 }

--- a/src/_common/Quotes/Quote.Validation.cs
+++ b/src/_common/Quotes/Quote.Validation.cs
@@ -7,7 +7,7 @@ public static partial class QuoteUtility
     // VALIDATION
     /// <include file='./info.xml' path='info/type[@name="Validate"]/*' />
     ///
-    public static IEnumerable<TQuote> Validate<TQuote>(
+    public static IReadOnlyList<TQuote> Validate<TQuote>(
         this IEnumerable<TQuote> quotes)
         where TQuote : IQuote
     {

--- a/src/_common/Quotes/Quote.Validation.cs
+++ b/src/_common/Quotes/Quote.Validation.cs
@@ -17,7 +17,7 @@ public static partial class QuoteUtility
 
         // check for duplicates
         DateTime lastDate = DateTime.MinValue;
-        foreach (var q in quotesList)
+        foreach (TQuote q in quotesList)
         {
             if (lastDate == q.Timestamp)
             {

--- a/src/_common/Reusable/Reusable.Utilities.cs
+++ b/src/_common/Reusable/Reusable.Utilities.cs
@@ -54,8 +54,8 @@ public static class ReusableUtility
         this IEnumerable<T> results)
         where T : IReusable
     {
-        // this is the default implementation;
-        // it will be overridden in the specific indicator class
+        // this is the default implementation, it will
+        // be overridden in the specific indicator class
 
         int removePeriods = results
             .ToList()

--- a/src/_common/Reusable/Reusable.Utilities.cs
+++ b/src/_common/Reusable/Reusable.Utilities.cs
@@ -25,7 +25,7 @@ public static class ReusableUtility
     /// <typeparam name="T">Any reusable result type.</typeparam>
     /// <param name="results">Indicator results to evaluate.</param>
     /// <returns>Time series of indicator results, condensed.</returns>
-    public static IEnumerable<T> Condense<T>(
+    public static IReadOnlyList<T> Condense<T>(
         this IEnumerable<T> results)
         where T : IReusable
     {
@@ -36,7 +36,7 @@ public static class ReusableUtility
             .RemoveAll(match:
                 x => double.IsNaN(x.Value));
 
-        return resultsList.ToSortedList();
+        return resultsList;
     }
 
     /// <summary>
@@ -50,7 +50,7 @@ public static class ReusableUtility
     /// <typeparam name="T">Any reusable result type.</typeparam>
     /// <param name="results">Indicator results to evaluate.</param>
     /// <returns>Time series of results, pruned.</returns>
-    internal static IEnumerable<T> RemoveWarmupPeriods<T>(
+    internal static IReadOnlyList<T> RemoveWarmupPeriods<T>(
         this IEnumerable<T> results)
         where T : IReusable
     {

--- a/src/_common/Use (QuotePart)/Use.Api.cs
+++ b/src/_common/Use (QuotePart)/Use.Api.cs
@@ -5,21 +5,23 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from Quotes
-    public static IEnumerable<QuotePart> Use(
+    public static IReadOnlyList<QuotePart> Use(
         this IEnumerable<IQuote> quotes,
         CandlePart candlePart)
         => quotes
             .OrderBy(q => q.Timestamp)
-            .Select(q => q.ToQuotePart(candlePart));
+            .Select(q => q.ToQuotePart(candlePart))
+            .ToList();
 
     // SERIES, from Quotes
-    public static IEnumerable<QuotePart> Use<TQuote>(
+    public static IReadOnlyList<QuotePart> Use<TQuote>(
         this IEnumerable<TQuote> quotes,
         CandlePart candlePart)
         where TQuote : IQuote
         => quotes
             .OrderBy(q => q.Timestamp)
-            .Select(q => q.ToQuotePart(candlePart));
+            .Select(q => q.ToQuotePart(candlePart))
+            .ToList();
 
     // OBSERVER, from Quote Provider
     public static QuotePartHub<TIn> ToQuotePart<TIn>(

--- a/src/a-d/Adl/Adl.Api.cs
+++ b/src/a-d/Adl/Adl.Api.cs
@@ -16,7 +16,7 @@ public static partial class Adl
     ///<typeparam name = "TQuote" > Configurable Quote type. See Guide for more information.</typeparam>
     ///<param name="quotes">Historical price quotes.</param>
     ///<returns>Time series of ADL values.</returns>
-    public static IEnumerable<AdlResult> GetAdl<TQuote>(
+    public static IReadOnlyList<AdlResult> GetAdl<TQuote>(
         this IEnumerable<TQuote> quotes)
         where TQuote : IQuote
         => quotes

--- a/src/a-d/Adl/Adl.Series.cs
+++ b/src/a-d/Adl/Adl.Series.cs
@@ -9,11 +9,12 @@ public static partial class Adl
         where TQuote : IQuote
     {
         // initialize
-        List<AdlResult> results = new(source.Count);
+        int length = source.Count;
+        List<AdlResult> results = new(length);
         double prevAdl = 0;
 
         // roll through source values
-        for (int i = 0; i < source.Count; i++)
+        for (int i = 0; i < length; i++)
         {
             IQuote q = source[i];
 

--- a/src/a-d/Adx/Adx.Api.cs
+++ b/src/a-d/Adx/Adx.Api.cs
@@ -7,7 +7,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/type[@name="standard"]/*' />
     ///
-    public static IEnumerable<AdxResult> GetAdx<TQuote>(
+    public static IReadOnlyList<AdxResult> GetAdx<TQuote>(
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods = 14)
         where TQuote : IQuote => quotes

--- a/src/a-d/Adx/Adx.Series.cs
+++ b/src/a-d/Adx/Adx.Series.cs
@@ -5,14 +5,14 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     private static List<AdxResult> CalcAdx(
-        this List<QuoteD> qdList,
+        this List<QuoteD> source,
         int lookbackPeriods)
     {
         // check parameter arguments
         Adx.Validate(lookbackPeriods);
 
         // initialize
-        int length = qdList.Count;
+        int length = source.Count;
         List<AdxResult> results = new(length);
 
         double prevHigh = 0;
@@ -31,7 +31,7 @@ public static partial class Indicator
         // roll through source values
         for (int i = 0; i < length; i++)
         {
-            QuoteD q = qdList[i];
+            QuoteD q = source[i];
 
             // skip first period
             if (i == 0)

--- a/src/a-d/Adx/Adx.Utilities.cs
+++ b/src/a-d/Adx/Adx.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<AdxResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<AdxResult> RemoveWarmupPeriods(
         this IEnumerable<AdxResult> results)
     {
         int n = results

--- a/src/a-d/Alligator/Alligator.Api.cs
+++ b/src/a-d/Alligator/Alligator.Api.cs
@@ -29,7 +29,7 @@ public static partial class Alligator
     /// <exception cref="ArgumentOutOfRangeException">
     /// Invalid parameter value provided.
     /// </exception>
-    public static IEnumerable<AlligatorResult> GetAlligator<T>(
+    public static IReadOnlyList<AlligatorResult> GetAlligator<T>(
         this IEnumerable<T> source,
         int jawPeriods = 13,
         int jawOffset = 8,

--- a/src/a-d/Alligator/Alligator.Utilities.cs
+++ b/src/a-d/Alligator/Alligator.Utilities.cs
@@ -3,7 +3,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Alligator
 {
     // CONDENSE (REMOVE null results)
-    public static IEnumerable<AlligatorResult> Condense(
+    public static IReadOnlyList<AlligatorResult> Condense(
         this IEnumerable<AlligatorResult> results)
     {
         List<AlligatorResult> resultsList = results
@@ -17,7 +17,7 @@ public static partial class Alligator
     }
 
     // remove recommended periods
-    public static IEnumerable<AlligatorResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<AlligatorResult> RemoveWarmupPeriods(
         this IEnumerable<AlligatorResult> results)
     {
         int removePeriods = results

--- a/src/a-d/Alma/Alma.Api.cs
+++ b/src/a-d/Alma/Alma.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<AlmaResult> GetAlma<T>(
+    public static IReadOnlyList<AlmaResult> GetAlma<T>(
         this IEnumerable<T> results,
         int lookbackPeriods = 9,
         double offset = 0.85,

--- a/src/a-d/Alma/Alma.Series.cs
+++ b/src/a-d/Alma/Alma.Series.cs
@@ -15,7 +15,8 @@ public static partial class Indicator
         Alma.Validate(lookbackPeriods, offset, sigma);
 
         // initialize
-        List<AlmaResult> results = new(source.Count);
+        int length = source.Count;
+        List<AlmaResult> results = new(length);
 
         // determine price weight constants
         double m = offset * (lookbackPeriods - 1);
@@ -32,7 +33,7 @@ public static partial class Indicator
         }
 
         // roll through source values
-        for (int i = 0; i < source.Count; i++)
+        for (int i = 0; i < length; i++)
         {
             double alma = double.NaN;
 

--- a/src/a-d/Alma/Alma.Utilities.cs
+++ b/src/a-d/Alma/Alma.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<AlmaResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<AlmaResult> RemoveWarmupPeriods(
         this IEnumerable<AlmaResult> results)
     {
         int removePeriods = results

--- a/src/a-d/Aroon/Aroon.Api.cs
+++ b/src/a-d/Aroon/Aroon.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<AroonResult> GetAroon<TQuote>(
+    public static IReadOnlyList<AroonResult> GetAroon<TQuote>(
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods = 25)
         where TQuote : IQuote => quotes

--- a/src/a-d/Aroon/Aroon.Series.cs
+++ b/src/a-d/Aroon/Aroon.Series.cs
@@ -5,19 +5,20 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     private static List<AroonResult> CalcAroon(
-        this List<QuoteD> qdList,
+        this List<QuoteD> source,
         int lookbackPeriods)
     {
         // check parameter arguments
         Aroon.Validate(lookbackPeriods);
 
         // initialize
-        List<AroonResult> results = new(qdList.Count);
+        int length = source.Count;
+        List<AroonResult> results = new(length);
 
         // roll through source values
-        for (int i = 0; i < qdList.Count; i++)
+        for (int i = 0; i < length; i++)
         {
-            QuoteD q = qdList[i];
+            QuoteD q = source[i];
             double? aroonUp = null;
             double? aroonDown = null;
 
@@ -31,7 +32,7 @@ public static partial class Indicator
 
                 for (int p = i + 1 - lookbackPeriods - 1; p <= i; p++)
                 {
-                    QuoteD d = qdList[p];
+                    QuoteD d = source[p];
 
                     if (d.High > lastHighPrice)
                     {

--- a/src/a-d/Aroon/Aroon.Utilities.cs
+++ b/src/a-d/Aroon/Aroon.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<AroonResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<AroonResult> RemoveWarmupPeriods(
         this IEnumerable<AroonResult> results)
     {
         int removePeriods = results

--- a/src/a-d/Atr/Atr.Api.cs
+++ b/src/a-d/Atr/Atr.Api.cs
@@ -6,7 +6,7 @@ public static partial class Atr
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<AtrResult> GetAtr<TQuote>(
+    public static IReadOnlyList<AtrResult> GetAtr<TQuote>(
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods = 14)
         where TQuote : IQuote => quotes

--- a/src/a-d/Atr/Atr.Series.cs
+++ b/src/a-d/Atr/Atr.Series.cs
@@ -6,14 +6,14 @@ public static partial class Atr
 {
     // calculate series
     internal static List<AtrResult> CalcAtr(
-        this List<QuoteD> qdList,
+        this List<QuoteD> source,
         int lookbackPeriods)
     {
         // check parameter arguments
         Atr.Validate(lookbackPeriods);
 
         // initialize
-        int length = qdList.Count;
+        int length = source.Count;
         List<AtrResult> results = new(length);
         double prevAtr = double.NaN;
         double prevClose = double.NaN;
@@ -22,7 +22,7 @@ public static partial class Atr
         // skip first period
         if (length > 0)
         {
-            QuoteD q = qdList[0];
+            QuoteD q = source[0];
             results.Add(new(Timestamp: q.Timestamp));
             prevClose = q.Close;
         }
@@ -30,7 +30,7 @@ public static partial class Atr
         // roll through source values
         for (int i = 1; i < length; i++)
         {
-            QuoteD q = qdList[i];
+            QuoteD q = source[i];
 
             double hmpc = Math.Abs(q.High - prevClose);
             double lmpc = Math.Abs(q.Low - prevClose);

--- a/src/a-d/Atr/Atr.Utilities.cs
+++ b/src/a-d/Atr/Atr.Utilities.cs
@@ -3,7 +3,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Atr
 {
     // remove recommended periods
-    public static IEnumerable<AtrResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<AtrResult> RemoveWarmupPeriods(
         this IEnumerable<AtrResult> results)
     {
         int removePeriods = results

--- a/src/a-d/AtrStop/AtrStop.Api.cs
+++ b/src/a-d/AtrStop/AtrStop.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<AtrStopResult> GetAtrStop<TQuote>(
+    public static IReadOnlyList<AtrStopResult> GetAtrStop<TQuote>(
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods = 21,
         double multiplier = 3,

--- a/src/a-d/AtrStop/AtrStop.Series.cs
+++ b/src/a-d/AtrStop/AtrStop.Series.cs
@@ -5,7 +5,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     private static List<AtrStopResult> CalcAtrStop(
-        this List<QuoteD> qdList,
+        this List<QuoteD> source,
         int lookbackPeriods,
         double multiplier,
         EndType endType)
@@ -14,9 +14,9 @@ public static partial class Indicator
         AtrStop.Validate(lookbackPeriods, multiplier);
 
         // initialize
-        int length = qdList.Count;
+        int length = source.Count;
         List<AtrStopResult> results = new(length);
-        List<AtrResult> atrResults = qdList.CalcAtr(lookbackPeriods);
+        List<AtrResult> atrResults = source.CalcAtr(lookbackPeriods);
 
         bool isBullish = true;
         double? upperBand = null;
@@ -25,7 +25,7 @@ public static partial class Indicator
         // roll through source values
         for (int i = 0; i < length; i++)
         {
-            QuoteD q = qdList[i];
+            QuoteD q = source[i];
 
             decimal? atrStop = null;
             decimal? buyStop = null;
@@ -34,7 +34,7 @@ public static partial class Indicator
             if (i >= lookbackPeriods)
             {
                 double? atr = atrResults[i].Atr;
-                QuoteD p = qdList[i - 1];
+                QuoteD p = source[i - 1];
 
                 double? upperEval;
                 double? lowerEval;

--- a/src/a-d/AtrStop/AtrStop.Utilities.cs
+++ b/src/a-d/AtrStop/AtrStop.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // CONDENSE (REMOVE null results)
     /// <inheritdoc cref="ReusableUtility.Condense{T}(IEnumerable{T})"/>
-    public static IEnumerable<AtrStopResult> Condense(
+    public static IReadOnlyList<AtrStopResult> Condense(
         this IEnumerable<AtrStopResult> results)
     {
         List<AtrStopResult> resultsList = results
@@ -17,7 +17,7 @@ public static partial class Indicator
 
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<AtrStopResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<AtrStopResult> RemoveWarmupPeriods(
         this IEnumerable<AtrStopResult> results)
     {
         int removePeriods = results

--- a/src/a-d/Awesome/Awesome.Api.cs
+++ b/src/a-d/Awesome/Awesome.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<AwesomeResult> GetAwesome<T>(
+    public static IReadOnlyList<AwesomeResult> GetAwesome<T>(
         this IEnumerable<T> source,
         int fastPeriods = 5,
         int slowPeriods = 34)

--- a/src/a-d/Awesome/Awesome.Utilities.cs
+++ b/src/a-d/Awesome/Awesome.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<AwesomeResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<AwesomeResult> RemoveWarmupPeriods(
         this IEnumerable<AwesomeResult> results)
     {
         int removePeriods = results

--- a/src/a-d/Beta/Beta.Api.cs
+++ b/src/a-d/Beta/Beta.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAINS (both inputs reusable)
-    public static IEnumerable<BetaResult> GetBeta<T>(
+    public static IReadOnlyList<BetaResult> GetBeta<T>(
         this IEnumerable<T> evalSource,
         IEnumerable<T> mrktSource,
         int lookbackPeriods,

--- a/src/a-d/Beta/Beta.Utilities.cs
+++ b/src/a-d/Beta/Beta.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<BetaResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<BetaResult> RemoveWarmupPeriods(
         this IEnumerable<BetaResult> results)
     {
         int removePeriods = results

--- a/src/a-d/BollingerBands/BollingerBands.Api.cs
+++ b/src/a-d/BollingerBands/BollingerBands.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<BollingerBandsResult> GetBollingerBands<T>(
+    public static IReadOnlyList<BollingerBandsResult> GetBollingerBands<T>(
         this IEnumerable<T> results,
         int lookbackPeriods = 20,
         double standardDeviations = 2)

--- a/src/a-d/BollingerBands/BollingerBands.Series.cs
+++ b/src/a-d/BollingerBands/BollingerBands.Series.cs
@@ -14,10 +14,11 @@ public static partial class Indicator
         BollingerBands.Validate(lookbackPeriods, standardDeviations);
 
         // initialize
-        List<BollingerBandsResult> results = new(source.Count);
+        int length = source.Count;
+        List<BollingerBandsResult> results = new(length);
 
         // roll through source values
-        for (int i = 0; i < source.Count; i++)
+        for (int i = 0; i < length; i++)
         {
             T s = source[i];
 

--- a/src/a-d/BollingerBands/BollingerBands.Utilities.cs
+++ b/src/a-d/BollingerBands/BollingerBands.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<BollingerBandsResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<BollingerBandsResult> RemoveWarmupPeriods(
         this IEnumerable<BollingerBandsResult> results)
     {
         int removePeriods = results

--- a/src/a-d/Bop/Bop.Api.cs
+++ b/src/a-d/Bop/Bop.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<BopResult> GetBop<TQuote>(
+    public static IReadOnlyList<BopResult> GetBop<TQuote>(
         this IEnumerable<TQuote> quotes,
         int smoothPeriods = 14)
         where TQuote : IQuote => quotes

--- a/src/a-d/Bop/Bop.Series.cs
+++ b/src/a-d/Bop/Bop.Series.cs
@@ -5,17 +5,17 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     private static List<BopResult> CalcBop(
-        this List<QuoteD> qdList,
+        this List<QuoteD> source,
         int smoothPeriods)
     {
         // check parameter arguments
         Bop.Validate(smoothPeriods);
 
         // initialize
-        int length = qdList.Count;
+        int length = source.Count;
         List<BopResult> results = new(length);
 
-        double[] raw = qdList
+        double[] raw = source
             .Select(x => x.High - x.Low != 0 ?
                 (x.Close - x.Open) / (x.High - x.Low) : double.NaN)
             .ToArray();
@@ -37,7 +37,7 @@ public static partial class Indicator
             }
 
             results.Add(new(
-                Timestamp: qdList[i].Timestamp,
+                Timestamp: source[i].Timestamp,
                 Bop: bop));
         }
 

--- a/src/a-d/Bop/Bop.Utilities.cs
+++ b/src/a-d/Bop/Bop.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<BopResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<BopResult> RemoveWarmupPeriods(
         this IEnumerable<BopResult> results)
     {
         int removePeriods = results

--- a/src/a-d/Cci/Cci.Api.cs
+++ b/src/a-d/Cci/Cci.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<CciResult> GetCci<TQuote>(
+    public static IReadOnlyList<CciResult> GetCci<TQuote>(
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods = 20)
         where TQuote : IQuote => quotes

--- a/src/a-d/Cci/Cci.Series.cs
+++ b/src/a-d/Cci/Cci.Series.cs
@@ -5,21 +5,21 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     private static List<CciResult> CalcCci(
-        this List<QuoteD> qdList,
+        this List<QuoteD> source,
         int lookbackPeriods)
     {
         // check parameter arguments
         Cci.Validate(lookbackPeriods);
 
         // initialize
-        int length = qdList.Count;
+        int length = source.Count;
         List<CciResult> results = new(length);
         double[] tp = new double[length];
 
         // roll through source values
         for (int i = 0; i < length; i++)
         {
-            QuoteD q = qdList[i];
+            QuoteD q = source[i];
             tp[i] = (q.High + q.Low + q.Close) / 3d;
 
             double? cci = null;

--- a/src/a-d/Cci/Cci.Utilities.cs
+++ b/src/a-d/Cci/Cci.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<CciResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<CciResult> RemoveWarmupPeriods(
         this IEnumerable<CciResult> results)
     {
         int removePeriods = results

--- a/src/a-d/ChaikinOsc/ChaikinOsc.Api.cs
+++ b/src/a-d/ChaikinOsc/ChaikinOsc.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<ChaikinOscResult> GetChaikinOsc<TQuote>(
+    public static IReadOnlyList<ChaikinOscResult> GetChaikinOsc<TQuote>(
         this IEnumerable<TQuote> quotes,
         int fastPeriods = 3,
         int slowPeriods = 10)

--- a/src/a-d/ChaikinOsc/ChaikinOsc.Utilities.cs
+++ b/src/a-d/ChaikinOsc/ChaikinOsc.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<ChaikinOscResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<ChaikinOscResult> RemoveWarmupPeriods(
         this IEnumerable<ChaikinOscResult> results)
     {
         int s = results

--- a/src/a-d/Chandelier/Chandelier.Api.cs
+++ b/src/a-d/Chandelier/Chandelier.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<ChandelierResult> GetChandelier<TQuote>(
+    public static IReadOnlyList<ChandelierResult> GetChandelier<TQuote>(
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods = 22,
         double multiplier = 3,

--- a/src/a-d/Chandelier/Chandelier.Series.cs
+++ b/src/a-d/Chandelier/Chandelier.Series.cs
@@ -5,7 +5,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     private static List<ChandelierResult> CalcChandelier(
-        this List<QuoteD> qdList,
+        this List<QuoteD> source,
         int lookbackPeriods,
         double multiplier,
         ChandelierType type)
@@ -14,16 +14,16 @@ public static partial class Indicator
         Chandelier.Validate(lookbackPeriods, multiplier);
 
         // initialize
-        int length = qdList.Count;
+        int length = source.Count;
         List<ChandelierResult> results = new(length);
-        List<AtrResult> atrResult = qdList
-            .CalcAtr(lookbackPeriods)
-            .ToList();
+
+        IReadOnlyList<AtrResult> atrResult
+            = source.CalcAtr(lookbackPeriods);
 
         // roll through source values
         for (int i = 0; i < length; i++)
         {
-            QuoteD q = qdList[i];
+            QuoteD q = source[i];
 
             double? exit = null;
 
@@ -39,14 +39,14 @@ public static partial class Indicator
                         double maxHigh = 0;
                         for (int p = i + 1 - lookbackPeriods; p <= i; p++)
                         {
-                            QuoteD d = qdList[p];
+                            QuoteD d = source[p];
                             if (d.High > maxHigh)
                             {
                                 maxHigh = d.High;
                             }
                         }
 
-                        exit = maxHigh - atr * multiplier;
+                        exit = maxHigh - (atr * multiplier);
                         break;
 
                     case ChandelierType.Short:
@@ -54,14 +54,14 @@ public static partial class Indicator
                         double minLow = double.MaxValue;
                         for (int p = i + 1 - lookbackPeriods; p <= i; p++)
                         {
-                            QuoteD d = qdList[p];
+                            QuoteD d = source[p];
                             if (d.Low < minLow)
                             {
                                 minLow = d.Low;
                             }
                         }
 
-                        exit = minLow + atr * multiplier;
+                        exit = minLow + (atr * multiplier);
                         break;
 
                     default:

--- a/src/a-d/Chandelier/Chandelier.Utilities.cs
+++ b/src/a-d/Chandelier/Chandelier.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<ChandelierResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<ChandelierResult> RemoveWarmupPeriods(
         this IEnumerable<ChandelierResult> results)
     {
         int removePeriods = results

--- a/src/a-d/Chop/Chop.Api.cs
+++ b/src/a-d/Chop/Chop.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<ChopResult> GetChop<TQuote>(
+    public static IReadOnlyList<ChopResult> GetChop<TQuote>(
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods = 14)
         where TQuote : IQuote => quotes

--- a/src/a-d/Chop/Chop.Series.cs
+++ b/src/a-d/Chop/Chop.Series.cs
@@ -5,14 +5,14 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     private static List<ChopResult> CalcChop(
-        this List<QuoteD> qdList,
+        this List<QuoteD> source,
         int lookbackPeriods)
     {
         // check parameter arguments
         Chop.Validate(lookbackPeriods);
 
         // initialize
-        int length = qdList.Count;
+        int length = source.Count;
         List<ChopResult> results = new(length);
         double[] trueHigh = new double[length];
         double[] trueLow = new double[length];
@@ -25,8 +25,8 @@ public static partial class Indicator
 
             if (i > 0)
             {
-                trueHigh[i] = Math.Max(qdList[i].High, qdList[i - 1].Close);
-                trueLow[i] = Math.Min(qdList[i].Low, qdList[i - 1].Close);
+                trueHigh[i] = Math.Max(source[i].High, source[i - 1].Close);
+                trueLow[i] = Math.Min(source[i].Low, source[i - 1].Close);
                 trueRange[i] = trueHigh[i] - trueLow[i];
 
                 // calculate CHOP
@@ -57,7 +57,7 @@ public static partial class Indicator
             }
 
             results.Add(new(
-                Timestamp: qdList[i].Timestamp,
+                Timestamp: source[i].Timestamp,
                 Chop: chop));
         }
 

--- a/src/a-d/Chop/Chop.Utilities.cs
+++ b/src/a-d/Chop/Chop.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<ChopResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<ChopResult> RemoveWarmupPeriods(
         this IEnumerable<ChopResult> results)
     {
         int removePeriods = results

--- a/src/a-d/Cmf/Cmf.Api.cs
+++ b/src/a-d/Cmf/Cmf.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<CmfResult> GetCmf<TQuote>(
+    public static IReadOnlyList<CmfResult> GetCmf<TQuote>(
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods = 20)
         where TQuote : IQuote => quotes

--- a/src/a-d/Cmf/Cmf.Utilities.cs
+++ b/src/a-d/Cmf/Cmf.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<CmfResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<CmfResult> RemoveWarmupPeriods(
         this IEnumerable<CmfResult> results)
     {
         int removePeriods = results

--- a/src/a-d/Cmo/Cmo.Api.cs
+++ b/src/a-d/Cmo/Cmo.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<CmoResult> GetCmo<T>(
+    public static IReadOnlyList<CmoResult> GetCmo<T>(
         this IEnumerable<T> source,
         int lookbackPeriods)
         where T : IReusable

--- a/src/a-d/Cmo/Cmo.Utilities.cs
+++ b/src/a-d/Cmo/Cmo.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<CmoResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<CmoResult> RemoveWarmupPeriods(
         this IEnumerable<CmoResult> results)
     {
         int removePeriods = results

--- a/src/a-d/ConnorsRsi/ConnorsRsi.Api.cs
+++ b/src/a-d/ConnorsRsi/ConnorsRsi.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<ConnorsRsiResult> GetConnorsRsi<T>(
+    public static IReadOnlyList<ConnorsRsiResult> GetConnorsRsi<T>(
         this IEnumerable<T> results,
         int rsiPeriods = 3,
         int streakPeriods = 2,

--- a/src/a-d/ConnorsRsi/ConnorsRsi.Series.cs
+++ b/src/a-d/ConnorsRsi/ConnorsRsi.Series.cs
@@ -21,15 +21,14 @@ public static partial class Indicator
         int startPeriod
             = Math.Max(rsiPeriods, Math.Max(streakPeriods, rankPeriods)) + 2;
 
-        List<ConnorsRsiResult> streakInfo
+        IReadOnlyList<ConnorsRsiResult> streakInfo
             = source.CalcStreak(rsiPeriods, rankPeriods);
 
         // RSI of streak
-        List<QuotePart> reStreak = streakInfo
+        IReadOnlyList<RsiResult> rsiStreak = streakInfo
             .Select(si => new QuotePart(si.Timestamp, si.Streak))
-            .ToList();
-
-        List<RsiResult> rsiStreak = reStreak.CalcRsi(streakPeriods);
+            .ToList()
+            .CalcRsi(streakPeriods);
 
         // compose final results
         for (int i = 0; i < length; i++)

--- a/src/a-d/ConnorsRsi/ConnorsRsi.Utilities.cs
+++ b/src/a-d/ConnorsRsi/ConnorsRsi.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<ConnorsRsiResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<ConnorsRsiResult> RemoveWarmupPeriods(
         this IEnumerable<ConnorsRsiResult> results)
     {
         int n = results

--- a/src/a-d/Correlation/Correlation.Api.cs
+++ b/src/a-d/Correlation/Correlation.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAINS (both inputs reusable)
-    public static IEnumerable<CorrResult> GetCorrelation<T>(
+    public static IReadOnlyList<CorrResult> GetCorrelation<T>(
         this IEnumerable<T> sourceA,
         IEnumerable<T> sourceB,
         int lookbackPeriods)

--- a/src/a-d/Correlation/Correlation.Utilities.cs
+++ b/src/a-d/Correlation/Correlation.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<CorrResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<CorrResult> RemoveWarmupPeriods(
         this IEnumerable<CorrResult> results)
     {
         int removePeriods = results

--- a/src/a-d/Dema/Dema.Api.cs
+++ b/src/a-d/Dema/Dema.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<DemaResult> GetDema<T>(
+    public static IReadOnlyList<DemaResult> GetDema<T>(
         this IEnumerable<T> results,
         int lookbackPeriods)
         where T : IReusable

--- a/src/a-d/Dema/Dema.Utilities.cs
+++ b/src/a-d/Dema/Dema.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<DemaResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<DemaResult> RemoveWarmupPeriods(
         this IEnumerable<DemaResult> results)
     {
         int n = results

--- a/src/a-d/Doji/Doji.Api.cs
+++ b/src/a-d/Doji/Doji.Api.cs
@@ -17,7 +17,7 @@ public static partial class Indicator
     /// <param name = "maxPriceChangePercent" > Optional.Maximum absolute percent difference in open and close price.</param>
     /// <returns>Time series of Doji values.</returns>
     /// <exception cref = "ArgumentOutOfRangeException" > Invalid parameter value provided.</exception>
-    public static IEnumerable<CandleResult> GetDoji<TQuote>(
+    public static IReadOnlyList<CandleResult> GetDoji<TQuote>(
         this IEnumerable<TQuote> quotes,
         double maxPriceChangePercent = 0.1)
         where TQuote : IQuote => quotes

--- a/src/a-d/Donchian/Donchian.Api.cs
+++ b/src/a-d/Donchian/Donchian.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<DonchianResult> GetDonchian<TQuote>(
+    public static IReadOnlyList<DonchianResult> GetDonchian<TQuote>(
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods = 20)
         where TQuote : IQuote => quotes

--- a/src/a-d/Donchian/Donchian.Utilities.cs
+++ b/src/a-d/Donchian/Donchian.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // CONDENSE (REMOVE null results)
     /// <inheritdoc cref="ReusableUtility.Condense{T}(IEnumerable{T})"/>
-    public static IEnumerable<DonchianResult> Condense(
+    public static IReadOnlyList<DonchianResult> Condense(
         this IEnumerable<DonchianResult> results)
     {
         List<DonchianResult> resultsList = results
@@ -19,7 +19,7 @@ public static partial class Indicator
 
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<DonchianResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<DonchianResult> RemoveWarmupPeriods(
         this IEnumerable<DonchianResult> results)
     {
         int removePeriods = results

--- a/src/a-d/Dpo/Dpo.Api.cs
+++ b/src/a-d/Dpo/Dpo.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<DpoResult> GetDpo<T>(
+    public static IReadOnlyList<DpoResult> GetDpo<T>(
         this IEnumerable<T> results,
         int lookbackPeriods)
         where T : IReusable

--- a/src/a-d/Dpo/Dpo.Series.cs
+++ b/src/a-d/Dpo/Dpo.Series.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
 {
     // calculate series
     private static List<DpoResult> CalcDpo<T>(
-        this List<T> tpList,
+        this List<T> source,
         int lookbackPeriods)
         where T : IReusable
     {
@@ -14,15 +14,18 @@ public static partial class Indicator
         Dpo.Validate(lookbackPeriods);
 
         // initialize
-        int length = tpList.Count;
-        int offset = lookbackPeriods / 2 + 1;
-        List<SmaResult> sma = tpList.GetSma(lookbackPeriods).ToList();
+        int length = source.Count;
         List<DpoResult> results = new(length);
+
+        int offset = (lookbackPeriods / 2) + 1;
+
+        IReadOnlyList<SmaResult> sma
+            = source.CalcSma(lookbackPeriods);
 
         // roll through source values
         for (int i = 0; i < length; i++)
         {
-            T src = tpList[i];
+            T src = source[i];
 
             double? dpoSma = null;
             double? dpoVal = null;

--- a/src/a-d/Dynamic/Dynamic.Api.cs
+++ b/src/a-d/Dynamic/Dynamic.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<DynamicResult> GetDynamic<T>(
+    public static IReadOnlyList<DynamicResult> GetDynamic<T>(
         this IEnumerable<T> results,
         int lookbackPeriods,
         double kFactor = 0.6)

--- a/src/e-k/ElderRay/ElderRay.Api.cs
+++ b/src/e-k/ElderRay/ElderRay.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<ElderRayResult> GetElderRay<TQuote>(
+    public static IReadOnlyList<ElderRayResult> GetElderRay<TQuote>(
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods = 13)
         where TQuote : IQuote => quotes

--- a/src/e-k/ElderRay/ElderRay.Series.cs
+++ b/src/e-k/ElderRay/ElderRay.Series.cs
@@ -5,24 +5,24 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     private static List<ElderRayResult> CalcElderRay(
-        this List<QuoteD> qdList,
+        this List<QuoteD> source,
         int lookbackPeriods)
     {
         // check parameter arguments
         ElderRay.Validate(lookbackPeriods);
 
         // initialize
-        int length = qdList.Count;
+        int length = source.Count;
         List<ElderRayResult> results = new(length);
 
         // EMA
         List<EmaResult> emaResults
-            = qdList.CalcEma(lookbackPeriods);
+            = source.CalcEma(lookbackPeriods);
 
         // roll through source values
         for (int i = 0; i < length; i++)
         {
-            QuoteD q = qdList[i];
+            QuoteD q = source[i];
             EmaResult e = emaResults[i];
 
             results.Add(new(

--- a/src/e-k/ElderRay/ElderRay.Utilities.cs
+++ b/src/e-k/ElderRay/ElderRay.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<ElderRayResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<ElderRayResult> RemoveWarmupPeriods(
         this IEnumerable<ElderRayResult> results)
     {
         int n = results

--- a/src/e-k/Ema/Ema.Api.cs
+++ b/src/e-k/Ema/Ema.Api.cs
@@ -5,7 +5,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Ema
 {
     // SERIES, from CHAIN
-    public static IEnumerable<EmaResult> GetEma<T>(
+    public static IReadOnlyList<EmaResult> GetEma<T>(
         this IEnumerable<T> results,
         int lookbackPeriods)
         where T : IReusable

--- a/src/e-k/Ema/Ema.Utilities.cs
+++ b/src/e-k/Ema/Ema.Utilities.cs
@@ -20,7 +20,7 @@ public static partial class Ema
     }
 
     // remove recommended periods
-    public static IEnumerable<EmaResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<EmaResult> RemoveWarmupPeriods(
         this IEnumerable<EmaResult> results)
     {
         int n = results

--- a/src/e-k/Epma/Epma.Api.cs
+++ b/src/e-k/Epma/Epma.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<EpmaResult> GetEpma<T>(
+    public static IReadOnlyList<EpmaResult> GetEpma<T>(
         this IEnumerable<T> results,
         int lookbackPeriods)
         where T : IReusable

--- a/src/e-k/Epma/Epma.Series.cs
+++ b/src/e-k/Epma/Epma.Series.cs
@@ -14,12 +14,11 @@ public static partial class Indicator
         Epma.Validate(lookbackPeriods);
 
         // initialize
-        List<SlopeResult> slope = source
-            .CalcSlope(lookbackPeriods)
-            .ToList();
-
-        int length = slope.Count;
+        int length = source.Count;
         List<EpmaResult> results = new(length);
+
+        IReadOnlyList<SlopeResult> slope
+            = source.CalcSlope(lookbackPeriods);
 
         // roll through source values
         for (int i = 0; i < length; i++)

--- a/src/e-k/Epma/Epma.Utilities.cs
+++ b/src/e-k/Epma/Epma.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<EpmaResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<EpmaResult> RemoveWarmupPeriods(
         this IEnumerable<EpmaResult> results)
     {
         int removePeriods = results

--- a/src/e-k/Fcb/Fcb.Api.cs
+++ b/src/e-k/Fcb/Fcb.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<FcbResult> GetFcb<TQuote>(
+    public static IReadOnlyList<FcbResult> GetFcb<TQuote>(
         this IEnumerable<TQuote> quotes,
         int windowSpan = 2)
         where TQuote : IQuote => quotes

--- a/src/e-k/Fcb/Fcb.Utilities.cs
+++ b/src/e-k/Fcb/Fcb.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // CONDENSE (REMOVE null results)
     /// <inheritdoc cref="ReusableUtility.Condense{T}(IEnumerable{T})"/>
-    public static IEnumerable<FcbResult> Condense(
+    public static IReadOnlyList<FcbResult> Condense(
         this IEnumerable<FcbResult> results)
     {
         List<FcbResult> resultsList = results
@@ -19,7 +19,7 @@ public static partial class Indicator
 
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<FcbResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<FcbResult> RemoveWarmupPeriods(
         this IEnumerable<FcbResult> results)
     {
         int removePeriods = results

--- a/src/e-k/FisherTransform/FisherTransform.Api.cs
+++ b/src/e-k/FisherTransform/FisherTransform.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<FisherTransformResult> GetFisherTransform<T>(
+    public static IReadOnlyList<FisherTransformResult> GetFisherTransform<T>(
         this IEnumerable<T> results,
         int lookbackPeriods = 10)
         where T : IReusable

--- a/src/e-k/ForceIndex/ForceIndex.Api.cs
+++ b/src/e-k/ForceIndex/ForceIndex.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<ForceIndexResult> GetForceIndex<TQuote>(
+    public static IReadOnlyList<ForceIndexResult> GetForceIndex<TQuote>(
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods = 2)
         where TQuote : IQuote => quotes

--- a/src/e-k/ForceIndex/ForceIndex.Series.cs
+++ b/src/e-k/ForceIndex/ForceIndex.Series.cs
@@ -5,14 +5,14 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     private static List<ForceIndexResult> CalcForceIndex(
-        this List<QuoteD> qdList,
+        this List<QuoteD> source,
         int lookbackPeriods)
     {
         // check parameter arguments
         ForceIndex.Validate(lookbackPeriods);
 
         // initialize
-        int length = qdList.Count;
+        int length = source.Count;
         List<ForceIndexResult> results = new(length);
         double? prevFi = null;
         double? sumRawFi = 0;
@@ -21,17 +21,17 @@ public static partial class Indicator
         // skip first period
         if (length > 0)
         {
-            results.Add(new(qdList[0].Timestamp));
+            results.Add(new(source[0].Timestamp));
         }
 
         // roll through source values
         for (int i = 1; i < length; i++)
         {
-            QuoteD q = qdList[i];
+            QuoteD q = source[i];
             double? fi = null;
 
             // raw Force Index
-            double? rawFi = q.Volume * (q.Close - qdList[i - 1].Close);
+            double? rawFi = q.Volume * (q.Close - source[i - 1].Close);
 
             // calculate EMA
             if (i > lookbackPeriods)

--- a/src/e-k/ForceIndex/ForceIndex.Utilities.cs
+++ b/src/e-k/ForceIndex/ForceIndex.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<ForceIndexResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<ForceIndexResult> RemoveWarmupPeriods(
         this IEnumerable<ForceIndexResult> results)
     {
         int n = results

--- a/src/e-k/Fractal/Fractal.Api.cs
+++ b/src/e-k/Fractal/Fractal.Api.cs
@@ -5,7 +5,7 @@ public static partial class Indicator
 {
     /// <include file='./info.xml' path='info/type[@name="standard"]/*' />
     ///
-    public static IEnumerable<FractalResult> GetFractal<TQuote>(
+    public static IReadOnlyList<FractalResult> GetFractal<TQuote>(
         this IEnumerable<TQuote> quotes,
         int windowSpan = 2,
         EndType endType = EndType.HighLow)
@@ -16,7 +16,7 @@ public static partial class Indicator
     // more configurable version (undocumented)
     /// <include file='./info.xml' path='info/type[@name="alt"]/*' />
     ///
-    public static IEnumerable<FractalResult> GetFractal<TQuote>(
+    public static IReadOnlyList<FractalResult> GetFractal<TQuote>(
         this IEnumerable<TQuote> quotes,
         int leftSpan,
         int rightSpan,

--- a/src/e-k/Fractal/Fractal.Utilities.cs
+++ b/src/e-k/Fractal/Fractal.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // CONDENSE (REMOVE null results)
     /// <inheritdoc cref="ReusableUtility.Condense{T}(IEnumerable{T})"/>
-    public static IEnumerable<FractalResult> Condense(
+    public static IReadOnlyList<FractalResult> Condense(
         this IEnumerable<FractalResult> results)
     {
         List<FractalResult> resultsList = results

--- a/src/e-k/Gator/Gator.Api.cs
+++ b/src/e-k/Gator/Gator.Api.cs
@@ -21,7 +21,7 @@ public static partial class Indicator
     /// <returns>Time series of Gator values.</returns>
 
     // See Alligator API for explanation of unusual setup.
-    public static IEnumerable<GatorResult> GetGator<T>(
+    public static IReadOnlyList<GatorResult> GetGator<T>(
         this IEnumerable<T> source)
         where T : IReusable
         => source
@@ -29,7 +29,7 @@ public static partial class Indicator
             .GetGator();
 
     // SERIES, from [custom] Alligator
-    public static IEnumerable<GatorResult> GetGator(
+    public static IReadOnlyList<GatorResult> GetGator(
         this IEnumerable<AlligatorResult> alligator)
         => alligator
             .ToList()

--- a/src/e-k/Gator/Gator.Utilities.cs
+++ b/src/e-k/Gator/Gator.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // CONDENSE (REMOVE null results)
     /// <inheritdoc cref="ReusableUtility.Condense{T}(IEnumerable{T})"/>
-    public static IEnumerable<GatorResult> Condense(
+    public static IReadOnlyList<GatorResult> Condense(
         this IEnumerable<GatorResult> results)
     {
         List<GatorResult> resultsList = results
@@ -19,6 +19,6 @@ public static partial class Indicator
 
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<GatorResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<GatorResult> RemoveWarmupPeriods(
         this IEnumerable<GatorResult> results) => results.Remove(150);
 }

--- a/src/e-k/HeikinAshi/HeikinAshi.Api.cs
+++ b/src/e-k/HeikinAshi/HeikinAshi.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<HeikinAshiResult> GetHeikinAshi<TQuote>(
+    public static IReadOnlyList<HeikinAshiResult> GetHeikinAshi<TQuote>(
         this IEnumerable<TQuote> quotes)
         where TQuote : IQuote => quotes
             .ToSortedList()

--- a/src/e-k/HeikinAshi/HeikinAshi.Utilities.cs
+++ b/src/e-k/HeikinAshi/HeikinAshi.Utilities.cs
@@ -1,9 +1,0 @@
-namespace Skender.Stock.Indicators;
-
-public static partial class Indicator
-{
-    // convert results to quotes
-    public static IEnumerable<Quote> ToQuotes(
-    this IEnumerable<HeikinAshiResult> results)
-        => results.Cast<Quote>();
-}

--- a/src/e-k/Hma/Hma.Api.cs
+++ b/src/e-k/Hma/Hma.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<HmaResult> GetHma<T>(
+    public static IReadOnlyList<HmaResult> GetHma<T>(
         this IEnumerable<T> results,
         int lookbackPeriods)
         where T : IReusable

--- a/src/e-k/Hma/Hma.Series.cs
+++ b/src/e-k/Hma/Hma.Series.cs
@@ -14,14 +14,18 @@ public static partial class Indicator
         Hma.Validate(lookbackPeriods);
 
         // initialize
+        int length = source.Count;
         int shiftQty = lookbackPeriods - 1;
         List<IReusable> synthHistory = [];
 
-        List<WmaResult> wmaN1 = source.GetWma(lookbackPeriods).ToList();
-        List<WmaResult> wmaN2 = source.GetWma(lookbackPeriods / 2).ToList();
+        IReadOnlyList<WmaResult> wmaN1
+            = source.CalcWma(lookbackPeriods);
+
+        IReadOnlyList<WmaResult> wmaN2
+            = source.CalcWma(lookbackPeriods / 2);
 
         // roll through source values, to get interim synthetic quotes
-        for (int i = 0; i < source.Count; i++)
+        for (int i = 0; i < length; i++)
         {
             T s = source[i];
 

--- a/src/e-k/Hma/Hma.Utilities.cs
+++ b/src/e-k/Hma/Hma.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<HmaResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<HmaResult> RemoveWarmupPeriods(
         this IEnumerable<HmaResult> results)
     {
         int removePeriods = results

--- a/src/e-k/HtTrendline/HtTrendline.Api.cs
+++ b/src/e-k/HtTrendline/HtTrendline.Api.cs
@@ -17,7 +17,7 @@ public static partial class Indicator
     /// </typeparam>
     /// <param name="source">Time-series values to transform.</param>
     /// <returns>Time series of HTL values and smoothed price.</returns>
-    public static IEnumerable<HtlResult> GetHtTrendline<T>(
+    public static IReadOnlyList<HtlResult> GetHtTrendline<T>(
         this IEnumerable<T> source)
         where T : IReusable
         => source

--- a/src/e-k/HtTrendline/HtTrendline.Utilities.cs
+++ b/src/e-k/HtTrendline/HtTrendline.Utilities.cs
@@ -4,6 +4,6 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<HtlResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<HtlResult> RemoveWarmupPeriods(
         this IEnumerable<HtlResult> results) => results.Remove(100);
 }

--- a/src/e-k/Hurst/Hurst.Api.cs
+++ b/src/e-k/Hurst/Hurst.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<HurstResult> GetHurst<T>(
+    public static IReadOnlyList<HurstResult> GetHurst<T>(
         this IEnumerable<T> results,
         int lookbackPeriods = 100)
         where T : IReusable

--- a/src/e-k/Hurst/Hurst.Utilities.cs
+++ b/src/e-k/Hurst/Hurst.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<HurstResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<HurstResult> RemoveWarmupPeriods(
         this IEnumerable<HurstResult> results)
     {
         int removePeriods = results

--- a/src/e-k/Ichimoku/Ichimoku.Api.cs
+++ b/src/e-k/Ichimoku/Ichimoku.Api.cs
@@ -5,7 +5,7 @@ public static partial class Indicator
 {
     /// <include file='./info.xml' path='info/type[@name="Standard"]/*' />
     ///
-    public static IEnumerable<IchimokuResult> GetIchimoku<TQuote>(
+    public static IReadOnlyList<IchimokuResult> GetIchimoku<TQuote>(
         this IEnumerable<TQuote> quotes,
         int tenkanPeriods = 9,
         int kijunPeriods = 26,
@@ -21,7 +21,7 @@ public static partial class Indicator
 
     /// <include file='./info.xml' path='info/type[@name="Extended"]/*' />
     ///
-    public static IEnumerable<IchimokuResult> GetIchimoku<TQuote>(
+    public static IReadOnlyList<IchimokuResult> GetIchimoku<TQuote>(
         this IEnumerable<TQuote> quotes,
         int tenkanPeriods,
         int kijunPeriods,
@@ -38,7 +38,7 @@ public static partial class Indicator
 
     /// <include file='./info.xml' path='info/type[@name="Full"]/*' />
     ///
-    public static IEnumerable<IchimokuResult> GetIchimoku<TQuote>(
+    public static IReadOnlyList<IchimokuResult> GetIchimoku<TQuote>(
         this IEnumerable<TQuote> quotes,
         int tenkanPeriods,
         int kijunPeriods,

--- a/src/e-k/Ichimoku/Ichimoku.Utilities.cs
+++ b/src/e-k/Ichimoku/Ichimoku.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // CONDENSE (REMOVE null results)
     /// <inheritdoc cref="ReusableUtility.Condense{T}(IEnumerable{T})"/>
-    public static IEnumerable<IchimokuResult> Condense(
+    public static IReadOnlyList<IchimokuResult> Condense(
         this IEnumerable<IchimokuResult> results)
     {
         List<IchimokuResult> resultsList = results

--- a/src/e-k/Kama/Kama.Api.cs
+++ b/src/e-k/Kama/Kama.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<KamaResult> GetKama<T>(
+    public static IReadOnlyList<KamaResult> GetKama<T>(
         this IEnumerable<T> source,
         int erPeriods = 10,
         int fastPeriods = 2,

--- a/src/e-k/Kama/Kama.Utilities.cs
+++ b/src/e-k/Kama/Kama.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<KamaResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<KamaResult> RemoveWarmupPeriods(
         this IEnumerable<KamaResult> results)
     {
         int erPeriods = results

--- a/src/e-k/Keltner/Keltner.Api.cs
+++ b/src/e-k/Keltner/Keltner.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<KeltnerResult> GetKeltner<TQuote>(
+    public static IReadOnlyList<KeltnerResult> GetKeltner<TQuote>(
         this IEnumerable<TQuote> quotes,
         int emaPeriods = 20,
         double multiplier = 2,

--- a/src/e-k/Keltner/Keltner.Series.cs
+++ b/src/e-k/Keltner/Keltner.Series.cs
@@ -5,7 +5,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     private static List<KeltnerResult> CalcKeltner(
-        this List<QuoteD> qdList,
+        this List<QuoteD> source,
         int emaPeriods,
         double multiplier,
         int atrPeriods)
@@ -14,23 +14,21 @@ public static partial class Indicator
         Keltner.Validate(emaPeriods, multiplier, atrPeriods);
 
         // initialize
-        int length = qdList.Count;
+        int length = source.Count;
         List<KeltnerResult> results = new(length);
 
-        List<EmaResult> emaResults = qdList
-            .CalcEma(emaPeriods)
-            .ToList();
+        IReadOnlyList<EmaResult> emaResults
+            = source.CalcEma(emaPeriods);
 
-        List<AtrResult> atrResults = qdList
-            .CalcAtr(atrPeriods)
-            .ToList();
+        IReadOnlyList<AtrResult> atrResults
+            = source.CalcAtr(atrPeriods);
 
         int lookbackPeriods = Math.Max(emaPeriods, atrPeriods);
 
         // roll through source values
         for (int i = 0; i < length; i++)
         {
-            QuoteD q = qdList[i];
+            QuoteD q = source[i];
 
             if (i >= lookbackPeriods - 1)
             {

--- a/src/e-k/Keltner/Keltner.Utilities.cs
+++ b/src/e-k/Keltner/Keltner.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // CONDENSE (REMOVE null results)
     /// <inheritdoc cref="ReusableUtility.Condense{T}(IEnumerable{T})"/>
-    public static IEnumerable<KeltnerResult> Condense(
+    public static IReadOnlyList<KeltnerResult> Condense(
         this IEnumerable<KeltnerResult> results)
     {
         List<KeltnerResult> resultsList = results
@@ -19,7 +19,7 @@ public static partial class Indicator
 
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<KeltnerResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<KeltnerResult> RemoveWarmupPeriods(
         this IEnumerable<KeltnerResult> results)
     {
         int n = results

--- a/src/e-k/Kvo/Kvo.Api.cs
+++ b/src/e-k/Kvo/Kvo.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<KvoResult> GetKvo<TQuote>(
+    public static IReadOnlyList<KvoResult> GetKvo<TQuote>(
         this IEnumerable<TQuote> quotes,
         int fastPeriods = 34,
         int slowPeriods = 55,

--- a/src/e-k/Kvo/Kvo.Series.cs
+++ b/src/e-k/Kvo/Kvo.Series.cs
@@ -5,7 +5,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     private static List<KvoResult> CalcKvo(
-        this List<QuoteD> qdList,
+        this List<QuoteD> source,
         int fastPeriods,
         int slowPeriods,
         int signalPeriods)
@@ -14,7 +14,7 @@ public static partial class Indicator
         Kvo.Validate(fastPeriods, slowPeriods, signalPeriods);
 
         // initialize
-        int length = qdList.Count;
+        int length = source.Count;
         List<KvoResult> results = new(length);
 
         double[] t = new double[length];          // trend direction
@@ -33,7 +33,7 @@ public static partial class Indicator
         // roll through source values
         for (int i = 0; i < length; i++)
         {
-            QuoteD q = qdList[i];
+            QuoteD q = source[i];
 
             double? kvo = null;
             double? sig = null;

--- a/src/e-k/Kvo/Kvo.Utilities.cs
+++ b/src/e-k/Kvo/Kvo.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<KvoResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<KvoResult> RemoveWarmupPeriods(
         this IEnumerable<KvoResult> results)
     {
         int l = results

--- a/src/m-r/MaEnvelopes/MaEnvelopes.Api.cs
+++ b/src/m-r/MaEnvelopes/MaEnvelopes.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<MaEnvelopeResult> GetMaEnvelopes<T>(
+    public static IReadOnlyList<MaEnvelopeResult> GetMaEnvelopes<T>(
         this IEnumerable<T> results,
         int lookbackPeriods,
         double percentOffset = 2.5,

--- a/src/m-r/MaEnvelopes/MaEnvelopes.Series.cs
+++ b/src/m-r/MaEnvelopes/MaEnvelopes.Series.cs
@@ -5,7 +5,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // calculate series
-    private static IEnumerable<MaEnvelopeResult> CalcMaEnvelopes<T>(
+    private static List<MaEnvelopeResult> CalcMaEnvelopes<T>(
         this List<T> source,
         int lookbackPeriods,
         double percentOffset,
@@ -20,7 +20,8 @@ public static partial class Indicator
         double offsetRatio = percentOffset / 100d;
 
         // get envelopes variant
-        return movingAverageType switch {
+        IEnumerable<MaEnvelopeResult> results = movingAverageType
+        switch {
             MaType.ALMA => source.MaEnvAlma(lookbackPeriods, offsetRatio),
             MaType.DEMA => source.MaEnvDema(lookbackPeriods, offsetRatio),
             MaType.EMA => source.MaEnvEma(lookbackPeriods, offsetRatio),
@@ -32,12 +33,14 @@ public static partial class Indicator
             MaType.WMA => source.MaEnvWma(lookbackPeriods, offsetRatio),
 
             _ => throw new ArgumentOutOfRangeException(
-                     nameof(movingAverageType), movingAverageType,
-                     string.Format(
-                         EnglishCulture,
-                         "Moving Average Envelopes does not support {0}.",
-                         Enum.GetName(typeof(MaType), movingAverageType)))
+                    nameof(movingAverageType), movingAverageType,
+                    string.Format(
+                        EnglishCulture,
+                        "Moving Average Envelopes does not support {0}.",
+                        Enum.GetName(typeof(MaType), movingAverageType)))
         };
+
+        return results.ToList();
     }
 
     private static IEnumerable<MaEnvelopeResult> MaEnvAlma<T>(
@@ -45,7 +48,7 @@ public static partial class Indicator
         int lookbackPeriods,
         double offsetRatio)
         where T : IReusable
-        => source.GetAlma(lookbackPeriods)
+        => source.CalcAlma(lookbackPeriods, offset: 0.85, sigma: 6)
         .Select(x => new MaEnvelopeResult(
             Timestamp: x.Timestamp,
             Centerline: x.Alma,
@@ -57,7 +60,7 @@ public static partial class Indicator
         int lookbackPeriods,
         double offsetRatio)
         where T : IReusable
-        => source.GetDema(lookbackPeriods)
+        => source.CalcDema(lookbackPeriods)
         .Select(x => new MaEnvelopeResult(
             Timestamp: x.Timestamp,
             Centerline: x.Dema,
@@ -69,8 +72,7 @@ public static partial class Indicator
         int lookbackPeriods,
         double offsetRatio)
         where T : IReusable
-        => source
-        .GetEma(lookbackPeriods)
+        => source.CalcEma(lookbackPeriods)
         .Select(x => new MaEnvelopeResult(
             Timestamp: x.Timestamp,
             Centerline: x.Ema,
@@ -82,7 +84,7 @@ public static partial class Indicator
         int lookbackPeriods,
         double offsetRatio)
         where T : IReusable
-        => source.GetEpma(lookbackPeriods)
+        => source.CalcEpma(lookbackPeriods)
         .Select(x => new MaEnvelopeResult(
             Timestamp: x.Timestamp,
             Centerline: x.Epma,
@@ -94,7 +96,7 @@ public static partial class Indicator
         int lookbackPeriods,
         double offsetRatio)
         where T : IReusable
-        => source.GetHma(lookbackPeriods)
+        => source.CalcHma(lookbackPeriods)
         .Select(x => new MaEnvelopeResult(
             Timestamp: x.Timestamp,
             Centerline: x.Hma,
@@ -106,7 +108,7 @@ public static partial class Indicator
         int lookbackPeriods,
         double offsetRatio)
         where T : IReusable
-        => source.GetSma(lookbackPeriods)
+        => source.CalcSma(lookbackPeriods)
         .Select(x => new MaEnvelopeResult(
             Timestamp: x.Timestamp,
             Centerline: x.Sma,
@@ -118,7 +120,7 @@ public static partial class Indicator
         int lookbackPeriods,
         double offsetRatio)
         where T : IReusable
-        => source.GetSmma(lookbackPeriods)
+        => source.CalcSmma(lookbackPeriods)
         .Select(x => new MaEnvelopeResult(
             Timestamp: x.Timestamp,
             Centerline: x.Smma,
@@ -126,11 +128,11 @@ public static partial class Indicator
             LowerEnvelope: x.Smma - (x.Smma * offsetRatio)));
 
     private static IEnumerable<MaEnvelopeResult> MaEnvTema<T>(
-        this List<T> tpList,
+        this List<T> source,
         int lookbackPeriods,
         double offsetRatio)
         where T : IReusable
-        => tpList.GetTema(lookbackPeriods)
+        => source.CalcTema(lookbackPeriods)
         .Select(x => new MaEnvelopeResult(
             Timestamp: x.Timestamp,
             Centerline: x.Tema,
@@ -138,11 +140,11 @@ public static partial class Indicator
             LowerEnvelope: x.Tema - (x.Tema * offsetRatio)));
 
     private static IEnumerable<MaEnvelopeResult> MaEnvWma<T>(
-        this List<T> tpList,
+        this List<T> source,
         int lookbackPeriods,
         double offsetRatio)
         where T : IReusable
-        => tpList.GetWma(lookbackPeriods)
+        => source.CalcWma(lookbackPeriods)
         .Select(x => new MaEnvelopeResult(
             Timestamp: x.Timestamp,
             Centerline: x.Wma,

--- a/src/m-r/MaEnvelopes/MaEnvelopes.Utilities.cs
+++ b/src/m-r/MaEnvelopes/MaEnvelopes.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // CONDENSE (REMOVE null results)
     /// <inheritdoc cref="ReusableUtility.Condense{T}(IEnumerable{T})"/>
-    public static IEnumerable<MaEnvelopeResult> Condense(
+    public static IReadOnlyList<MaEnvelopeResult> Condense(
         this IEnumerable<MaEnvelopeResult> results)
     {
         List<MaEnvelopeResult> resultsList = results

--- a/src/m-r/Macd/Macd.Utilities.cs
+++ b/src/m-r/Macd/Macd.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<MacdResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<MacdResult> RemoveWarmupPeriods(
         this IEnumerable<MacdResult> results)
     {
         int n = results

--- a/src/m-r/Macd/MacdApi.cs
+++ b/src/m-r/Macd/MacdApi.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<MacdResult> GetMacd<T>(
+    public static IReadOnlyList<MacdResult> GetMacd<T>(
         this IEnumerable<T> results,
         int fastPeriods = 12,
         int slowPeriods = 26,

--- a/src/m-r/Mama/Mama.Api.cs
+++ b/src/m-r/Mama/Mama.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<MamaResult> GetMama<T>(
+    public static IReadOnlyList<MamaResult> GetMama<T>(
         this IEnumerable<T> results,
         double fastLimit = 0.5,
         double slowLimit = 0.05)

--- a/src/m-r/Mama/Mama.Utilities.cs
+++ b/src/m-r/Mama/Mama.Utilities.cs
@@ -4,6 +4,6 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<MamaResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<MamaResult> RemoveWarmupPeriods(
         this IEnumerable<MamaResult> results) => results.Remove(50);
 }

--- a/src/m-r/Marubozu/Marubozu.Api.cs
+++ b/src/m-r/Marubozu/Marubozu.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<CandleResult> GetMarubozu<TQuote>(
+    public static IReadOnlyList<CandleResult> GetMarubozu<TQuote>(
         this IEnumerable<TQuote> quotes,
         double minBodyPercent = 95)
         where TQuote : IQuote => quotes

--- a/src/m-r/Mfi/Mfi.Api.cs
+++ b/src/m-r/Mfi/Mfi.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<MfiResult> GetMfi<TQuote>(
+    public static IReadOnlyList<MfiResult> GetMfi<TQuote>(
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods = 14)
         where TQuote : IQuote => quotes

--- a/src/m-r/Mfi/Mfi.Series.cs
+++ b/src/m-r/Mfi/Mfi.Series.cs
@@ -5,14 +5,14 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     private static List<MfiResult> CalcMfi(
-        this List<QuoteD> qdList,
+        this List<QuoteD> source,
         int lookbackPeriods)
     {
         // check parameter arguments
         Mfi.Validate(lookbackPeriods);
 
         // initialize
-        int length = qdList.Count;
+        int length = source.Count;
         List<MfiResult> results = new(length);
 
         double[] tp = new double[length];  // true price
@@ -24,7 +24,7 @@ public static partial class Indicator
         // roll through source values, to get preliminary data
         for (int i = 0; i < length; i++)
         {
-            QuoteD q = qdList[i];
+            QuoteD q = source[i];
             double mfi;
 
             // true price

--- a/src/m-r/Mfi/Mfi.Utilities.cs
+++ b/src/m-r/Mfi/Mfi.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<MfiResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<MfiResult> RemoveWarmupPeriods(
         this IEnumerable<MfiResult> results)
     {
         int removePeriods = results

--- a/src/m-r/Obv/Obv.Api.cs
+++ b/src/m-r/Obv/Obv.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<ObvResult> GetObv<TQuote>(
+    public static IReadOnlyList<ObvResult> GetObv<TQuote>(
         this IEnumerable<TQuote> quotes)
         where TQuote : IQuote => quotes
             .ToQuoteDList()

--- a/src/m-r/Obv/Obv.Series.cs
+++ b/src/m-r/Obv/Obv.Series.cs
@@ -5,18 +5,19 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     private static List<ObvResult> CalcObv(
-        this List<QuoteD> qdList)
+        this List<QuoteD> source)
     {
         // initialize
-        List<ObvResult> results = new(qdList.Count);
+        int length = source.Count;
+        List<ObvResult> results = new(length);
 
         double prevClose = double.NaN;
         double obv = 0;
 
         // roll through source values
-        for (int i = 0; i < qdList.Count; i++)
+        for (int i = 0; i < length; i++)
         {
-            QuoteD q = qdList[i];
+            QuoteD q = source[i];
 
             if (double.IsNaN(prevClose) || q.Close == prevClose)
             {

--- a/src/m-r/ParabolicSar/ParabolicSar.Api.cs
+++ b/src/m-r/ParabolicSar/ParabolicSar.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/type[@name="Standard"]/*' />
     ///
-    public static IEnumerable<ParabolicSarResult> GetParabolicSar<TQuote>(
+    public static IReadOnlyList<ParabolicSarResult> GetParabolicSar<TQuote>(
         this IEnumerable<TQuote> quotes,
         double accelerationStep = 0.02,
         double maxAccelerationFactor = 0.2)
@@ -20,7 +20,7 @@ public static partial class Indicator
     // SERIES, from TQuote (alt)
     /// <include file='./info.xml' path='info/type[@name="Extended"]/*' />
     ///
-    public static IEnumerable<ParabolicSarResult> GetParabolicSar<TQuote>(
+    public static IReadOnlyList<ParabolicSarResult> GetParabolicSar<TQuote>(
         this IEnumerable<TQuote> quotes,
         double accelerationStep,
         double maxAccelerationFactor,

--- a/src/m-r/ParabolicSar/ParabolicSar.Series.cs
+++ b/src/m-r/ParabolicSar/ParabolicSar.Series.cs
@@ -5,7 +5,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     private static List<ParabolicSarResult> CalcParabolicSar(
-        this List<QuoteD> qdList,
+        this List<QuoteD> source,
         double accelerationStep,
         double maxAccelerationFactor,
         double initialFactor)
@@ -15,7 +15,7 @@ public static partial class Indicator
             accelerationStep, maxAccelerationFactor, initialFactor);
 
         // initialize
-        int length = qdList.Count;
+        int length = source.Count;
         List<ParabolicSarResult> results = new(length);
 
         if (length == 0)
@@ -23,7 +23,7 @@ public static partial class Indicator
             return results;
         }
 
-        QuoteD q0 = qdList[0];
+        QuoteD q0 = source[0];
 
         double accelerationFactor = initialFactor;
         double extremePoint = q0.High;
@@ -33,7 +33,7 @@ public static partial class Indicator
         // roll through source values
         for (int i = 0; i < length; i++)
         {
-            QuoteD q = qdList[i];
+            QuoteD q = source[i];
 
             bool? isReversal;
             double psar;
@@ -56,8 +56,8 @@ public static partial class Indicator
                 {
                     double minLastTwo =
                         Math.Min(
-                            qdList[i - 1].Low,
-                            qdList[i - 2].Low);
+                            source[i - 1].Low,
+                            source[i - 2].Low);
 
                     sar = Math.Min(sar, minLastTwo);
                 }
@@ -101,8 +101,8 @@ public static partial class Indicator
                 if (i >= 2)
                 {
                     double maxLastTwo = Math.Max(
-                        qdList[i - 1].High,
-                        qdList[i - 2].High);
+                        source[i - 1].High,
+                        source[i - 2].High);
 
                     sar = Math.Max(sar, maxLastTwo);
                 }

--- a/src/m-r/ParabolicSar/ParabolicSar.Utilities.cs
+++ b/src/m-r/ParabolicSar/ParabolicSar.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<ParabolicSarResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<ParabolicSarResult> RemoveWarmupPeriods(
         this IEnumerable<ParabolicSarResult> results)
     {
         int removePeriods = results

--- a/src/m-r/PivotPoints/PivotPoints.Api.cs
+++ b/src/m-r/PivotPoints/PivotPoints.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<PivotPointsResult> GetPivotPoints<TQuote>(
+    public static IReadOnlyList<PivotPointsResult> GetPivotPoints<TQuote>(
         this IEnumerable<TQuote> quotes,
         PeriodSize windowSize,
         PivotPointType pointType = PivotPointType.Standard)

--- a/src/m-r/PivotPoints/PivotPoints.Utilities.cs
+++ b/src/m-r/PivotPoints/PivotPoints.Utilities.cs
@@ -5,7 +5,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<PivotPointsResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<PivotPointsResult> RemoveWarmupPeriods(
         this IEnumerable<PivotPointsResult> results)
     {
         int removePeriods = results

--- a/src/m-r/Pivots/Pivots.Api.cs
+++ b/src/m-r/Pivots/Pivots.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<PivotsResult> GetPivots<TQuote>(
+    public static IReadOnlyList<PivotsResult> GetPivots<TQuote>(
         this IEnumerable<TQuote> quotes,
         int leftSpan = 2,
         int rightSpan = 2,

--- a/src/m-r/Pivots/Pivots.Utilities.cs
+++ b/src/m-r/Pivots/Pivots.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // CONDENSE (REMOVE null results)
     /// <inheritdoc cref="ReusableUtility.Condense{T}(IEnumerable{T})"/>
-    public static IEnumerable<PivotsResult> Condense(
+    public static IReadOnlyList<PivotsResult> Condense(
         this IEnumerable<PivotsResult> results)
     {
         List<PivotsResult> resultsList = results

--- a/src/m-r/Pmo/Pmo.Api.cs
+++ b/src/m-r/Pmo/Pmo.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<PmoResult> GetPmo<T>(
+    public static IReadOnlyList<PmoResult> GetPmo<T>(
         this IEnumerable<T> results,
         int timePeriods = 35,
         int smoothPeriods = 20,

--- a/src/m-r/Pmo/Pmo.Utilities.cs
+++ b/src/m-r/Pmo/Pmo.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<PmoResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<PmoResult> RemoveWarmupPeriods(
         this IEnumerable<PmoResult> results)
     {
         int ts = results

--- a/src/m-r/Prs/Prs.Api.cs
+++ b/src/m-r/Prs/Prs.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAINS (both inputs reusable)
-    public static IEnumerable<PrsResult> GetPrs<T>(
+    public static IReadOnlyList<PrsResult> GetPrs<T>(
         this IEnumerable<T> quotesEval,
         IEnumerable<T> quotesBase,
         int? lookbackPeriods = null)

--- a/src/m-r/Pvo/Pvo.Api.cs
+++ b/src/m-r/Pvo/Pvo.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<PvoResult> GetPvo<TQuote>(
+    public static IReadOnlyList<PvoResult> GetPvo<TQuote>(
         this IEnumerable<TQuote> quotes,
         int fastPeriods = 12,
         int slowPeriods = 26,

--- a/src/m-r/Pvo/Pvo.Utilities.cs
+++ b/src/m-r/Pvo/Pvo.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<PvoResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<PvoResult> RemoveWarmupPeriods(
         this IEnumerable<PvoResult> results)
     {
         int n = results

--- a/src/m-r/Renko/Renko.Api.cs
+++ b/src/m-r/Renko/Renko.Api.cs
@@ -5,7 +5,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Renko
 {
     // SERIES, from TQuote
-    public static IEnumerable<RenkoResult> GetRenko<TQuote>(
+    public static IReadOnlyList<RenkoResult> GetRenko<TQuote>(
         this IEnumerable<TQuote> quotes,
         decimal brickSize,
         EndType endType = EndType.Close)

--- a/src/m-r/Renko/Renko.Utilities.cs
+++ b/src/m-r/Renko/Renko.Utilities.cs
@@ -4,11 +4,6 @@ namespace Skender.Stock.Indicators;
 
 public static partial class Renko
 {
-    // convert results to quotes
-    public static IEnumerable<Quote> ToQuotes(
-    this IEnumerable<RenkoResult> results)
-        => results.Cast<Quote>();
-
     // calculate brick size
     internal static int GetNewBrickQuantity<TQuote>(
         TQuote q,

--- a/src/m-r/RenkoAtr/RenkoAtr.Api.cs
+++ b/src/m-r/RenkoAtr/RenkoAtr.Api.cs
@@ -3,7 +3,7 @@ namespace Skender.Stock.Indicators;
 // RENKO CHART - ATR (API)
 public static partial class RenkoAtr
 {
-    public static IEnumerable<RenkoResult> GetRenkoAtr<TQuote>(
+    public static IReadOnlyList<RenkoResult> GetRenkoAtr<TQuote>(
         this IEnumerable<TQuote> quotes,
         int atrPeriods,
         EndType endType = EndType.Close)

--- a/src/m-r/Roc/Roc.Api.cs
+++ b/src/m-r/Roc/Roc.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<RocResult> GetRoc<T>(
+    public static IReadOnlyList<RocResult> GetRoc<T>(
         this IEnumerable<T> results,
         int lookbackPeriods)
         where T : IReusable

--- a/src/m-r/Roc/Roc.Utilities.cs
+++ b/src/m-r/Roc/Roc.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<RocResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<RocResult> RemoveWarmupPeriods(
         this IEnumerable<RocResult> results)
     {
         int removePeriods = results

--- a/src/m-r/RocWb/RocWb.Api.cs
+++ b/src/m-r/RocWb/RocWb.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<RocWbResult> GetRocWb<T>(
+    public static IReadOnlyList<RocWbResult> GetRocWb<T>(
         this IEnumerable<T> results,
         int lookbackPeriods,
         int emaPeriods,

--- a/src/m-r/RocWb/RocWb.Utilities.cs
+++ b/src/m-r/RocWb/RocWb.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<RocWbResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<RocWbResult> RemoveWarmupPeriods(
         this IEnumerable<RocWbResult> results)
     {
         int n = results

--- a/src/m-r/RollingPivots/RollingPivots.Api.cs
+++ b/src/m-r/RollingPivots/RollingPivots.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<RollingPivotsResult> GetRollingPivots<TQuote>(
+    public static IReadOnlyList<RollingPivotsResult> GetRollingPivots<TQuote>(
         this IEnumerable<TQuote> quotes,
         int windowPeriods,
         int offsetPeriods,

--- a/src/m-r/RollingPivots/RollingPivots.Utilities.cs
+++ b/src/m-r/RollingPivots/RollingPivots.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<RollingPivotsResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<RollingPivotsResult> RemoveWarmupPeriods(
         this IEnumerable<RollingPivotsResult> results)
     {
         int removePeriods = results

--- a/src/m-r/Rsi/Rsi.Api.cs
+++ b/src/m-r/Rsi/Rsi.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<RsiResult> GetRsi<T>(
+    public static IReadOnlyList<RsiResult> GetRsi<T>(
         this IEnumerable<T> results,
         int lookbackPeriods = 14)
         where T : IReusable

--- a/src/m-r/Rsi/Rsi.Series.cs
+++ b/src/m-r/Rsi/Rsi.Series.cs
@@ -31,7 +31,7 @@ public static partial class Indicator
         // roll through source values
         for (int i = 0; i < length; i++)
         {
-            var s = source[i];
+            T s = source[i];
 
             if (double.IsNaN(s.Value) || double.IsNaN(prevValue))
             {

--- a/src/m-r/Rsi/Rsi.Utilities.cs
+++ b/src/m-r/Rsi/Rsi.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<RsiResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<RsiResult> RemoveWarmupPeriods(
         this IEnumerable<RsiResult> results)
     {
         int n = results

--- a/src/s-z/Slope/Slope.Api.cs
+++ b/src/s-z/Slope/Slope.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<SlopeResult> GetSlope<T>(
+    public static IReadOnlyList<SlopeResult> GetSlope<T>(
         this IEnumerable<T> results,
         int lookbackPeriods)
         where T : IReusable

--- a/src/s-z/Slope/Slope.Utilities.cs
+++ b/src/s-z/Slope/Slope.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<SlopeResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<SlopeResult> RemoveWarmupPeriods(
         this IEnumerable<SlopeResult> results)
     {
         int removePeriods = results

--- a/src/s-z/Sma/Sma.Api.cs
+++ b/src/s-z/Sma/Sma.Api.cs
@@ -5,7 +5,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Sma
 {
     // SERIES, from CHAIN
-    public static IEnumerable<SmaResult> GetSma<T>(
+    public static IReadOnlyList<SmaResult> GetSma<T>(
         this IEnumerable<T> source,
         int lookbackPeriods)
         where T : IReusable

--- a/src/s-z/Sma/Sma.Series.cs
+++ b/src/s-z/Sma/Sma.Series.cs
@@ -13,10 +13,11 @@ public static partial class Sma
         Sma.Validate(lookbackPeriods);
 
         // initialize
-        List<SmaResult> results = new(source.Count);
+        int length = source.Count;
+        List<SmaResult> results = new(length);
 
         // roll through source values
-        for (int i = 0; i < source.Count; i++)
+        for (int i = 0; i < length; i++)
         {
             T s = source[i];
 

--- a/src/s-z/SmaAnalysis/SmaAnalysis.Api.cs
+++ b/src/s-z/SmaAnalysis/SmaAnalysis.Api.cs
@@ -6,7 +6,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // ANALYSIS, from CHAIN
-    public static IEnumerable<SmaAnalysis> GetSmaAnalysis<T>(
+    public static IReadOnlyList<SmaAnalysis> GetSmaAnalysis<T>(
         this IEnumerable<T> source,
         int lookbackPeriods)
         where T : IReusable

--- a/src/s-z/Smi/Smi.Api.cs
+++ b/src/s-z/Smi/Smi.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/type[@name="Main"]/*' />
     ///
-    public static IEnumerable<SmiResult> GetSmi<TQuote>(
+    public static IReadOnlyList<SmiResult> GetSmi<TQuote>(
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods = 13,
         int firstSmoothPeriods = 25,

--- a/src/s-z/Smi/Smi.Series.cs
+++ b/src/s-z/Smi/Smi.Series.cs
@@ -5,7 +5,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     private static List<SmiResult> CalcSmi(
-        this List<QuoteD> qdList,
+        this List<QuoteD> source,
         int lookbackPeriods,
         int firstSmoothPeriods,
         int secondSmoothPeriods,
@@ -19,7 +19,7 @@ public static partial class Indicator
             signalPeriods);
 
         // initialize
-        int length = qdList.Count;
+        int length = source.Count;
         List<SmiResult> results = new(length);
 
         double k1 = 2d / (firstSmoothPeriods + 1);
@@ -35,7 +35,7 @@ public static partial class Indicator
         // roll through source values
         for (int i = 0; i < length; i++)
         {
-            QuoteD q = qdList[i];
+            QuoteD q = source[i];
 
             double smi;
             double signal;
@@ -47,7 +47,7 @@ public static partial class Indicator
 
                 for (int p = i + 1 - lookbackPeriods; p <= i; p++)
                 {
-                    QuoteD x = qdList[p];
+                    QuoteD x = source[p];
 
                     if (x.High > hH)
                     {

--- a/src/s-z/Smi/Smi.Utilities.cs
+++ b/src/s-z/Smi/Smi.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<SmiResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<SmiResult> RemoveWarmupPeriods(
         this IEnumerable<SmiResult> results)
     {
         int removePeriods = results

--- a/src/s-z/Smma/Smma.Api.cs
+++ b/src/s-z/Smma/Smma.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<SmmaResult> GetSmma<T>(
+    public static IReadOnlyList<SmmaResult> GetSmma<T>(
         this IEnumerable<T> results,
         int lookbackPeriods)
         where T : IReusable

--- a/src/s-z/Smma/Smma.Utilities.cs
+++ b/src/s-z/Smma/Smma.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<SmmaResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<SmmaResult> RemoveWarmupPeriods(
         this IEnumerable<SmmaResult> results)
     {
         int n = results

--- a/src/s-z/StarcBands/StarcBands.Api.cs
+++ b/src/s-z/StarcBands/StarcBands.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<StarcBandsResult> GetStarcBands<TQuote>(
+    public static IReadOnlyList<StarcBandsResult> GetStarcBands<TQuote>(
         this IEnumerable<TQuote> quotes,
         int smaPeriods,
         double multiplier = 2,

--- a/src/s-z/StarcBands/StarcBands.Series.cs
+++ b/src/s-z/StarcBands/StarcBands.Series.cs
@@ -5,7 +5,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     private static List<StarcBandsResult> CalcStarcBands(
-        this List<QuoteD> qdList,
+        this List<QuoteD> source,
         int smaPeriods,
         double multiplier,
         int atrPeriods)
@@ -14,10 +14,10 @@ public static partial class Indicator
         StarcBands.Validate(smaPeriods, multiplier, atrPeriods);
 
         // initialize
-        int length = qdList.Count;
+        int length = source.Count;
         List<StarcBandsResult> results = new(length);
-        List<AtrResult> atrResults = qdList.CalcAtr(atrPeriods);
-        List<SmaResult> smaResults = qdList.CalcSma(smaPeriods);
+        List<AtrResult> atrResults = source.CalcAtr(atrPeriods);
+        List<SmaResult> smaResults = source.CalcSma(smaPeriods);
 
         // roll through source values
         for (int i = 0; i < length; i++)

--- a/src/s-z/StarcBands/StarcBands.Utilities.cs
+++ b/src/s-z/StarcBands/StarcBands.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // CONDENSE (REMOVE null results)
     /// <inheritdoc cref="ReusableUtility.Condense{T}(IEnumerable{T})"/>
-    public static IEnumerable<StarcBandsResult> Condense(
+    public static IReadOnlyList<StarcBandsResult> Condense(
         this IEnumerable<StarcBandsResult> results)
     {
         List<StarcBandsResult> resultsList = results
@@ -19,7 +19,7 @@ public static partial class Indicator
 
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<StarcBandsResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<StarcBandsResult> RemoveWarmupPeriods(
         this IEnumerable<StarcBandsResult> results)
     {
         int n = results

--- a/src/s-z/Stc/Stc.Api.cs
+++ b/src/s-z/Stc/Stc.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<StcResult> GetStc<T>(
+    public static IReadOnlyList<StcResult> GetStc<T>(
         this IEnumerable<T> results,
         int cyclePeriods = 10,
         int fastPeriods = 23,

--- a/src/s-z/Stc/Stc.Series.cs
+++ b/src/s-z/Stc/Stc.Series.cs
@@ -5,7 +5,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     private static List<StcResult> CalcStc<T>(
-        this List<T> tpList,
+        this List<T> source,
         int cyclePeriods,
         int fastPeriods,
         int slowPeriods)
@@ -15,11 +15,11 @@ public static partial class Indicator
         Stc.Validate(cyclePeriods, fastPeriods, slowPeriods);
 
         // initialize results
-        int length = tpList.Count;
+        int length = source.Count;
         List<StcResult> results = new(length);
 
         // get stochastic of macd
-        List<StochResult> stochMacd = tpList
+        IReadOnlyList<StochResult> stochMacd = source
           .CalcMacd(fastPeriods, slowPeriods, 1)
           .Select(x => new QuoteD(
               x.Timestamp, 0,

--- a/src/s-z/Stc/Stc.Utilities.cs
+++ b/src/s-z/Stc/Stc.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<StcResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<StcResult> RemoveWarmupPeriods(
         this IEnumerable<StcResult> results)
     {
         int n = results

--- a/src/s-z/StdDev/StdDev.Api.cs
+++ b/src/s-z/StdDev/StdDev.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<StdDevResult> GetStdDev<T>(
+    public static IReadOnlyList<StdDevResult> GetStdDev<T>(
         this IEnumerable<T> results,
         int lookbackPeriods)
         where T : IReusable

--- a/src/s-z/StdDev/StdDev.Utilities.cs
+++ b/src/s-z/StdDev/StdDev.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<StdDevResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<StdDevResult> RemoveWarmupPeriods(
         this IEnumerable<StdDevResult> results)
     {
         int removePeriods = results

--- a/src/s-z/StdDevChannels/StdDevChannels.Api.cs
+++ b/src/s-z/StdDevChannels/StdDevChannels.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<StdDevChannelsResult> GetStdDevChannels<T>(
+    public static IReadOnlyList<StdDevChannelsResult> GetStdDevChannels<T>(
         this IEnumerable<T> results,
         int? lookbackPeriods = 20,
         double stdDeviations = 2)

--- a/src/s-z/StdDevChannels/StdDevChannels.Utilities.cs
+++ b/src/s-z/StdDevChannels/StdDevChannels.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // CONDENSE (REMOVE null results)
     /// <inheritdoc cref="ReusableUtility.Condense{T}(IEnumerable{T})"/>
-    public static IEnumerable<StdDevChannelsResult> Condense(
+    public static IReadOnlyList<StdDevChannelsResult> Condense(
         this IEnumerable<StdDevChannelsResult> results)
     {
         List<StdDevChannelsResult> resultsList = results
@@ -22,7 +22,7 @@ public static partial class Indicator
 
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<StdDevChannelsResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<StdDevChannelsResult> RemoveWarmupPeriods(
         this IEnumerable<StdDevChannelsResult> results)
     {
         int removePeriods = results

--- a/src/s-z/Stoch/Stoch.Api.cs
+++ b/src/s-z/Stoch/Stoch.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote (standard)
     /// <include file='./info.xml' path='info/type[@name="Main"]/*' />
     ///
-    public static IEnumerable<StochResult> GetStoch<TQuote>(
+    public static IReadOnlyList<StochResult> GetStoch<TQuote>(
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods = 14,
         int signalPeriods = 3,
@@ -21,7 +21,7 @@ public static partial class Indicator
     // SERIES, from TQuote (extended)
     /// <include file='./info.xml' path='info/type[@name="Extended"]/*' />
     ///
-    public static IEnumerable<StochResult> GetStoch<TQuote>(
+    public static IReadOnlyList<StochResult> GetStoch<TQuote>(
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods,
         int signalPeriods,

--- a/src/s-z/Stoch/Stoch.Series.cs
+++ b/src/s-z/Stoch/Stoch.Series.cs
@@ -5,7 +5,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     private static List<StochResult> CalcStoch(
-        this List<QuoteD> qdList,
+        this List<QuoteD> source,
         int lookbackPeriods,
         int signalPeriods,
         int smoothPeriods,
@@ -19,7 +19,7 @@ public static partial class Indicator
             kFactor, dFactor, movingAverageType);
 
         // initialize
-        int length = qdList.Count;
+        int length = source.Count;
         List<StochResult> results = new(length);
 
         double[] o = new double[length]; // %K oscillator (initial)
@@ -31,7 +31,7 @@ public static partial class Indicator
         // roll through source values
         for (int i = 0; i < length; i++)
         {
-            QuoteD q = qdList[i];
+            QuoteD q = source[i];
 
             // initial %K oscillator
             if (i >= lookbackPeriods - 1)
@@ -42,7 +42,7 @@ public static partial class Indicator
 
                 for (int p = i - lookbackPeriods + 1; p <= i; p++)
                 {
-                    QuoteD x = qdList[p];
+                    QuoteD x = source[p];
 
                     if (double.IsNaN(x.High)
                      || double.IsNaN(x.Low)

--- a/src/s-z/Stoch/Stoch.Utilities.cs
+++ b/src/s-z/Stoch/Stoch.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<StochResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<StochResult> RemoveWarmupPeriods(
         this IEnumerable<StochResult> results)
     {
         int removePeriods = results

--- a/src/s-z/StochRsi/StochRsi.Api.cs
+++ b/src/s-z/StochRsi/StochRsi.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<StochRsiResult> GetStochRsi<T>(
+    public static IReadOnlyList<StochRsiResult> GetStochRsi<T>(
         this IEnumerable<T> results,
         int rsiPeriods,
         int stochPeriods,

--- a/src/s-z/StochRsi/StochRsi.Utilities.cs
+++ b/src/s-z/StochRsi/StochRsi.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<StochRsiResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<StochRsiResult> RemoveWarmupPeriods(
         this IEnumerable<StochRsiResult> results)
     {
         int n = results

--- a/src/s-z/SuperTrend/SuperTrend.Api.cs
+++ b/src/s-z/SuperTrend/SuperTrend.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<SuperTrendResult> GetSuperTrend<TQuote>(
+    public static IReadOnlyList<SuperTrendResult> GetSuperTrend<TQuote>(
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods = 10,
         double multiplier = 3)

--- a/src/s-z/SuperTrend/SuperTrend.Series.cs
+++ b/src/s-z/SuperTrend/SuperTrend.Series.cs
@@ -5,7 +5,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     private static List<SuperTrendResult> CalcSuperTrend(
-        this List<QuoteD> qdList,
+        this List<QuoteD> source,
         int lookbackPeriods,
         double multiplier)
     {
@@ -13,9 +13,9 @@ public static partial class Indicator
         SuperTrend.Validate(lookbackPeriods, multiplier);
 
         // initialize
-        int length = qdList.Count;
+        int length = source.Count;
         List<SuperTrendResult> results = new(length);
-        List<AtrResult> atrResults = qdList.CalcAtr(lookbackPeriods);
+        List<AtrResult> atrResults = source.CalcAtr(lookbackPeriods);
 
         bool isBullish = true;
         double? upperBand = null;
@@ -24,7 +24,7 @@ public static partial class Indicator
         // roll through source values
         for (int i = 0; i < length; i++)
         {
-            QuoteD q = qdList[i];
+            QuoteD q = source[i];
 
             double? superTrend;
             double? upperOnly;
@@ -34,7 +34,7 @@ public static partial class Indicator
             {
                 double? mid = (q.High + q.Low) / 2;
                 double? atr = atrResults[i].Atr;
-                double? prevClose = qdList[i - 1].Close;
+                double? prevClose = source[i - 1].Close;
 
                 // potential bands
                 double? upperEval = mid + multiplier * atr;

--- a/src/s-z/SuperTrend/SuperTrend.Utilities.cs
+++ b/src/s-z/SuperTrend/SuperTrend.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // CONDENSE (REMOVE null results)
     /// <inheritdoc cref="ReusableUtility.Condense{T}(IEnumerable{T})"/>
-    public static IEnumerable<SuperTrendResult> Condense(
+    public static IReadOnlyList<SuperTrendResult> Condense(
         this IEnumerable<SuperTrendResult> results)
     {
         List<SuperTrendResult> resultsList = results
@@ -19,7 +19,7 @@ public static partial class Indicator
 
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<SuperTrendResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<SuperTrendResult> RemoveWarmupPeriods(
         this IEnumerable<SuperTrendResult> results)
     {
         int removePeriods = results

--- a/src/s-z/T3/T3.Api.cs
+++ b/src/s-z/T3/T3.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<T3Result> GetT3<T>(
+    public static IReadOnlyList<T3Result> GetT3<T>(
         this IEnumerable<T> results,
         int lookbackPeriods = 5,
         double volumeFactor = 0.7)

--- a/src/s-z/Tema/Tema.Api.cs
+++ b/src/s-z/Tema/Tema.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<TemaResult> GetTema<T>(
+    public static IReadOnlyList<TemaResult> GetTema<T>(
         this IEnumerable<T> results,
         int lookbackPeriods)
         where T : IReusable

--- a/src/s-z/Tema/Tema.Utilities.cs
+++ b/src/s-z/Tema/Tema.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<TemaResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<TemaResult> RemoveWarmupPeriods(
         this IEnumerable<TemaResult> results)
     {
         int n = results

--- a/src/s-z/Tr/Tr.Api.cs
+++ b/src/s-z/Tr/Tr.Api.cs
@@ -7,7 +7,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/type[@name="standard"]/*' />
     ///
-    public static IEnumerable<TrResult> GetTr<TQuote>(
+    public static IReadOnlyList<TrResult> GetTr<TQuote>(
         this IEnumerable<TQuote> quotes)
         where TQuote : IQuote => quotes
             .ToQuoteDList()

--- a/src/s-z/Tr/Tr.Series.cs
+++ b/src/s-z/Tr/Tr.Series.cs
@@ -6,27 +6,27 @@ public static partial class Indicator
 {
     // calculate series
     private static List<TrResult> CalcTr(
-        this List<QuoteD> qdList)
+        this List<QuoteD> source)
     {
         // initialize
-        int length = qdList.Count;
+        int length = source.Count;
         List<TrResult> results = new(length);
 
         // skip first period
         if (length > 0)
         {
             results.Add(
-                new(qdList[0].Timestamp, null));
+                new(source[0].Timestamp, null));
         }
 
         // roll through source values
         for (int i = 1; i < length; i++)
         {
-            QuoteD q = qdList[i];
+            QuoteD q = source[i];
 
             results.Add(new(
                 Timestamp: q.Timestamp,
-                Tr: Tr.Increment(qdList[i - 1].Close, q.High, q.Low)
+                Tr: Tr.Increment(source[i - 1].Close, q.High, q.Low)
                       .NaN2Null()));
         }
 

--- a/src/s-z/Trix/Trix.Api.cs
+++ b/src/s-z/Trix/Trix.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<TrixResult> GetTrix<T>(
+    public static IReadOnlyList<TrixResult> GetTrix<T>(
         this IEnumerable<T> results,
         int lookbackPeriods)
         where T : IReusable

--- a/src/s-z/Trix/Trix.Utilities.cs
+++ b/src/s-z/Trix/Trix.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<TrixResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<TrixResult> RemoveWarmupPeriods(
         this IEnumerable<TrixResult> results)
     {
         int n = results

--- a/src/s-z/Tsi/Tsi.Api.cs
+++ b/src/s-z/Tsi/Tsi.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<TsiResult> GetTsi<T>(
+    public static IReadOnlyList<TsiResult> GetTsi<T>(
         this IEnumerable<T> results,
         int lookbackPeriods = 25,
         int smoothPeriods = 13,

--- a/src/s-z/Tsi/Tsi.Utilities.cs
+++ b/src/s-z/Tsi/Tsi.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<TsiResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<TsiResult> RemoveWarmupPeriods(
         this IEnumerable<TsiResult> results)
     {
         int nm = results

--- a/src/s-z/UlcerIndex/UlcerIndex.Api.cs
+++ b/src/s-z/UlcerIndex/UlcerIndex.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<UlcerIndexResult> GetUlcerIndex<T>(
+    public static IReadOnlyList<UlcerIndexResult> GetUlcerIndex<T>(
         this IEnumerable<T> results,
         int lookbackPeriods = 14)
         where T : IReusable

--- a/src/s-z/UlcerIndex/UlcerIndex.Utilities.cs
+++ b/src/s-z/UlcerIndex/UlcerIndex.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<UlcerIndexResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<UlcerIndexResult> RemoveWarmupPeriods(
         this IEnumerable<UlcerIndexResult> results)
     {
         int removePeriods = results

--- a/src/s-z/Ultimate/Ultimate.Api.cs
+++ b/src/s-z/Ultimate/Ultimate.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<UltimateResult> GetUltimate<TQuote>(
+    public static IReadOnlyList<UltimateResult> GetUltimate<TQuote>(
         this IEnumerable<TQuote> quotes,
         int shortPeriods = 7,
         int middlePeriods = 14,

--- a/src/s-z/Ultimate/Ultimate.Series.cs
+++ b/src/s-z/Ultimate/Ultimate.Series.cs
@@ -5,7 +5,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     private static List<UltimateResult> CalcUltimate(
-        this List<QuoteD> qdList,
+        this List<QuoteD> source,
         int shortPeriods,
         int middlePeriods,
         int longPeriods)
@@ -14,7 +14,7 @@ public static partial class Indicator
         Ultimate.Validate(shortPeriods, middlePeriods, longPeriods);
 
         // initialize
-        int length = qdList.Count;
+        int length = source.Count;
         List<UltimateResult> results = new(length);
         double[] bp = new double[length]; // buying pressure
         double[] tr = new double[length]; // true range
@@ -24,7 +24,7 @@ public static partial class Indicator
         // roll through source values
         for (int i = 0; i < length; i++)
         {
-            QuoteD q = qdList[i];
+            QuoteD q = source[i];
             double? ultimate;
 
             if (i > 0)

--- a/src/s-z/Ultimate/Ultimate.Utilities.cs
+++ b/src/s-z/Ultimate/Ultimate.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<UltimateResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<UltimateResult> RemoveWarmupPeriods(
         this IEnumerable<UltimateResult> results)
     {
         int removePeriods = results

--- a/src/s-z/VolatilityStop/VolatilityStop.Api.cs
+++ b/src/s-z/VolatilityStop/VolatilityStop.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<VolatilityStopResult> GetVolatilityStop<TQuote>(
+    public static IReadOnlyList<VolatilityStopResult> GetVolatilityStop<TQuote>(
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods = 7,
         double multiplier = 3)

--- a/src/s-z/VolatilityStop/VolatilityStop.Series.cs
+++ b/src/s-z/VolatilityStop/VolatilityStop.Series.cs
@@ -5,12 +5,12 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     private static List<VolatilityStopResult> CalcVolatilityStop(
-        this List<QuoteD> qdList,
+        this List<QuoteD> source,
         int lookbackPeriods,
         double multiplier)
     {
         //convert quotes
-        List<IReusable> reList = qdList
+        List<IReusable> reList = source
             .Cast<IReusable>()
             .ToList();
 
@@ -18,7 +18,7 @@ public static partial class Indicator
         VolatilityStop.Validate(lookbackPeriods, multiplier);
 
         // initialize
-        int length = qdList.Count;
+        int length = source.Count;
         List<VolatilityStopResult> results = new(length);
 
         if (length == 0)
@@ -26,7 +26,7 @@ public static partial class Indicator
             return results;
         }
 
-        List<AtrResult> atrList = qdList.CalcAtr(lookbackPeriods);
+        List<AtrResult> atrList = source.CalcAtr(lookbackPeriods);
 
         // initial trend (guess)
         int initPeriods = Math.Min(length, lookbackPeriods);

--- a/src/s-z/VolatilityStop/VolatilityStop.Utilities.cs
+++ b/src/s-z/VolatilityStop/VolatilityStop.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<VolatilityStopResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<VolatilityStopResult> RemoveWarmupPeriods(
         this IEnumerable<VolatilityStopResult> results)
     {
         int removePeriods = results

--- a/src/s-z/Vortex/Vortex.Api.cs
+++ b/src/s-z/Vortex/Vortex.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<VortexResult> GetVortex<TQuote>(
+    public static IReadOnlyList<VortexResult> GetVortex<TQuote>(
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods)
         where TQuote : IQuote => quotes

--- a/src/s-z/Vortex/Vortex.Series.cs
+++ b/src/s-z/Vortex/Vortex.Series.cs
@@ -5,14 +5,14 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     private static List<VortexResult> CalcVortex(
-        this List<QuoteD> qdList,
+        this List<QuoteD> source,
         int lookbackPeriods)
     {
         // check parameter arguments
         Vortex.Validate(lookbackPeriods);
 
         // initialize
-        int length = qdList.Count;
+        int length = source.Count;
         List<VortexResult> results = new(length);
 
         double[] tr = new double[length];
@@ -26,7 +26,7 @@ public static partial class Indicator
         // roll through source values
         for (int i = 0; i < length; i++)
         {
-            QuoteD q = qdList[i];
+            QuoteD q = source[i];
 
             // skip first period
             if (i == 0)

--- a/src/s-z/Vortex/Vortex.Utilities.cs
+++ b/src/s-z/Vortex/Vortex.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // CONDENSE (REMOVE null results)
     /// <inheritdoc cref="ReusableUtility.Condense{T}(IEnumerable{T})"/>
-    public static IEnumerable<VortexResult> Condense(
+    public static IReadOnlyList<VortexResult> Condense(
         this IEnumerable<VortexResult> results)
     {
         List<VortexResult> resultsList = results
@@ -19,7 +19,7 @@ public static partial class Indicator
 
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<VortexResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<VortexResult> RemoveWarmupPeriods(
         this IEnumerable<VortexResult> results)
     {
         int removePeriods = results

--- a/src/s-z/Vwap/Vwap.Api.cs
+++ b/src/s-z/Vwap/Vwap.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<VwapResult> GetVwap<TQuote>(
+    public static IReadOnlyList<VwapResult> GetVwap<TQuote>(
         this IEnumerable<TQuote> quotes,
         DateTime? startDate = null)
         where TQuote : IQuote => quotes

--- a/src/s-z/Vwap/Vwap.Series.cs
+++ b/src/s-z/Vwap/Vwap.Series.cs
@@ -5,14 +5,14 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     private static List<VwapResult> CalcVwap(
-        this List<QuoteD> qdList,
+        this List<QuoteD> source,
         DateTime? startDate = null)
     {
         // check parameter arguments
-        Vwap.Validate(qdList, startDate);
+        Vwap.Validate(source, startDate);
 
         // initialize
-        int length = qdList.Count;
+        int length = source.Count;
         List<VwapResult> results = new(length);
 
         if (length == 0)
@@ -20,7 +20,7 @@ public static partial class Indicator
             return results;
         }
 
-        startDate ??= qdList[0].Timestamp;
+        startDate ??= source[0].Timestamp;
 
         double? cumVolume = 0;
         double? cumVolumeTp = 0;
@@ -28,7 +28,7 @@ public static partial class Indicator
         // roll through source values
         for (int i = 0; i < length; i++)
         {
-            QuoteD q = qdList[i];
+            QuoteD q = source[i];
 
             double? v = q.Volume;
             double? h = q.High;

--- a/src/s-z/Vwap/Vwap.Utilities.cs
+++ b/src/s-z/Vwap/Vwap.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<VwapResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<VwapResult> RemoveWarmupPeriods(
         this IEnumerable<VwapResult> results)
     {
         int removePeriods = results

--- a/src/s-z/Vwma/Vwma.Api.cs
+++ b/src/s-z/Vwma/Vwma.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<VwmaResult> GetVwma<TQuote>(
+    public static IReadOnlyList<VwmaResult> GetVwma<TQuote>(
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods)
         where TQuote : IQuote => quotes

--- a/src/s-z/Vwma/Vwma.Series.cs
+++ b/src/s-z/Vwma/Vwma.Series.cs
@@ -5,20 +5,20 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     private static List<VwmaResult> CalcVwma(
-        this List<QuoteD> qdList,
+        this List<QuoteD> source,
         int lookbackPeriods)
     {
         // check parameter arguments
         Vwma.Validate(lookbackPeriods);
 
         // initialize
-        int length = qdList.Count;
+        int length = source.Count;
         List<VwmaResult> results = new(length);
 
         // roll through source values
         for (int i = 0; i < length; i++)
         {
-            QuoteD q = qdList[i];
+            QuoteD q = source[i];
 
             double vwma;
 
@@ -28,7 +28,7 @@ public static partial class Indicator
                 double sumVl = 0;
                 for (int p = i + 1 - lookbackPeriods; p <= i; p++)
                 {
-                    QuoteD d = qdList[p];
+                    QuoteD d = source[p];
                     double c = d.Close;
                     double v = d.Volume;
 

--- a/src/s-z/Vwma/Vwma.Utilities.cs
+++ b/src/s-z/Vwma/Vwma.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<VwmaResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<VwmaResult> RemoveWarmupPeriods(
         this IEnumerable<VwmaResult> results)
     {
         int removePeriods = results

--- a/src/s-z/WilliamsR/WilliamsR.Api.cs
+++ b/src/s-z/WilliamsR/WilliamsR.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<WilliamsResult> GetWilliamsR<TQuote>(
+    public static IReadOnlyList<WilliamsResult> GetWilliamsR<TQuote>(
         this IEnumerable<TQuote> quotes,
         int lookbackPeriods = 14)
         where TQuote : IQuote => quotes

--- a/src/s-z/WilliamsR/WilliamsR.Series.cs
+++ b/src/s-z/WilliamsR/WilliamsR.Series.cs
@@ -5,14 +5,14 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     private static List<WilliamsResult> CalcWilliamsR(
-        this List<QuoteD> qdList,
+        this List<QuoteD> source,
         int lookbackPeriods)
     {
         // check parameter arguments
         WilliamsR.Validate(lookbackPeriods);
 
         // convert Fast Stochastic to William %R
-        return qdList.CalcStoch(lookbackPeriods, 1, 1, 3, 2, MaType.SMA)
+        return source.CalcStoch(lookbackPeriods, 1, 1, 3, 2, MaType.SMA)
             .Select(s => new WilliamsResult(
                 Timestamp: s.Timestamp,
                 WilliamsR: s.Oscillator - 100

--- a/src/s-z/WilliamsR/WilliamsR.Utilities.cs
+++ b/src/s-z/WilliamsR/WilliamsR.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<WilliamsResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<WilliamsResult> RemoveWarmupPeriods(
         this IEnumerable<WilliamsResult> results)
     {
         int removePeriods = results

--- a/src/s-z/Wma/Wma.Api.cs
+++ b/src/s-z/Wma/Wma.Api.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 public static partial class Indicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<WmaResult> GetWma<T>(
+    public static IReadOnlyList<WmaResult> GetWma<T>(
         this IEnumerable<T> results,
         int lookbackPeriods)
         where T : IReusable

--- a/src/s-z/Wma/Wma.Utilities.cs
+++ b/src/s-z/Wma/Wma.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // remove recommended periods
     /// <inheritdoc cref="ReusableUtility.RemoveWarmupPeriods{T}(IEnumerable{T})"/>
-    public static IEnumerable<WmaResult> RemoveWarmupPeriods(
+    public static IReadOnlyList<WmaResult> RemoveWarmupPeriods(
         this IEnumerable<WmaResult> results)
     {
         int removePeriods = results

--- a/src/s-z/ZigZag/ZigZag.Api.cs
+++ b/src/s-z/ZigZag/ZigZag.Api.cs
@@ -6,7 +6,7 @@ public static partial class Indicator
     // SERIES, from TQuote
     /// <include file='./info.xml' path='info/*' />
     ///
-    public static IEnumerable<ZigZagResult> GetZigZag<TQuote>(
+    public static IReadOnlyList<ZigZagResult> GetZigZag<TQuote>(
         this IEnumerable<TQuote> quotes,
         EndType endType = EndType.Close,
         decimal percentChange = 5)

--- a/src/s-z/ZigZag/ZigZag.Utilities.cs
+++ b/src/s-z/ZigZag/ZigZag.Utilities.cs
@@ -4,7 +4,7 @@ public static partial class Indicator
 {
     // CONDENSE (REMOVE null results)
     /// <inheritdoc cref="ReusableUtility.Condense{T}(IEnumerable{T})"/>
-    public static IEnumerable<ZigZagResult> Condense(
+    public static IReadOnlyList<ZigZagResult> Condense(
         this IEnumerable<ZigZagResult> results)
     {
         List<ZigZagResult> resultsList = results

--- a/tests/indicators/_common/Candles/Candles.Tests.cs
+++ b/tests/indicators/_common/Candles/Candles.Tests.cs
@@ -9,8 +9,8 @@ public class Candles : TestBase
         IReadOnlyList<Quote> quotes = Data.GetMismatch();
 
         // sort
-        List<CandleProperties> candles
-            = quotes.ToCandles().ToList();  // not sorted
+        IReadOnlyList<CandleProperties> candles = quotes
+            .ToCandles();  // not sorted
 
         // proper quantities
         Assert.AreEqual(502, candles.Count);
@@ -20,7 +20,7 @@ public class Candles : TestBase
         Assert.AreEqual(firstDate, candles[0].Timestamp);
 
         DateTime lastDate = DateTime.ParseExact("12/31/2018", "MM/dd/yyyy", englishCulture);
-        Assert.AreEqual(lastDate, candles.LastOrDefault().Timestamp);
+        Assert.AreEqual(lastDate, candles[^1].Timestamp);
 
         DateTime spotDate = DateTime.ParseExact("03/16/2017", "MM/dd/yyyy", englishCulture);
         Assert.AreEqual(spotDate, candles[50].Timestamp);
@@ -29,8 +29,8 @@ public class Candles : TestBase
     [TestMethod]
     public void CandleValues()
     {
-        List<CandleProperties> candles
-            = Quotes.ToCandles().ToList();  // not sorted
+        IReadOnlyList<CandleProperties> candles = Quotes
+            .ToCandles();
 
         // proper quantities
         Assert.AreEqual(502, candles.Count);
@@ -74,7 +74,9 @@ public class Candles : TestBase
     [TestMethod]
     public void ToCandles()
     {
-        IEnumerable<CandleProperties> candles = Quotes.ToCandles();
-        Assert.AreEqual(Quotes.Count, candles.Count());
+        IReadOnlyList<CandleProperties> candles
+            = Quotes.ToCandles();
+
+        Assert.AreEqual(Quotes.Count, candles.Count);
     }
 }

--- a/tests/indicators/_common/Generics/Pruning.Tests.cs
+++ b/tests/indicators/_common/Generics/Pruning.Tests.cs
@@ -7,11 +7,11 @@ public class Pruning : TestBase
     public void Remove()
     {
         // specific periods
-        IEnumerable<HeikinAshiResult> results =
-            Quotes.GetHeikinAshi()
-              .RemoveWarmupPeriods(102);
+        IReadOnlyList<HeikinAshiResult> results = Quotes
+            .GetHeikinAshi()
+            .RemoveWarmupPeriods(102);
 
-        Assert.AreEqual(400, results.Count());
+        Assert.AreEqual(400, results.Count);
 
         // bad remove period
         Assert.ThrowsException<ArgumentOutOfRangeException>(()
@@ -22,10 +22,10 @@ public class Pruning : TestBase
     public void RemoveTooMany()
     {
         // more than available
-        IEnumerable<HeikinAshiResult> results =
-            Quotes.GetHeikinAshi()
-              .RemoveWarmupPeriods(600);
+        IReadOnlyList<HeikinAshiResult> results = Quotes
+            .GetHeikinAshi()
+            .RemoveWarmupPeriods(600);
 
-        Assert.AreEqual(0, results.Count());
+        Assert.AreEqual(0, results.Count);
     }
 }

--- a/tests/indicators/_common/Generics/Sorting.Tests.cs
+++ b/tests/indicators/_common/Generics/Sorting.Tests.cs
@@ -9,7 +9,7 @@ public class Sorting : TestBase
     public void ToSortedCollection()
     {
         // baseline for comparison
-        List<SmaResult> baseline =
+        IReadOnlyList<SmaResult> baseline =
         [
             new(Timestamp: DateTime.Parse("1/1/2000", englishCulture), Sma: null),
             new(Timestamp: DateTime.Parse("1/2/2000", englishCulture), Sma: null),

--- a/tests/indicators/_common/Generics/Transforms.Tests.cs
+++ b/tests/indicators/_common/Generics/Transforms.Tests.cs
@@ -21,7 +21,7 @@ public class TransformTests : TestBase
     [TestMethod]
     public void Exceptions()
     {
-        List<Quote> nullQuotes = null;
+        IReadOnlyList<Quote> nullQuotes = null;
 
         Assert.ThrowsException<ArgumentNullException>(()
             => nullQuotes.ToCollection());

--- a/tests/indicators/_common/Observables/Cache.Utilities.Tests.cs
+++ b/tests/indicators/_common/Observables/Cache.Utilities.Tests.cs
@@ -9,8 +9,7 @@ public class CacheUtilsTests : TestBase
 
         // setup quote provider
 
-        List<Quote> quotesList = Quotes
-            .ToSortedList()
+        IReadOnlyList<Quote> quotesList = Quotes
             .Take(10)
             .ToList();
 
@@ -53,8 +52,7 @@ public class CacheUtilsTests : TestBase
     {
         // setup quote provider
 
-        List<Quote> quotesList = Quotes
-            .ToSortedList()
+        IReadOnlyList<Quote> quotesList = Quotes
             .Take(10)
             .ToList();
 

--- a/tests/indicators/_common/Observables/ChainProvider.Tests.cs
+++ b/tests/indicators/_common/Observables/ChainProvider.Tests.cs
@@ -15,7 +15,7 @@ public class ChainProviderTests : TestBase, ITestChainProvider
         QuoteHub<Quote> provider = new();
 
         // initialize observer
-        var observer = provider
+        EmaHub<QuotePart> observer = provider
             .ToQuotePart(CandlePart.HL2)
             .ToEma(11);
 

--- a/tests/indicators/_common/Observables/ChainProvider.Tests.cs
+++ b/tests/indicators/_common/Observables/ChainProvider.Tests.cs
@@ -32,10 +32,9 @@ public class ChainProviderTests : TestBase, ITestChainProvider
             = observer.Results;
 
         // time-series, for comparison
-        List<EmaResult> staticEma = Quotes
+        IReadOnlyList<EmaResult> staticEma = Quotes
             .Use(CandlePart.HL2)
-            .GetEma(11)
-            .ToList();
+            .GetEma(11);
 
         // assert, should equal series
         for (int i = 0; i < length; i++)

--- a/tests/indicators/_common/Observables/Stackoverflow.Tests.cs
+++ b/tests/indicators/_common/Observables/Stackoverflow.Tests.cs
@@ -12,8 +12,8 @@ public class StackoverflowTests : TestBase
         int qtyQuotes = 20000;
 
         // setup: many random quotes (massive)
-        List<Quote> quotesList
-            = Data.GetRandom(qtyQuotes).ToList();
+        IReadOnlyList<Quote> quotesList
+            = Data.GetRandom(qtyQuotes);
 
         QuoteHub<Quote> provider = new();
 
@@ -59,7 +59,7 @@ public class StackoverflowTests : TestBase
 
         // assert: [last subscriber] has the same dates
 
-        List<ISeries> lastSubscriber
+        IReadOnlyList<ISeries> lastSubscriber
             = subscribers[^1].results.ToList();
 
         for (int i = 0; i < qtyQuotes; i++)
@@ -103,8 +103,8 @@ public class StackoverflowTests : TestBase
         int chainDepth = 500;
 
         // setup: many random quotes (massive)
-        List<Quote> quotesList
-            = Data.GetRandom(qtyQuotes).ToList();
+        IReadOnlyList<Quote> quotesList
+            = Data.GetRandom(qtyQuotes);
 
         QuoteHub<Quote> provider = new();
 
@@ -156,7 +156,7 @@ public class StackoverflowTests : TestBase
 
         // assert: [last subscriber] has the same dates
 
-        List<ISeries> lastSubscriber
+        IReadOnlyList<ISeries> lastSubscriber
             = subscribers[^1].results.ToList();
 
         for (int i = 0; i < qtyQuotes; i++)
@@ -200,8 +200,8 @@ public class StackoverflowTests : TestBase
         int qtyQuotes = 5000;
 
         // setup: many random quotes
-        List<Quote> quotesList
-            = Data.GetRandom(qtyQuotes).ToList();
+        IReadOnlyList<Quote> quotesList
+            = Data.GetRandom(qtyQuotes);
 
         QuoteHub<Quote> provider = new();
 
@@ -258,7 +258,7 @@ public class StackoverflowTests : TestBase
 
         // assert: [last subscriber] has the same dates
 
-        List<ISeries> lastSubscriber
+        IReadOnlyList<ISeries> lastSubscriber
             = subscribers[^1].results.ToList();
 
         for (int i = 0; i < qtyQuotes; i++)

--- a/tests/indicators/_common/Observables/StreamObserver.Tests.cs
+++ b/tests/indicators/_common/Observables/StreamObserver.Tests.cs
@@ -9,7 +9,7 @@ public class ObserverTests : TestBase
         int qtyQuotes = 5000;
 
         // setup: many random quotes (massive)
-        List<Quote> quotesList
+        IReadOnlyList<Quote> quotesList
             = Data.GetRandom(qtyQuotes).ToList();
 
         int length = quotesList.Count;
@@ -27,7 +27,7 @@ public class ObserverTests : TestBase
         }
 
         // original results
-        List<QuotePart> original = observer.Results.ToList();
+        IReadOnlyList<QuotePart> original = observer.Results.ToList();
 
         // quotes to replace
         Quote q1000original = quotesList[1000] with { /* copy */ };
@@ -39,7 +39,7 @@ public class ObserverTests : TestBase
 
         observer.Modify(r1000modified);  // add directly to observer
 
-        List<QuotePart> modified = observer.Results.ToList();
+        IReadOnlyList<QuotePart> modified = observer.Results.ToList();
 
         // precondition: prefilled, modified
         provider.Cache.Should().HaveCount(length);

--- a/tests/indicators/_common/Observables/StreamProvider.Tests.cs
+++ b/tests/indicators/_common/Observables/StreamProvider.Tests.cs
@@ -6,8 +6,7 @@ public class ProviderTests : TestBase
     [TestMethod]
     public void Prefill()
     {
-        List<Quote> quotesList = Quotes
-            .ToSortedList()
+        IReadOnlyList<Quote> quotesList = Quotes
             .Take(50)
             .ToList();
 
@@ -48,8 +47,7 @@ public class ProviderTests : TestBase
     {
         // setup quote provider
 
-        List<Quote> quotesList = Quotes
-            .ToSortedList()
+        IReadOnlyList<Quote> quotesList = Quotes
             .Take(10)
             .ToList();
 
@@ -79,10 +77,9 @@ public class ProviderTests : TestBase
 
         // setup quote provider
 
-        List<Quote> quotesList = Quotes
-            .ToSortedList()
+        IReadOnlyList<Quote> quotesList = Quotes
             .Take(10)
-            .ToList();
+            .ToSortedList();
 
         int length = quotesList.Count;
 
@@ -105,11 +102,11 @@ public class ProviderTests : TestBase
         observer.Cache.Should().HaveCount(3);
         provider.Cache.Should().HaveCount(10);
 
-        List<QuotePart> cacheOver
+        IReadOnlyList<QuotePart> cacheOver
             = observer.Results
                 .Where(c => c.Timestamp >= q3.Timestamp).ToList();
 
-        List<QuotePart> cacheUndr
+        IReadOnlyList<QuotePart> cacheUndr
             = observer.Results
                 .Where(c => c.Timestamp <= q3.Timestamp).ToList();
 
@@ -123,8 +120,7 @@ public class ProviderTests : TestBase
 
         // setup quote provider
 
-        List<Quote> quotesList = Quotes
-            .ToSortedList()
+        IReadOnlyList<Quote> quotesList = Quotes
             .Take(10)
             .ToList();
 
@@ -149,11 +145,11 @@ public class ProviderTests : TestBase
         observer.Cache.Should().HaveCount(3);
         provider.Cache.Should().HaveCount(10);
 
-        List<QuotePart> cacheOver
+        IReadOnlyList<QuotePart> cacheOver
             = observer.Results
                 .Where(c => c.Timestamp >= q3.Timestamp).ToList();
 
-        List<QuotePart> cacheUndr
+        IReadOnlyList<QuotePart> cacheUndr
             = observer.Results
                 .Where(c => c.Timestamp <= q3.Timestamp).ToList();
 

--- a/tests/indicators/_common/Quotes/Quote.Aggregates.Tests.cs
+++ b/tests/indicators/_common/Quotes/Quote.Aggregates.Tests.cs
@@ -9,9 +9,8 @@ public class QuoteAggregateTests : TestBase
         IReadOnlyList<Quote> quotes = Data.GetIntraday();
 
         // aggregate
-        List<Quote> results = quotes
-            .Aggregate(PeriodSize.FifteenMinutes)
-            .ToList();
+        IReadOnlyList<Quote> results = quotes
+            .Aggregate(PeriodSize.FifteenMinutes);
 
         // proper quantities
         Assert.AreEqual(108, results.Count);
@@ -42,7 +41,7 @@ public class QuoteAggregateTests : TestBase
         Assert.AreEqual(1396993m, r2.Volume);
 
         // no history scenario
-        List<Quote> noQuotes = [];
+        IReadOnlyList<Quote> noQuotes = [];
         IEnumerable<Quote> noResults = noQuotes.Aggregate(PeriodSize.Day);
         Assert.IsFalse(noResults.Any());
     }
@@ -53,9 +52,8 @@ public class QuoteAggregateTests : TestBase
         IReadOnlyList<Quote> quotes = Data.GetIntraday();
 
         // aggregate
-        List<Quote> results = quotes
-            .Aggregate(TimeSpan.FromMinutes(15))
-            .ToList();
+        IReadOnlyList<Quote> results = quotes
+            .Aggregate(TimeSpan.FromMinutes(15));
 
         // proper quantities
         Assert.AreEqual(108, results.Count);
@@ -86,7 +84,7 @@ public class QuoteAggregateTests : TestBase
         Assert.AreEqual(1396993m, r2.Volume);
 
         // no history scenario
-        List<Quote> noQuotes = [];
+        IReadOnlyList<Quote> noQuotes = [];
         IEnumerable<Quote> noResults = noQuotes.Aggregate(TimeSpan.FromDays(1));
         Assert.IsFalse(noResults.Any());
     }
@@ -95,9 +93,8 @@ public class QuoteAggregateTests : TestBase
     public void AggregateMonth()
     {
         // aggregate
-        List<Quote> results = Quotes
-            .Aggregate(PeriodSize.Month)
-            .ToList();
+        IReadOnlyList<Quote> results = Quotes
+            .Aggregate(PeriodSize.Month);
 
         // proper quantities
         Assert.AreEqual(24, results.Count);

--- a/tests/indicators/_common/Quotes/Quote.Converters.Tests.cs
+++ b/tests/indicators/_common/Quotes/Quote.Converters.Tests.cs
@@ -33,7 +33,7 @@ public class QuoteUtilityTests : TestBase
     {
         IReadOnlyList<Quote> quotes = Data.GetMismatch();
 
-        List<Quote> h = quotes.ToSortedList();
+        IReadOnlyList<Quote> h = quotes.ToSortedList();
 
         // proper quantities
         Assert.AreEqual(502, h.Count);
@@ -44,7 +44,7 @@ public class QuoteUtilityTests : TestBase
 
         // check last date
         DateTime lastDate = DateTime.ParseExact("12/31/2018", "MM/dd/yyyy", englishCulture);
-        Assert.AreEqual(lastDate, h.LastOrDefault().Timestamp);
+        Assert.AreEqual(lastDate, h[^1].Timestamp);
 
         // spot check an out of sequence date
         DateTime spotDate = DateTime.ParseExact("03/16/2017", "MM/dd/yyyy", englishCulture);

--- a/tests/indicators/_common/Quotes/Quote.Stream.Tests.cs
+++ b/tests/indicators/_common/Quotes/Quote.Stream.Tests.cs
@@ -81,10 +81,9 @@ public class QuoteTests : StreamTestBase, ITestChainProvider
             = observer.Results;
 
         // time-series, for comparison
-        List<SmaResult> seriesList
+        IReadOnlyList<SmaResult> seriesList
            = quotesList
-            .GetSma(smaPeriods)
-            .ToList();
+            .GetSma(smaPeriods);
 
         // assert, should equal series
         for (int i = 0; i < length - 1; i++)

--- a/tests/indicators/_common/Quotes/Quote.Validation.Tests.cs
+++ b/tests/indicators/_common/Quotes/Quote.Validation.Tests.cs
@@ -8,7 +8,7 @@ public class QuoteValidationTests : TestBase
     {
         IReadOnlyList<Quote> quotes = Data.GetDefault();
 
-        List<Quote> h = quotes.Validate().ToList();
+        IReadOnlyList<Quote> h = quotes.Validate();
 
         // proper quantities
         Assert.AreEqual(502, h.Count);
@@ -24,7 +24,7 @@ public class QuoteValidationTests : TestBase
     [TestMethod]
     public void ValidateLong()
     {
-        List<Quote> h = LongishQuotes.Validate().ToList();
+        IReadOnlyList<Quote> h = LongishQuotes.Validate();
 
         // proper quantities
         Assert.AreEqual(5285, h.Count);
@@ -40,13 +40,14 @@ public class QuoteValidationTests : TestBase
         // if quotes post-cleaning, is cut down in size it should not corrupt the results
 
         IReadOnlyList<Quote> quotes = Data.GetDefault(200);
-        List<Quote> h = quotes.Validate().ToList();
+
+        IReadOnlyList<Quote> h = quotes.Validate();
 
         // should be 200 periods, initially
         Assert.AreEqual(200, h.Count);
 
         // should be 20 results and no index corruption
-        List<SmaResult> r1 = h.TakeLast(20).GetSma(14).ToList();
+        IReadOnlyList<SmaResult> r1 = h.TakeLast(20).GetSma(14).ToList();
         Assert.AreEqual(20, r1.Count);
 
         for (int i = 1; i < r1.Count; i++)
@@ -55,7 +56,7 @@ public class QuoteValidationTests : TestBase
         }
 
         // should be 50 results and no index corruption
-        List<SmaResult> r2 = h.TakeLast(50).GetSma(14).ToList();
+        IReadOnlyList<SmaResult> r2 = h.TakeLast(50).GetSma(14).ToList();
         Assert.AreEqual(50, r2.Count);
 
         for (int i = 1; i < r2.Count; i++)
@@ -77,7 +78,7 @@ public class QuoteValidationTests : TestBase
     [ExpectedException(typeof(InvalidQuotesException), "Duplicate date found.")]
     public void DuplicateHistory()
     {
-        List<Quote> badHistory =
+        IReadOnlyList<Quote> badHistory =
         [
             new(Timestamp: DateTime.ParseExact("2017-01-03", "yyyy-MM-dd", englishCulture), Open: 214.86m, High: 220.33m, Low: 210.96m, Close: 216.99m, Volume: 5923254),
             new(Timestamp: DateTime.ParseExact("2017-01-04", "yyyy-MM-dd", englishCulture), Open: 214.75m, High: 228.00m, Low: 214.31m, Close: 226.99m, Volume: 11213471),

--- a/tests/indicators/_common/Reusable/Reusable.Utilities.Tests.cs
+++ b/tests/indicators/_common/Reusable/Reusable.Utilities.Tests.cs
@@ -6,21 +6,22 @@ public class Reusable : TestBase
     [TestMethod]
     public void Condense()
     {
-        List<AdxResult> results = Quotes
+        List<AdxResult> original = Quotes
             .GetAdx()
             .ToList();
 
         // make a few more in the middle null and NaN
-        results[249] = results[249] with { Adx = null };
-        results[345] = results[345] with { Adx = double.NaN };
+        original[249] = original[249] with { Adx = null };
+        original[345] = original[345] with { Adx = double.NaN };
 
-        List<AdxResult> r = results.Condense().ToList();
+        IReadOnlyList<AdxResult> results
+            = original.Condense();
 
         // proper quantities
-        Assert.AreEqual(473, r.Count);
+        Assert.AreEqual(473, results.Count);
 
         // sample values
-        AdxResult last = r.LastOrDefault();
+        AdxResult last = results[^1];
         Assert.AreEqual(17.7565, last.Pdi.Round(4));
         Assert.AreEqual(31.1510, last.Mdi.Round(4));
         Assert.AreEqual(34.2987, last.Adx.Round(4));

--- a/tests/indicators/_common/Use (QuotePart)/Use.Series.Tests.cs
+++ b/tests/indicators/_common/Use (QuotePart)/Use.Series.Tests.cs
@@ -7,16 +7,16 @@ public class UseTests : SeriesTestBase
     public override void Standard()
     {
         // compose basic data
-        List<QuotePart> o = Quotes.Use(CandlePart.Open).ToList();
-        List<QuotePart> h = Quotes.Use(CandlePart.High).ToList();
-        List<QuotePart> l = Quotes.Use(CandlePart.Low).ToList();
-        List<QuotePart> c = Quotes.Use(CandlePart.Close).ToList();
-        List<QuotePart> v = Quotes.Use(CandlePart.Volume).ToList();
-        List<QuotePart> hl = Quotes.Use(CandlePart.HL2).ToList();
-        List<QuotePart> hlc = Quotes.Use(CandlePart.HLC3).ToList();
-        List<QuotePart> oc = Quotes.Use(CandlePart.OC2).ToList();
-        List<QuotePart> ohl = Quotes.Use(CandlePart.OHL3).ToList();
-        List<QuotePart> ohlc = Quotes.Use(CandlePart.OHLC4).ToList();
+        IReadOnlyList<QuotePart> o = Quotes.Use(CandlePart.Open).ToList();
+        IReadOnlyList<QuotePart> h = Quotes.Use(CandlePart.High).ToList();
+        IReadOnlyList<QuotePart> l = Quotes.Use(CandlePart.Low).ToList();
+        IReadOnlyList<QuotePart> c = Quotes.Use(CandlePart.Close).ToList();
+        IReadOnlyList<QuotePart> v = Quotes.Use(CandlePart.Volume).ToList();
+        IReadOnlyList<QuotePart> hl = Quotes.Use(CandlePart.HL2).ToList();
+        IReadOnlyList<QuotePart> hlc = Quotes.Use(CandlePart.HLC3).ToList();
+        IReadOnlyList<QuotePart> oc = Quotes.Use(CandlePart.OC2).ToList();
+        IReadOnlyList<QuotePart> ohl = Quotes.Use(CandlePart.OHL3).ToList();
+        IReadOnlyList<QuotePart> ohlc = Quotes.Use(CandlePart.OHLC4).ToList();
 
         // proper quantities
         Assert.AreEqual(502, c.Count);
@@ -54,9 +54,8 @@ public class UseTests : SeriesTestBase
     [TestMethod]
     public void Use()
     {
-        List<QuotePart> results = Quotes
-            .Use(CandlePart.Close)
-            .ToList();
+        IReadOnlyList<QuotePart> results = Quotes
+            .Use(CandlePart.Close);
 
         Assert.AreEqual(502, results.Count);
     }
@@ -64,10 +63,9 @@ public class UseTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(493, results.Count(x => x.Sma != null));
@@ -76,9 +74,8 @@ public class UseTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<QuotePart> r = BadQuotes
-            .Use(CandlePart.Close)
-            .ToList();
+        IReadOnlyList<QuotePart> r = BadQuotes
+            .Use(CandlePart.Close);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Value is double.NaN));
@@ -87,15 +84,13 @@ public class UseTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<QuotePart> r0 = Noquotes
-            .Use(CandlePart.Close)
-            .ToList();
+        IReadOnlyList<QuotePart> r0 = Noquotes
+            .Use(CandlePart.Close);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<QuotePart> r1 = Onequote
-            .Use(CandlePart.Close)
-            .ToList();
+        IReadOnlyList<QuotePart> r1 = Onequote
+            .Use(CandlePart.Close);
 
         Assert.AreEqual(1, r1.Count);
     }

--- a/tests/indicators/_common/Use (QuotePart)/Use.Stream.Tests.cs
+++ b/tests/indicators/_common/Use (QuotePart)/Use.Stream.Tests.cs
@@ -57,10 +57,9 @@ public class UseTests : StreamTestBase, ITestChainProvider
         quotesList.RemoveAt(400);
 
         // time-series, for comparison
-        List<QuotePart> seriesList
+        IReadOnlyList<QuotePart> seriesList
            = quotesList
-            .Use(candlePart)
-            .ToList();
+            .Use(candlePart);
 
         // assert, should equal series
         for (int i = 0; i < length - 1; i++)
@@ -114,11 +113,10 @@ public class UseTests : StreamTestBase, ITestChainProvider
             = observer.Results;
 
         // time-series, for comparison
-        List<SmaResult> seriesList
+        IReadOnlyList<SmaResult> seriesList
            = quotesList
             .Use(candlePart)
-            .GetSma(smaPeriods)
-            .ToList();
+            .GetSma(smaPeriods);
 
         // assert, should equal series
         for (int i = 0; i < length - 1; i++)

--- a/tests/indicators/a-d/Adl/Adl.Series.Tests.cs
+++ b/tests/indicators/a-d/Adl/Adl.Series.Tests.cs
@@ -6,9 +6,8 @@ public class AdlTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<AdlResult> results = Quotes
-            .GetAdl()
-            .ToList();
+        IReadOnlyList<AdlResult> results = Quotes
+            .GetAdl();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -28,10 +27,9 @@ public class AdlTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetAdl()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         // assertions
 
@@ -43,9 +41,8 @@ public class AdlTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<AdlResult> r = BadQuotes
-            .GetAdl()
-            .ToList();
+        IReadOnlyList<AdlResult> r = BadQuotes
+            .GetAdl();
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => double.IsNaN(x.Adl)));
@@ -54,9 +51,8 @@ public class AdlTests : SeriesTestBase
     [TestMethod]
     public void BigData()
     {
-        List<AdlResult> r = BigQuotes
-            .GetAdl()
-            .ToList();
+        IReadOnlyList<AdlResult> r = BigQuotes
+            .GetAdl();
 
         Assert.AreEqual(1246, r.Count);
     }
@@ -64,9 +60,8 @@ public class AdlTests : SeriesTestBase
     [TestMethod]
     public void RandomData()
     {
-        List<AdlResult> r = RandomQuotes
-            .GetAdl()
-            .ToList();
+        IReadOnlyList<AdlResult> r = RandomQuotes
+            .GetAdl();
 
         Assert.AreEqual(1000, r.Count);
     }
@@ -74,15 +69,13 @@ public class AdlTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<AdlResult> r0 = Noquotes
-            .GetAdl()
-            .ToList();
+        IReadOnlyList<AdlResult> r0 = Noquotes
+            .GetAdl();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<AdlResult> r1 = Onequote
-            .GetAdl()
-            .ToList();
+        IReadOnlyList<AdlResult> r1 = Onequote
+            .GetAdl();
 
         Assert.AreEqual(1, r1.Count);
     }

--- a/tests/indicators/a-d/Adl/Adl.Stream.Tests.cs
+++ b/tests/indicators/a-d/Adl/Adl.Stream.Tests.cs
@@ -55,9 +55,8 @@ public class AdlTests : StreamTestBase, ITestChainProvider
         quotesList.RemoveAt(400);
 
         // time-series, for comparison
-        List<AdlResult> seriesList = quotesList
-            .GetAdl()
-            .ToList();
+        var seriesList = quotesList
+            .GetAdl();
 
         // assert, should equal series
         for (int i = 0; i < length - 1; i++)
@@ -111,10 +110,9 @@ public class AdlTests : StreamTestBase, ITestChainProvider
             = observer.Results;
 
         // time-series, for comparison
-        List<SmaResult> seriesList = quotesList
+        var seriesList = quotesList
             .GetAdl()
-            .GetSma(smaPeriods)
-            .ToList();
+            .GetSma(smaPeriods);
 
         // assert, should equal series
         for (int i = 0; i < length - 1; i++)

--- a/tests/indicators/a-d/Adx/Adx.Tests.cs
+++ b/tests/indicators/a-d/Adx/Adx.Tests.cs
@@ -6,9 +6,7 @@ public class AdxTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<AdxResult> results = Quotes
-            .GetAdx()
-            .ToList();
+        IReadOnlyList<AdxResult> results = Quotes.GetAdx();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -47,10 +45,9 @@ public class AdxTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetAdx()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(466, results.Count(x => x.Sma != null));
@@ -59,9 +56,7 @@ public class AdxTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<AdxResult> r = BadQuotes
-            .GetAdx(20)
-            .ToList();
+        IReadOnlyList<AdxResult> r = BadQuotes.GetAdx(20);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Adx is double.NaN));
@@ -70,9 +65,7 @@ public class AdxTests : SeriesTestBase
     [TestMethod]
     public void BigData()
     {
-        List<AdxResult> r = BigQuotes
-            .GetAdx(200)
-            .ToList();
+        IReadOnlyList<AdxResult> r = BigQuotes.GetAdx(200);
 
         Assert.AreEqual(1246, r.Count);
     }
@@ -80,15 +73,11 @@ public class AdxTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<AdxResult> r0 = Noquotes
-            .GetAdx(5)
-            .ToList();
+        IReadOnlyList<AdxResult> r0 = Noquotes.GetAdx(5);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<AdxResult> r1 = Onequote
-            .GetAdx(5)
-            .ToList();
+        IReadOnlyList<AdxResult> r1 = Onequote.GetAdx(5);
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -101,7 +90,7 @@ public class AdxTests : SeriesTestBase
             .Select(Imports.QuoteFromCsv)
             .OrderByDescending(x => x.Timestamp);
 
-        List<AdxResult> r = test859.GetAdx().ToList();
+        IReadOnlyList<AdxResult> r = test859.GetAdx();
 
         Assert.AreEqual(0, r.Count(x => x.Adx is double.NaN));
         Assert.AreEqual(595, r.Count);
@@ -110,7 +99,7 @@ public class AdxTests : SeriesTestBase
     [TestMethod]
     public void Zeroes()
     {
-        List<AdxResult> r = ZeroesQuotes.GetAdx().ToList();
+        IReadOnlyList<AdxResult> r = ZeroesQuotes.GetAdx();
 
         Assert.AreEqual(0, r.Count(x => x.Adx is double.NaN));
         Assert.AreEqual(200, r.Count);
@@ -119,14 +108,14 @@ public class AdxTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<AdxResult> r = Quotes.GetAdx()
-            .RemoveWarmupPeriods()
-            .ToList();
+        IReadOnlyList<AdxResult> results = Quotes
+            .GetAdx()
+            .RemoveWarmupPeriods();
 
         // assertions
-        Assert.AreEqual(502 - (2 * 14 + 100), r.Count);
+        Assert.AreEqual(502 - ((2 * 14) + 100), results.Count);
 
-        AdxResult last = r.LastOrDefault();
+        AdxResult last = results[^1];
         Assert.AreEqual(17.7565, last.Pdi.Round(4));
         Assert.AreEqual(31.1510, last.Mdi.Round(4));
         Assert.AreEqual(34.2987, last.Adx.Round(4));

--- a/tests/indicators/a-d/Alligator/Alligator.Series.Tests.cs
+++ b/tests/indicators/a-d/Alligator/Alligator.Series.Tests.cs
@@ -6,9 +6,8 @@ public class AlligatorTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<AlligatorResult> results = Quotes
-            .GetAlligator()
-            .ToList();
+        IReadOnlyList<AlligatorResult> results = Quotes
+            .GetAlligator();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -46,10 +45,9 @@ public class AlligatorTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<AlligatorResult> results = Quotes
+        IReadOnlyList<AlligatorResult> results = Quotes
             .GetSma(2)
-            .GetAlligator()
-            .ToList();
+            .GetAlligator();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(481, results.Count(x => x.Jaw != null));
@@ -58,9 +56,8 @@ public class AlligatorTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<AlligatorResult> r = BadQuotes
-            .GetAlligator(3, 3, 2, 1, 1, 1)
-            .ToList();
+        IReadOnlyList<AlligatorResult> r = BadQuotes
+            .GetAlligator(3, 3, 2, 1, 1, 1);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Jaw is double.NaN));
@@ -69,15 +66,13 @@ public class AlligatorTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<AlligatorResult> r0 = Noquotes
-            .GetAlligator()
-            .ToList();
+        IReadOnlyList<AlligatorResult> r0 = Noquotes
+            .GetAlligator();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<AlligatorResult> r1 = Onequote
-            .GetAlligator()
-            .ToList();
+        IReadOnlyList<AlligatorResult> r1 = Onequote
+            .GetAlligator();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -85,14 +80,13 @@ public class AlligatorTests : SeriesTestBase
     [TestMethod]
     public void Condense()
     {
-        List<AlligatorResult> r = Quotes
+        IReadOnlyList<AlligatorResult> results = Quotes
             .GetAlligator()
-            .Condense()
-            .ToList();
+            .Condense();
 
-        Assert.AreEqual(495, r.Count);
+        Assert.AreEqual(495, results.Count);
 
-        AlligatorResult last = r.LastOrDefault();
+        AlligatorResult last = results[^1];
         Assert.AreEqual(260.98953, last.Jaw.Round(5));
         Assert.AreEqual(253.53576, last.Teeth.Round(5));
         Assert.AreEqual(244.29591, last.Lips.Round(5));
@@ -101,14 +95,13 @@ public class AlligatorTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<AlligatorResult> r = Quotes
+        IReadOnlyList<AlligatorResult> results = Quotes
             .GetAlligator()
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
-        Assert.AreEqual(502 - 21 - 250, r.Count);
+        Assert.AreEqual(502 - 21 - 250, results.Count);
 
-        AlligatorResult last = r.LastOrDefault();
+        AlligatorResult last = results[^1];
         Assert.AreEqual(260.98953, last.Jaw.Round(5));
         Assert.AreEqual(253.53576, last.Teeth.Round(5));
         Assert.AreEqual(244.29591, last.Lips.Round(5));

--- a/tests/indicators/a-d/Alligator/Alligator.Stream.Tests.cs
+++ b/tests/indicators/a-d/Alligator/Alligator.Stream.Tests.cs
@@ -55,10 +55,9 @@ public class AlligatorTests : StreamTestBase, ITestChainObserver
         quotesList.RemoveAt(400);
 
         // time-series, for comparison
-        List<AlligatorResult> seriesList
+        var seriesList
            = quotesList
-            .GetAlligator()
-            .ToList();
+            .GetAlligator();
 
         // assert, should equal series
         for (int i = 0; i < length - 1; i++)
@@ -127,11 +126,10 @@ public class AlligatorTests : StreamTestBase, ITestChainObserver
             = observer.Results;
 
         // time-series, for comparison
-        List<AlligatorResult> seriesList
+        var seriesList
            = quotesList
             .GetSma(10)
-            .GetAlligator()
-            .ToList();
+            .GetAlligator();
 
         // assert, should equal series
         for (int i = 0; i < length - 1; i++)

--- a/tests/indicators/a-d/Alma/Alma.Tests.cs
+++ b/tests/indicators/a-d/Alma/Alma.Tests.cs
@@ -10,9 +10,8 @@ public class Alma : SeriesTestBase
         double offset = 0.85;
         double sigma = 6;
 
-        List<AlmaResult> results = Quotes
-            .GetAlma(lookbackPeriods, offset, sigma)
-            .ToList();
+        IReadOnlyList<AlmaResult> results = Quotes
+            .GetAlma(lookbackPeriods, offset, sigma);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -41,25 +40,23 @@ public class Alma : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<AlmaResult> results = Quotes
+        IReadOnlyList<AlmaResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetAlma(10)
-            .ToList();
+            .GetAlma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(493, results.Count(x => x.Alma != null));
 
-        AlmaResult last = results.LastOrDefault();
+        AlmaResult last = results[^1];
         Assert.AreEqual(242.1871, last.Alma.Round(4));
     }
 
     [TestMethod]
     public void Chainee()
     {
-        List<AlmaResult> results = Quotes
+        IReadOnlyList<AlmaResult> results = Quotes
             .GetSma(2)
-            .GetAlma(10)
-            .ToList();
+            .GetAlma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(492, results.Count(x => x.Alma != null));
@@ -72,10 +69,9 @@ public class Alma : SeriesTestBase
         double offset = 0.85;
         double sigma = 6;
 
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetAlma(lookbackPeriods, offset, sigma)
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(484, results.Count(x => x.Sma != null));
@@ -84,11 +80,13 @@ public class Alma : SeriesTestBase
     [TestMethod]
     public void NaN()
     {
-        List<AlmaResult> r1 = Data.GetBtcUsdNan().GetAlma().ToList();
+        IReadOnlyList<AlmaResult> r1
+            = Data.GetBtcUsdNan().GetAlma();
 
         Assert.AreEqual(0, r1.Count(x => x.Alma is double.NaN));
 
-        List<AlmaResult> r2 = Data.GetBtcUsdNan().GetAlma(20).ToList();
+        IReadOnlyList<AlmaResult> r2
+            = Data.GetBtcUsdNan().GetAlma(20);
 
         Assert.AreEqual(0, r2.Count(x => x.Alma is double.NaN));
     }
@@ -96,9 +94,7 @@ public class Alma : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<AlmaResult> r = BadQuotes
-            .GetAlma(14, 0.5, 3)
-            .ToList();
+        IReadOnlyList<AlmaResult> r = BadQuotes.GetAlma(14, 0.5, 3);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Alma is double.NaN));
@@ -107,15 +103,11 @@ public class Alma : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<AlmaResult> r0 = Noquotes
-            .GetAlma()
-            .ToList();
+        IReadOnlyList<AlmaResult> r0 = Noquotes.GetAlma();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<AlmaResult> r1 = Onequote
-            .GetAlma()
-            .ToList();
+        IReadOnlyList<AlmaResult> r1 = Onequote.GetAlma();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -123,15 +115,14 @@ public class Alma : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<AlmaResult> results = Quotes
+        IReadOnlyList<AlmaResult> results = Quotes
             .GetAlma(10)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 9, results.Count);
 
-        AlmaResult last = results.LastOrDefault();
+        AlmaResult last = results[^1];
         Assert.AreEqual(242.1871, last.Alma.Round(4));
     }
 

--- a/tests/indicators/a-d/Aroon/Aroon.Tests.cs
+++ b/tests/indicators/a-d/Aroon/Aroon.Tests.cs
@@ -6,9 +6,8 @@ public class Aroon : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<AroonResult> results = Quotes
-            .GetAroon()
-            .ToList();
+        IReadOnlyList<AroonResult> results = Quotes
+            .GetAroon();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -46,10 +45,9 @@ public class Aroon : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetAroon()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(468, results.Count(x => x.Sma != null));
@@ -58,9 +56,8 @@ public class Aroon : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<AroonResult> r = BadQuotes
-            .GetAroon(20)
-            .ToList();
+        IReadOnlyList<AroonResult> r = BadQuotes
+            .GetAroon(20);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Oscillator is double.NaN));
@@ -69,15 +66,13 @@ public class Aroon : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<AroonResult> r0 = Noquotes
-            .GetAroon()
-            .ToList();
+        IReadOnlyList<AroonResult> r0 = Noquotes
+            .GetAroon();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<AroonResult> r1 = Onequote
-            .GetAroon()
-            .ToList();
+        IReadOnlyList<AroonResult> r1 = Onequote
+            .GetAroon();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -85,15 +80,14 @@ public class Aroon : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<AroonResult> results = Quotes
+        IReadOnlyList<AroonResult> results = Quotes
             .GetAroon()
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 25, results.Count);
 
-        AroonResult last = results.LastOrDefault();
+        AroonResult last = results[^1];
         Assert.AreEqual(28, last.AroonUp);
         Assert.AreEqual(88, last.AroonDown);
         Assert.AreEqual(-60, last.Oscillator);

--- a/tests/indicators/a-d/Atr/Atr.Tests.cs
+++ b/tests/indicators/a-d/Atr/Atr.Tests.cs
@@ -6,9 +6,8 @@ public class AtrTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<AtrResult> results = Quotes
-            .GetAtr()
-            .ToList();
+        IReadOnlyList<AtrResult> results = Quotes
+            .GetAtr();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -44,10 +43,9 @@ public class AtrTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetAtr(10)
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(502 - 19, results.Count(x => x.Sma != null));
@@ -56,9 +54,8 @@ public class AtrTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<AtrResult> r = BadQuotes
-            .GetAtr(20)
-            .ToList();
+        IReadOnlyList<AtrResult> r = BadQuotes
+            .GetAtr(20);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Atr is double.NaN));
@@ -67,15 +64,13 @@ public class AtrTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<AtrResult> r0 = Noquotes
-            .GetAtr()
-            .ToList();
+        IReadOnlyList<AtrResult> r0 = Noquotes
+            .GetAtr();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<AtrResult> r1 = Onequote
-            .GetAtr()
-            .ToList();
+        IReadOnlyList<AtrResult> r1 = Onequote
+            .GetAtr();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -83,15 +78,14 @@ public class AtrTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<AtrResult> results = Quotes
+        IReadOnlyList<AtrResult> results = Quotes
             .GetAtr()
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 14, results.Count);
 
-        AtrResult last = results.LastOrDefault();
+        AtrResult last = results[^1];
         Assert.AreEqual(2.67, last.Tr.Round(8));
         Assert.AreEqual(6.1497, last.Atr.Round(4));
         Assert.AreEqual(2.5072, last.Atrp.Round(4));

--- a/tests/indicators/a-d/AtrStop/AtrStop.Tests.cs
+++ b/tests/indicators/a-d/AtrStop/AtrStop.Tests.cs
@@ -9,9 +9,8 @@ public class AtrStopTests : SeriesTestBase
         int lookbackPeriods = 21;
         double multiplier = 3;
 
-        List<AtrStopResult> results = Quotes
-            .GetAtrStop(lookbackPeriods, multiplier)
-            .ToList();
+        IReadOnlyList<AtrStopResult> results = Quotes
+            .GetAtrStop(lookbackPeriods, multiplier);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -55,9 +54,8 @@ public class AtrStopTests : SeriesTestBase
         int lookbackPeriods = 21;
         double multiplier = 3;
 
-        List<AtrStopResult> results = Quotes
-            .GetAtrStop(lookbackPeriods, multiplier, EndType.HighLow)
-            .ToList();
+        IReadOnlyList<AtrStopResult> results = Quotes
+            .GetAtrStop(lookbackPeriods, multiplier, EndType.HighLow);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -98,9 +96,8 @@ public class AtrStopTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<AtrStopResult> r = BadQuotes
-            .GetAtrStop(7)
-            .ToList();
+        IReadOnlyList<AtrStopResult> r = BadQuotes
+            .GetAtrStop(7);
 
         Assert.AreEqual(502, r.Count);
     }
@@ -108,15 +105,13 @@ public class AtrStopTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<AtrStopResult> r0 = Noquotes
-            .GetAtrStop()
-            .ToList();
+        IReadOnlyList<AtrStopResult> r0 = Noquotes
+            .GetAtrStop();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<AtrStopResult> r1 = Onequote
-            .GetAtrStop()
-            .ToList();
+        IReadOnlyList<AtrStopResult> r1 = Onequote
+            .GetAtrStop();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -127,15 +122,14 @@ public class AtrStopTests : SeriesTestBase
         int lookbackPeriods = 21;
         double multiplier = 3;
 
-        List<AtrStopResult> results =
-            Quotes.GetAtrStop(lookbackPeriods, multiplier)
-             .Condense()
-             .ToList();
+        IReadOnlyList<AtrStopResult> results = Quotes
+            .GetAtrStop(lookbackPeriods, multiplier)
+            .Condense();
 
         // assertions
         Assert.AreEqual(481, results.Count);
 
-        AtrStopResult last = results.LastOrDefault();
+        AtrStopResult last = results[^1];
         Assert.AreEqual(246.3232m, last.AtrStop.Round(4));
         Assert.AreEqual(last.AtrStop, last.BuyStop);
         Assert.AreEqual(null, last.SellStop);
@@ -147,15 +141,14 @@ public class AtrStopTests : SeriesTestBase
         int lookbackPeriods = 21;
         double multiplier = 3;
 
-        List<AtrStopResult> results =
-            Quotes.GetAtrStop(lookbackPeriods, multiplier)
-             .RemoveWarmupPeriods()
-             .ToList();
+        IReadOnlyList<AtrStopResult> results = Quotes
+            .GetAtrStop(lookbackPeriods, multiplier)
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(481, results.Count);
 
-        AtrStopResult last = results.LastOrDefault();
+        AtrStopResult last = results[^1];
         Assert.AreEqual(246.3232m, last.AtrStop.Round(4));
         Assert.AreEqual(last.AtrStop, last.BuyStop);
         Assert.AreEqual(null, last.SellStop);

--- a/tests/indicators/a-d/Awesome/Awesome.Tests.cs
+++ b/tests/indicators/a-d/Awesome/Awesome.Tests.cs
@@ -6,9 +6,8 @@ public class AwesomeTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<AwesomeResult> results = Quotes
-            .GetAwesome()
-            .ToList();
+        IReadOnlyList<AwesomeResult> results = Quotes
+            .GetAwesome();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -35,10 +34,9 @@ public class AwesomeTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<AwesomeResult> results = Quotes
+        IReadOnlyList<AwesomeResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetAwesome()
-            .ToList();
+            .GetAwesome();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(469, results.Count(x => x.Oscillator != null));
@@ -47,10 +45,9 @@ public class AwesomeTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<AwesomeResult> results = Quotes
+        IReadOnlyList<AwesomeResult> results = Quotes
             .GetSma(2)
-            .GetAwesome()
-            .ToList();
+            .GetAwesome();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(468, results.Count(x => x.Oscillator != null));
@@ -59,10 +56,9 @@ public class AwesomeTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetAwesome()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(460, results.Count(x => x.Sma != null));
@@ -71,9 +67,8 @@ public class AwesomeTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<AwesomeResult> r = BadQuotes
-            .GetAwesome()
-            .ToList();
+        IReadOnlyList<AwesomeResult> r = BadQuotes
+            .GetAwesome();
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Oscillator is double.NaN));
@@ -82,15 +77,13 @@ public class AwesomeTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<AwesomeResult> r0 = Noquotes
-            .GetAwesome()
-            .ToList();
+        IReadOnlyList<AwesomeResult> r0 = Noquotes
+            .GetAwesome();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<AwesomeResult> r1 = Onequote
-            .GetAwesome()
-            .ToList();
+        IReadOnlyList<AwesomeResult> r1 = Onequote
+            .GetAwesome();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -98,15 +91,14 @@ public class AwesomeTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<AwesomeResult> results = Quotes
+        IReadOnlyList<AwesomeResult> results = Quotes
             .GetAwesome()
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 33, results.Count);
 
-        AwesomeResult last = results.LastOrDefault();
+        AwesomeResult last = results[^1];
         Assert.AreEqual(-17.7692, last.Oscillator.Round(4));
         Assert.AreEqual(-7.2763, last.Normalized.Round(4));
     }

--- a/tests/indicators/a-d/Beta/Beta.Tests.cs
+++ b/tests/indicators/a-d/Beta/Beta.Tests.cs
@@ -6,9 +6,8 @@ public class BetaTests : SeriesTestBase
     [TestMethod]
     public void All()
     {
-        List<BetaResult> results = OtherQuotes
-            .GetBeta(Quotes, 20, BetaType.All)
-            .ToList();
+        IReadOnlyList<BetaResult> results = OtherQuotes
+            .GetBeta(Quotes, 20, BetaType.All);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -51,9 +50,8 @@ public class BetaTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<BetaResult> results = OtherQuotes
-            .GetBeta(Quotes, 20)
-            .ToList();
+        IReadOnlyList<BetaResult> results = OtherQuotes
+            .GetBeta(Quotes, 20);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -67,9 +65,8 @@ public class BetaTests : SeriesTestBase
     [TestMethod]
     public void Up()
     {
-        List<BetaResult> results = OtherQuotes
-            .GetBeta(Quotes, 20, BetaType.Up)
-            .ToList();
+        IReadOnlyList<BetaResult> results = OtherQuotes
+            .GetBeta(Quotes, 20, BetaType.Up);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -83,9 +80,8 @@ public class BetaTests : SeriesTestBase
     [TestMethod]
     public void Down()
     {
-        List<BetaResult> results = OtherQuotes
-            .GetBeta(Quotes, 20, BetaType.Down)
-            .ToList();
+        IReadOnlyList<BetaResult> results = OtherQuotes
+            .GetBeta(Quotes, 20, BetaType.Down);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -99,10 +95,9 @@ public class BetaTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<BetaResult> results = OtherQuotes
+        IReadOnlyList<BetaResult> results = OtherQuotes
             .Use(CandlePart.Close)
-            .GetBeta(Quotes.Use(CandlePart.Close), 20)
-            .ToList();
+            .GetBeta(Quotes.Use(CandlePart.Close), 20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(482, results.Count(x => x.Beta != null));
@@ -111,10 +106,9 @@ public class BetaTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = OtherQuotes
+        IReadOnlyList<SmaResult> results = OtherQuotes
             .GetBeta(Quotes, 20)
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(473, results.Count(x => x.Sma != null));
@@ -123,10 +117,9 @@ public class BetaTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<BetaResult> results = Quotes
+        IReadOnlyList<BetaResult> results = Quotes
             .GetSma(2)
-            .GetBeta(OtherQuotes.GetSma(2), 20)
-            .ToList();
+            .GetBeta(OtherQuotes.GetSma(2), 20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(481, results.Count(x => x.Beta != null));
@@ -136,23 +129,20 @@ public class BetaTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<BetaResult> r1 = BadQuotes
-            .GetBeta(BadQuotes, 15)
-            .ToList();
+        IReadOnlyList<BetaResult> r1 = BadQuotes
+            .GetBeta(BadQuotes, 15);
 
         Assert.AreEqual(502, r1.Count);
         Assert.AreEqual(0, r1.Count(x => x.Beta is double.NaN));
 
-        List<BetaResult> r2 = BadQuotes
-            .GetBeta(BadQuotes, 15, BetaType.Up)
-            .ToList();
+        IReadOnlyList<BetaResult> r2 = BadQuotes
+            .GetBeta(BadQuotes, 15, BetaType.Up);
 
         Assert.AreEqual(502, r2.Count);
         Assert.AreEqual(0, r2.Count(x => x.BetaUp is double.NaN));
 
-        List<BetaResult> r3 = BadQuotes
-            .GetBeta(BadQuotes, 15, BetaType.Down)
-            .ToList();
+        IReadOnlyList<BetaResult> r3 = BadQuotes
+            .GetBeta(BadQuotes, 15, BetaType.Down);
 
         Assert.AreEqual(502, r3.Count);
         Assert.AreEqual(0, r3.Count(x => x.BetaDown is double.NaN));
@@ -161,9 +151,8 @@ public class BetaTests : SeriesTestBase
     [TestMethod]
     public void BigData()
     {
-        List<BetaResult> r = BigQuotes
-            .GetBeta(BigQuotes, 150, BetaType.All)
-            .ToList();
+        IReadOnlyList<BetaResult> r = BigQuotes
+            .GetBeta(BigQuotes, 150, BetaType.All);
 
         Assert.AreEqual(1246, r.Count);
     }
@@ -179,13 +168,12 @@ public class BetaTests : SeriesTestBase
           https://www.nasdaq.com/market-activity/stocks/msft
         */
 
-        List<Quote> evalQuotes = Data.GetMsft().ToList();
-        List<Quote> mktQuotes = Data.GetSpx().ToList();
+        IReadOnlyList<Quote> evalQuotes = Data.GetMsft();
+        IReadOnlyList<Quote> mktQuotes = Data.GetSpx();
 
-        List<BetaResult> results = evalQuotes.Aggregate(PeriodSize.Month)
-            .GetBeta(mktQuotes.Aggregate(PeriodSize.Month),
-                60)
-            .ToList();
+        IReadOnlyList<BetaResult> results = evalQuotes
+            .Aggregate(PeriodSize.Month)
+            .GetBeta(mktQuotes.Aggregate(PeriodSize.Month), 60);
 
         Assert.AreEqual(0.91, results[385].Beta.Round(2));
     }
@@ -193,15 +181,14 @@ public class BetaTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<BetaResult> results = OtherQuotes
+        IReadOnlyList<BetaResult> results = OtherQuotes
             .GetBeta(Quotes, 20)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 20, results.Count);
 
-        BetaResult last = results.LastOrDefault();
+        BetaResult last = results[^1];
         Assert.AreEqual(1.5123, last.Beta.Round(4));
     }
 
@@ -209,9 +196,8 @@ public class BetaTests : SeriesTestBase
     public void SameSame()
     {
         // Beta should be 1 if evaluating against self
-        List<BetaResult> results = Quotes
-            .GetBeta(Quotes, 20)
-            .ToList();
+        IReadOnlyList<BetaResult> results = Quotes
+            .GetBeta(Quotes, 20);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -225,20 +211,21 @@ public class BetaTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<BetaResult> r0 = Noquotes
-            .GetBeta(Noquotes, 5)
-            .ToList();
+        IReadOnlyList<BetaResult> r0 = Noquotes
+            .GetBeta(Noquotes, 5);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<BetaResult> r1 = Onequote.GetBeta(Onequote, 5).ToList();
+        IReadOnlyList<BetaResult> r1 = Onequote
+            .GetBeta(Onequote, 5);
+
         Assert.AreEqual(1, r1.Count);
     }
 
     [TestMethod]
     public void NoMatch()
     {
-        List<Quote> quoteA =
+        IReadOnlyList<Quote> quoteA =
         [
             new(DateTime.Parse("1/1/2020", englishCulture), 0, 0, 0, 1234, 0),
             new(DateTime.Parse("1/2/2020", englishCulture), 0, 0, 0, 1234, 0),
@@ -251,7 +238,7 @@ public class BetaTests : SeriesTestBase
             new(DateTime.Parse("1/9/2020", englishCulture), 0, 0, 0, 1234, 0)
         ];
 
-        List<Quote> quoteB =
+        IReadOnlyList<Quote> quoteB =
         [
             new(DateTime.Parse("1/1/2020", englishCulture), 0, 0, 0, 1234, 0),
             new(DateTime.Parse("1/2/2020", englishCulture), 0, 0, 0, 1234, 0),
@@ -276,7 +263,7 @@ public class BetaTests : SeriesTestBase
             => Quotes.GetBeta(OtherQuotes, 0));
 
         // bad evaluation quotes
-        List<Quote> eval = Data.GetCompare(300).ToList();
+        IReadOnlyList<Quote> eval = Data.GetCompare(300).ToList();
 
         Assert.ThrowsException<InvalidQuotesException>(()
             => Quotes.GetBeta(eval, 30));

--- a/tests/indicators/a-d/BollingerBands/BollingerBands.Tests.cs
+++ b/tests/indicators/a-d/BollingerBands/BollingerBands.Tests.cs
@@ -6,9 +6,8 @@ public class BollingerBandsTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<BollingerBandsResult> results =
-            Quotes.GetBollingerBands()
-            .ToList();
+        IReadOnlyList<BollingerBandsResult> results =
+            Quotes.GetBollingerBands();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -40,10 +39,9 @@ public class BollingerBandsTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<BollingerBandsResult> results = Quotes
+        IReadOnlyList<BollingerBandsResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetBollingerBands()
-            .ToList();
+            .GetBollingerBands();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(483, results.Count(x => x.Sma != null));
@@ -52,10 +50,9 @@ public class BollingerBandsTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<BollingerBandsResult> results = Quotes
+        IReadOnlyList<BollingerBandsResult> results = Quotes
             .GetSma(2)
-            .GetBollingerBands()
-            .ToList();
+            .GetBollingerBands();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(482, results.Count(x => x.UpperBand != null));
@@ -64,10 +61,9 @@ public class BollingerBandsTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetBollingerBands()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(474, results.Count(x => x.Sma != null));
@@ -76,9 +72,8 @@ public class BollingerBandsTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<BollingerBandsResult> r = BadQuotes
-            .GetBollingerBands(15, 3)
-            .ToList();
+        IReadOnlyList<BollingerBandsResult> r = BadQuotes
+            .GetBollingerBands(15, 3);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.UpperBand is double.NaN));
@@ -87,15 +82,13 @@ public class BollingerBandsTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<BollingerBandsResult> r0 = Noquotes
-            .GetBollingerBands()
-            .ToList();
+        IReadOnlyList<BollingerBandsResult> r0 = Noquotes
+            .GetBollingerBands();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<BollingerBandsResult> r1 = Onequote
-            .GetBollingerBands()
-            .ToList();
+        IReadOnlyList<BollingerBandsResult> r1 = Onequote
+            .GetBollingerBands();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -103,15 +96,14 @@ public class BollingerBandsTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<BollingerBandsResult> results =
-            Quotes.GetBollingerBands()
-                .RemoveWarmupPeriods()
-                .ToList();
+        IReadOnlyList<BollingerBandsResult> results = Quotes
+            .GetBollingerBands()
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 19, results.Count);
 
-        BollingerBandsResult last = results.LastOrDefault();
+        BollingerBandsResult last = results[^1];
         Assert.AreEqual(251.8600, last.Sma.Round(4));
         Assert.AreEqual(273.7004, last.UpperBand.Round(4));
         Assert.AreEqual(230.0196, last.LowerBand.Round(4));

--- a/tests/indicators/a-d/Bop/Bop.Tests.cs
+++ b/tests/indicators/a-d/Bop/Bop.Tests.cs
@@ -6,9 +6,8 @@ public class BopTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<BopResult> results = Quotes
-            .GetBop()
-            .ToList();
+        IReadOnlyList<BopResult> results = Quotes
+            .GetBop();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -34,10 +33,9 @@ public class BopTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetBop()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(480, results.Count(x => x.Sma != null));
@@ -55,9 +53,8 @@ public class BopTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<BopResult> r = BadQuotes
-            .GetBop()
-            .ToList();
+        IReadOnlyList<BopResult> r = BadQuotes
+            .GetBop();
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Bop is double.NaN));
@@ -66,29 +63,26 @@ public class BopTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<BopResult> r0 = Noquotes
-            .GetBop()
-            .ToList();
+        IReadOnlyList<BopResult> r0 = Noquotes
+            .GetBop();
         Assert.AreEqual(0, r0.Count);
 
-        List<BopResult> r1 = Onequote
-            .GetBop()
-            .ToList();
+        IReadOnlyList<BopResult> r1 = Onequote
+            .GetBop();
         Assert.AreEqual(1, r1.Count);
     }
 
     [TestMethod]
     public void Removed()
     {
-        List<BopResult> results = Quotes
+        IReadOnlyList<BopResult> results = Quotes
             .GetBop()
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 13, results.Count);
 
-        BopResult last = results.LastOrDefault();
+        BopResult last = results[^1];
         Assert.AreEqual(-0.292788, last.Bop.Round(6));
     }
 

--- a/tests/indicators/a-d/Cci/Cci.Tests.cs
+++ b/tests/indicators/a-d/Cci/Cci.Tests.cs
@@ -6,9 +6,8 @@ public class CciTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<CciResult> results = Quotes
-            .GetCci()
-            .ToList();
+        IReadOnlyList<CciResult> results = Quotes
+            .GetCci();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -22,10 +21,9 @@ public class CciTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetCci()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(474, results.Count(x => x.Sma != null));
@@ -34,9 +32,8 @@ public class CciTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<CciResult> r = BadQuotes
-            .GetCci(15)
-            .ToList();
+        IReadOnlyList<CciResult> r = BadQuotes
+            .GetCci(15);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Cci is double.NaN));
@@ -45,15 +42,13 @@ public class CciTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<CciResult> r0 = Noquotes
-            .GetCci()
-            .ToList();
+        IReadOnlyList<CciResult> r0 = Noquotes
+            .GetCci();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<CciResult> r1 = Onequote
-            .GetCci()
-            .ToList();
+        IReadOnlyList<CciResult> r1 = Onequote
+            .GetCci();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -61,15 +56,14 @@ public class CciTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<CciResult> results = Quotes
+        IReadOnlyList<CciResult> results = Quotes
             .GetCci()
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 19, results.Count);
 
-        CciResult last = results.LastOrDefault();
+        CciResult last = results[^1];
         Assert.AreEqual(-52.9946, last.Cci.Round(4));
     }
 

--- a/tests/indicators/a-d/ChaikinOsc/ChaikinOsc.Tests.cs
+++ b/tests/indicators/a-d/ChaikinOsc/ChaikinOsc.Tests.cs
@@ -9,9 +9,8 @@ public class ChaikinOscTests : SeriesTestBase
         int fastPeriods = 3;
         int slowPeriods = 10;
 
-        List<ChaikinOscResult> results = Quotes
-            .GetChaikinOsc(fastPeriods, slowPeriods)
-            .ToList();
+        IReadOnlyList<ChaikinOscResult> results = Quotes
+            .GetChaikinOsc(fastPeriods, slowPeriods);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -28,10 +27,9 @@ public class ChaikinOscTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetChaikinOsc()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(484, results.Count(x => x.Sma != null));
@@ -40,9 +38,8 @@ public class ChaikinOscTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<ChaikinOscResult> r = BadQuotes
-            .GetChaikinOsc(5, 15)
-            .ToList();
+        IReadOnlyList<ChaikinOscResult> r = BadQuotes
+            .GetChaikinOsc(5, 15);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Oscillator is double.NaN));
@@ -51,15 +48,13 @@ public class ChaikinOscTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<ChaikinOscResult> r0 = Noquotes
-            .GetChaikinOsc()
-            .ToList();
+        IReadOnlyList<ChaikinOscResult> r0 = Noquotes
+            .GetChaikinOsc();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<ChaikinOscResult> r1 = Onequote
-            .GetChaikinOsc()
-            .ToList();
+        IReadOnlyList<ChaikinOscResult> r1 = Onequote
+            .GetChaikinOsc();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -70,15 +65,14 @@ public class ChaikinOscTests : SeriesTestBase
         int fastPeriods = 3;
         int slowPeriods = 10;
 
-        List<ChaikinOscResult> results = Quotes
+        IReadOnlyList<ChaikinOscResult> results = Quotes
             .GetChaikinOsc(fastPeriods, slowPeriods)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - (slowPeriods + 100), results.Count);
 
-        ChaikinOscResult last = results.LastOrDefault();
+        ChaikinOscResult last = results[^1];
         Assert.AreEqual(3439986548.42, last.Adl.Round(2));
         Assert.AreEqual(0.8052, last.MoneyFlowMultiplier.Round(4));
         Assert.AreEqual(118396116.25, last.MoneyFlowVolume.Round(2));

--- a/tests/indicators/a-d/Chandelier/Chandelier.Tests.cs
+++ b/tests/indicators/a-d/Chandelier/Chandelier.Tests.cs
@@ -8,9 +8,8 @@ public class ChandelierTests : SeriesTestBase
     {
         int lookbackPeriods = 22;
 
-        List<ChandelierResult> longResult =
-            Quotes.GetChandelier(lookbackPeriods)
-            .ToList();
+        IReadOnlyList<ChandelierResult> longResult =
+            Quotes.GetChandelier(lookbackPeriods);
 
         // proper quantities
         Assert.AreEqual(502, longResult.Count);
@@ -24,9 +23,8 @@ public class ChandelierTests : SeriesTestBase
         Assert.AreEqual(259.0480, b.ChandelierExit.Round(4));
 
         // short
-        List<ChandelierResult> shortResult =
-            Quotes.GetChandelier(lookbackPeriods, 3, ChandelierType.Short)
-            .ToList();
+        IReadOnlyList<ChandelierResult> shortResult =
+            Quotes.GetChandelier(lookbackPeriods, 3, ChandelierType.Short);
 
         ChandelierResult c = shortResult[501];
         Assert.AreEqual(246.4240, c.ChandelierExit.Round(4));
@@ -35,10 +33,9 @@ public class ChandelierTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetChandelier()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(471, results.Count(x => x.Sma != null));
@@ -47,9 +44,8 @@ public class ChandelierTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<ChandelierResult> r = BadQuotes
-            .GetChandelier(15, 2)
-            .ToList();
+        IReadOnlyList<ChandelierResult> r = BadQuotes
+            .GetChandelier(15, 2);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.ChandelierExit is double.NaN));
@@ -58,15 +54,13 @@ public class ChandelierTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<ChandelierResult> r0 = Noquotes
-            .GetChandelier()
-            .ToList();
+        IReadOnlyList<ChandelierResult> r0 = Noquotes
+            .GetChandelier();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<ChandelierResult> r1 = Onequote
-            .GetChandelier()
-            .ToList();
+        IReadOnlyList<ChandelierResult> r1 = Onequote
+            .GetChandelier();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -74,15 +68,14 @@ public class ChandelierTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<ChandelierResult> longResult = Quotes
+        IReadOnlyList<ChandelierResult> results = Quotes
             .GetChandelier()
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
-        Assert.AreEqual(502 - 22, longResult.Count);
+        Assert.AreEqual(502 - 22, results.Count);
 
-        ChandelierResult last = longResult.LastOrDefault();
+        ChandelierResult last = results[^1];
         Assert.AreEqual(256.5860, last.ChandelierExit.Round(4));
     }
 

--- a/tests/indicators/a-d/Chop/Chop.Tests.cs
+++ b/tests/indicators/a-d/Chop/Chop.Tests.cs
@@ -6,9 +6,8 @@ public class ChopTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<ChopResult> results = Quotes
-            .GetChop()
-            .ToList();
+        IReadOnlyList<ChopResult> results = Quotes
+            .GetChop();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -31,10 +30,9 @@ public class ChopTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetChop()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(479, results.Count(x => x.Sma != null));
@@ -44,9 +42,8 @@ public class ChopTests : SeriesTestBase
     public void SmallLookback()
     {
         int lookbackPeriods = 2;
-        List<ChopResult> results = Quotes
-            .GetChop(lookbackPeriods)
-            .ToList();
+        IReadOnlyList<ChopResult> results = Quotes
+            .GetChop(lookbackPeriods);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -56,9 +53,8 @@ public class ChopTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<ChopResult> r = BadQuotes
-            .GetChop(20)
-            .ToList();
+        IReadOnlyList<ChopResult> r = BadQuotes
+            .GetChop(20);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Chop is double.NaN));
@@ -67,15 +63,13 @@ public class ChopTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<ChopResult> r0 = Noquotes
-            .GetChop()
-            .ToList();
+        IReadOnlyList<ChopResult> r0 = Noquotes
+            .GetChop();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<ChopResult> r1 = Onequote
-            .GetChop()
-            .ToList();
+        IReadOnlyList<ChopResult> r1 = Onequote
+            .GetChop();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -83,15 +77,14 @@ public class ChopTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<ChopResult> results = Quotes
+        IReadOnlyList<ChopResult> results = Quotes
             .GetChop()
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 14, results.Count);
 
-        ChopResult last = results.LastOrDefault();
+        ChopResult last = results[^1];
         Assert.AreEqual(38.6526, last.Chop.Round(4));
     }
 

--- a/tests/indicators/a-d/Cmf/Cmf.Tests.cs
+++ b/tests/indicators/a-d/Cmf/Cmf.Tests.cs
@@ -6,9 +6,8 @@ public class CmfTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<CmfResult> results = Quotes
-            .GetCmf()
-            .ToList();
+        IReadOnlyList<CmfResult> results = Quotes
+            .GetCmf();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -34,10 +33,9 @@ public class CmfTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetCmf()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(474, results.Count(x => x.Sma != null));
@@ -46,9 +44,8 @@ public class CmfTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<CmfResult> r = BadQuotes
-            .GetCmf(15)
-            .ToList();
+        IReadOnlyList<CmfResult> r = BadQuotes
+            .GetCmf(15);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Cmf is double.NaN));
@@ -57,9 +54,8 @@ public class CmfTests : SeriesTestBase
     [TestMethod]
     public void BigData()
     {
-        List<CmfResult> r = BigQuotes
-            .GetCmf(150)
-            .ToList();
+        IReadOnlyList<CmfResult> r = BigQuotes
+            .GetCmf(150);
 
         Assert.AreEqual(1246, r.Count);
     }
@@ -67,15 +63,13 @@ public class CmfTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<CmfResult> r0 = Noquotes
-            .GetCmf()
-            .ToList();
+        IReadOnlyList<CmfResult> r0 = Noquotes
+            .GetCmf();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<CmfResult> r1 = Onequote
-            .GetCmf()
-            .ToList();
+        IReadOnlyList<CmfResult> r1 = Onequote
+            .GetCmf();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -83,15 +77,14 @@ public class CmfTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<CmfResult> results = Quotes
+        IReadOnlyList<CmfResult> results = Quotes
             .GetCmf()
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 19, results.Count);
 
-        CmfResult last = results.LastOrDefault();
+        CmfResult last = results[^1];
         Assert.AreEqual(0.8052, last.MoneyFlowMultiplier.Round(4));
         Assert.AreEqual(118396116.25, last.MoneyFlowVolume.Round(2));
         Assert.AreEqual(-0.123754, last.Cmf.Round(6));

--- a/tests/indicators/a-d/Cmo/Cmo.Tests.cs
+++ b/tests/indicators/a-d/Cmo/Cmo.Tests.cs
@@ -6,9 +6,8 @@ public class CmoTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<CmoResult> results = Quotes
-            .GetCmo(14)
-            .ToList();
+        IReadOnlyList<CmoResult> results = Quotes
+            .GetCmo(14);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -31,10 +30,9 @@ public class CmoTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<CmoResult> results = Quotes
+        IReadOnlyList<CmoResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetCmo(14)
-            .ToList();
+            .GetCmo(14);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(488, results.Count(x => x.Cmo != null));
@@ -43,10 +41,9 @@ public class CmoTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<CmoResult> results = Quotes
+        IReadOnlyList<CmoResult> results = Quotes
             .GetSma(2)
-            .GetCmo(20)
-            .ToList();
+            .GetCmo(20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(481, results.Count(x => x.Cmo != null));
@@ -55,10 +52,9 @@ public class CmoTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetCmo(20)
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(473, results.Count(x => x.Sma != null));
@@ -67,9 +63,8 @@ public class CmoTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<CmoResult> r = BadQuotes
-            .GetCmo(35)
-            .ToList();
+        IReadOnlyList<CmoResult> r = BadQuotes
+            .GetCmo(35);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Cmo is double.NaN));
@@ -78,15 +73,13 @@ public class CmoTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<CmoResult> r0 = Noquotes
-            .GetCmo(5)
-            .ToList();
+        IReadOnlyList<CmoResult> r0 = Noquotes
+            .GetCmo(5);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<CmoResult> r1 = Onequote
-            .GetCmo(5)
-            .ToList();
+        IReadOnlyList<CmoResult> r1 = Onequote
+            .GetCmo(5);
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -94,15 +87,14 @@ public class CmoTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<CmoResult> results = Quotes
+        IReadOnlyList<CmoResult> results = Quotes
             .GetCmo(14)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(488, results.Count);
 
-        CmoResult last = results.LastOrDefault();
+        CmoResult last = results[^1];
         Assert.AreEqual(-26.7502, last.Cmo.Round(4));
     }
 

--- a/tests/indicators/a-d/ConnorsRsi/ConnorsRsi.Tests.cs
+++ b/tests/indicators/a-d/ConnorsRsi/ConnorsRsi.Tests.cs
@@ -11,9 +11,8 @@ public class ConnorsRsiTests : SeriesTestBase
         int rankPeriods = 100;
         int startPeriod = Math.Max(rsiPeriods, Math.Max(streakPeriods, rankPeriods)) + 2;
 
-        List<ConnorsRsiResult> results1 = Quotes
-            .GetConnorsRsi(rsiPeriods, streakPeriods, rankPeriods)
-            .ToList();
+        IReadOnlyList<ConnorsRsiResult> results1 = Quotes
+            .GetConnorsRsi(rsiPeriods, streakPeriods, rankPeriods);
 
         // proper quantities
         Assert.AreEqual(502, results1.Count);
@@ -27,7 +26,7 @@ public class ConnorsRsiTests : SeriesTestBase
         Assert.AreEqual(74.7662, r1.ConnorsRsi.Round(4));
 
         // different parameters
-        List<ConnorsRsiResult> results2 = Quotes.GetConnorsRsi(14, 20, 10).ToList();
+        IReadOnlyList<ConnorsRsiResult> results2 = Quotes.GetConnorsRsi(14, 20, 10).ToList();
         ConnorsRsiResult r2 = results2[501];
         Assert.AreEqual(42.0773, r2.Rsi.Round(4));
         Assert.AreEqual(52.7386, r2.RsiStreak.Round(4));
@@ -38,10 +37,9 @@ public class ConnorsRsiTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<ConnorsRsiResult> results = Quotes
+        IReadOnlyList<ConnorsRsiResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetConnorsRsi()
-            .ToList();
+            .GetConnorsRsi();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(401, results.Count(x => x.ConnorsRsi != null));
@@ -50,10 +48,9 @@ public class ConnorsRsiTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<ConnorsRsiResult> results = Quotes
+        IReadOnlyList<ConnorsRsiResult> results = Quotes
             .GetSma(2)
-            .GetConnorsRsi()
-            .ToList();
+            .GetConnorsRsi();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(400, results.Count(x => x.ConnorsRsi != null));
@@ -62,10 +59,9 @@ public class ConnorsRsiTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetConnorsRsi()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(392, results.Count(x => x.Sma != null));
@@ -74,9 +70,8 @@ public class ConnorsRsiTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<ConnorsRsiResult> r = BadQuotes
-            .GetConnorsRsi(4, 3, 25)
-            .ToList();
+        IReadOnlyList<ConnorsRsiResult> r = BadQuotes
+            .GetConnorsRsi(4, 3, 25);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Rsi is double.NaN));
@@ -85,15 +80,13 @@ public class ConnorsRsiTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<ConnorsRsiResult> r0 = Noquotes
-            .GetConnorsRsi()
-            .ToList();
+        IReadOnlyList<ConnorsRsiResult> r0 = Noquotes
+            .GetConnorsRsi();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<ConnorsRsiResult> r1 = Onequote
-            .GetConnorsRsi()
-            .ToList();
+        IReadOnlyList<ConnorsRsiResult> r1 = Onequote
+            .GetConnorsRsi();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -108,15 +101,14 @@ public class ConnorsRsiTests : SeriesTestBase
         // TODO: I don't think this is right, inconsistent
         int removePeriods = Math.Max(rsiPeriods, Math.Max(streakPeriods, rankPeriods)) + 2;
 
-        List<ConnorsRsiResult> results =
-            Quotes.GetConnorsRsi(rsiPeriods, streakPeriods, rankPeriods)
-            .RemoveWarmupPeriods()
-            .ToList();
+        IReadOnlyList<ConnorsRsiResult> results = Quotes
+            .GetConnorsRsi(rsiPeriods, streakPeriods, rankPeriods)
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - removePeriods + 1, results.Count);
 
-        ConnorsRsiResult last = results.LastOrDefault();
+        ConnorsRsiResult last = results[^1];
         Assert.AreEqual(68.8087, last.Rsi.Round(4));
         Assert.AreEqual(67.4899, last.RsiStreak.Round(4));
         Assert.AreEqual(88.0000, last.PercentRank.Round(4));

--- a/tests/indicators/a-d/Correlation/Correlation.Tests.cs
+++ b/tests/indicators/a-d/Correlation/Correlation.Tests.cs
@@ -6,9 +6,8 @@ public class CorrelationTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<CorrResult> results = Quotes
-            .GetCorrelation(OtherQuotes, 20)
-            .ToList();
+        IReadOnlyList<CorrResult> results = Quotes
+            .GetCorrelation(OtherQuotes, 20);
 
         // proper quantities
         // should always be the same number of results as there is quotes
@@ -36,10 +35,9 @@ public class CorrelationTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<CorrResult> results = Quotes
+        IReadOnlyList<CorrResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetCorrelation(OtherQuotes.Use(CandlePart.Close), 20)
-            .ToList();
+            .GetCorrelation(OtherQuotes.Use(CandlePart.Close), 20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(483, results.Count(x => x.Correlation != null));
@@ -48,10 +46,9 @@ public class CorrelationTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetCorrelation(OtherQuotes, 20)
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(474, results.Count(x => x.Sma != null));
@@ -60,10 +57,9 @@ public class CorrelationTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<CorrResult> results = Quotes
+        IReadOnlyList<CorrResult> results = Quotes
             .GetSma(2)
-            .GetCorrelation(OtherQuotes.GetSma(2), 20)
-            .ToList();
+            .GetCorrelation(OtherQuotes.GetSma(2), 20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(482, results.Count(x => x.Correlation != null));
@@ -73,9 +69,8 @@ public class CorrelationTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<CorrResult> r = BadQuotes
-            .GetCorrelation(BadQuotes, 15)
-            .ToList();
+        IReadOnlyList<CorrResult> r = BadQuotes
+            .GetCorrelation(BadQuotes, 15);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Correlation is double.NaN));
@@ -84,9 +79,8 @@ public class CorrelationTests : SeriesTestBase
     [TestMethod]
     public void BigData()
     {
-        List<CorrResult> r = BigQuotes
-            .GetCorrelation(BigQuotes, 150)
-            .ToList();
+        IReadOnlyList<CorrResult> r = BigQuotes
+            .GetCorrelation(BigQuotes, 150);
 
         Assert.AreEqual(1246, r.Count);
     }
@@ -94,15 +88,13 @@ public class CorrelationTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<CorrResult> r0 = Noquotes
-            .GetCorrelation(Noquotes, 10)
-            .ToList();
+        IReadOnlyList<CorrResult> r0 = Noquotes
+            .GetCorrelation(Noquotes, 10);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<CorrResult> r1 = Onequote
-            .GetCorrelation(Onequote, 10)
-            .ToList();
+        IReadOnlyList<CorrResult> r1 = Onequote
+            .GetCorrelation(Onequote, 10);
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -110,15 +102,14 @@ public class CorrelationTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<CorrResult> results = Quotes
+        IReadOnlyList<CorrResult> results = Quotes
             .GetCorrelation(OtherQuotes, 20)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 19, results.Count);
 
-        CorrResult last = results.LastOrDefault();
+        CorrResult last = results[^1];
         Assert.AreEqual(0.8460, last.Correlation.Round(4));
         Assert.AreEqual(0.7157, last.RSquared.Round(4));
     }

--- a/tests/indicators/a-d/Dema/Dema.Tests.cs
+++ b/tests/indicators/a-d/Dema/Dema.Tests.cs
@@ -6,9 +6,8 @@ public class DemaTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<DemaResult> results = Quotes
-            .GetDema(20)
-            .ToList();
+        IReadOnlyList<DemaResult> results = Quotes
+            .GetDema(20);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -31,10 +30,9 @@ public class DemaTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<DemaResult> results = Quotes
+        IReadOnlyList<DemaResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetDema(20)
-            .ToList();
+            .GetDema(20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(483, results.Count(x => x.Dema != null));
@@ -43,10 +41,9 @@ public class DemaTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<DemaResult> results = Quotes
+        IReadOnlyList<DemaResult> results = Quotes
             .GetSma(2)
-            .GetDema(20)
-            .ToList();
+            .GetDema(20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(482, results.Count(x => x.Dema != null));
@@ -55,10 +52,9 @@ public class DemaTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetDema(20)
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(474, results.Count(x => x.Sma != null));
@@ -67,9 +63,8 @@ public class DemaTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<DemaResult> r = BadQuotes
-            .GetDema(15)
-            .ToList();
+        IReadOnlyList<DemaResult> r = BadQuotes
+            .GetDema(15);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Dema is double.NaN));
@@ -78,15 +73,13 @@ public class DemaTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<DemaResult> r0 = Noquotes
-            .GetDema(5)
-            .ToList();
+        IReadOnlyList<DemaResult> r0 = Noquotes
+            .GetDema(5);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<DemaResult> r1 = Onequote
-            .GetDema(5)
-            .ToList();
+        IReadOnlyList<DemaResult> r1 = Onequote
+            .GetDema(5);
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -94,15 +87,14 @@ public class DemaTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<DemaResult> results = Quotes
+        IReadOnlyList<DemaResult> results = Quotes
             .GetDema(20)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - (40 + 100), results.Count);
 
-        DemaResult last = results.LastOrDefault();
+        DemaResult last = results[^1];
         Assert.AreEqual(241.1677, last.Dema.Round(4));
     }
 

--- a/tests/indicators/a-d/Doji/Doji.Tests.cs
+++ b/tests/indicators/a-d/Doji/Doji.Tests.cs
@@ -6,9 +6,8 @@ public class DojiTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<CandleResult> results = Quotes
-            .GetDoji()
-            .ToList();
+        IReadOnlyList<CandleResult> results = Quotes
+            .GetDoji();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -43,9 +42,8 @@ public class DojiTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<CandleResult> r = BadQuotes
-            .GetDoji()
-            .ToList();
+        IReadOnlyList<CandleResult> r = BadQuotes
+            .GetDoji();
 
         Assert.AreEqual(502, r.Count);
     }
@@ -53,15 +51,13 @@ public class DojiTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<CandleResult> r0 = Noquotes
-            .GetDoji()
-            .ToList();
+        IReadOnlyList<CandleResult> r0 = Noquotes
+            .GetDoji();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<CandleResult> r1 = Onequote
-            .GetDoji()
-            .ToList();
+        IReadOnlyList<CandleResult> r1 = Onequote
+            .GetDoji();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -69,12 +65,11 @@ public class DojiTests : SeriesTestBase
     [TestMethod]
     public void Condense()
     {
-        List<CandleResult> r = Quotes
+        IReadOnlyList<CandleResult> results = Quotes
             .GetDoji()
-            .Condense()
-            .ToList();
+            .Condense();
 
-        Assert.AreEqual(112, r.Count);
+        Assert.AreEqual(112, results.Count);
     }
 
     [TestMethod]

--- a/tests/indicators/a-d/Donchian/Donchian.Tests.cs
+++ b/tests/indicators/a-d/Donchian/Donchian.Tests.cs
@@ -6,9 +6,8 @@ public class DonchianTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<DonchianResult> results = Quotes
-            .GetDonchian()
-            .ToList();
+        IReadOnlyList<DonchianResult> results = Quotes
+            .GetDonchian();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -52,9 +51,8 @@ public class DonchianTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<DonchianResult> r = BadQuotes
-            .GetDonchian(15)
-            .ToList();
+        IReadOnlyList<DonchianResult> r = BadQuotes
+            .GetDonchian(15);
 
         Assert.AreEqual(502, r.Count);
     }
@@ -62,15 +60,13 @@ public class DonchianTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<DonchianResult> r0 = Noquotes
-            .GetDonchian()
-            .ToList();
+        IReadOnlyList<DonchianResult> r0 = Noquotes
+            .GetDonchian();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<DonchianResult> r1 = Onequote
-            .GetDonchian()
-            .ToList();
+        IReadOnlyList<DonchianResult> r1 = Onequote
+            .GetDonchian();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -78,15 +74,14 @@ public class DonchianTests : SeriesTestBase
     [TestMethod]
     public void Condense()
     {
-        List<DonchianResult> r = Quotes
+        IReadOnlyList<DonchianResult> results = Quotes
             .GetDonchian()
-            .Condense()
-            .ToList();
+            .Condense();
 
         // assertions
-        Assert.AreEqual(502 - 20, r.Count);
+        Assert.AreEqual(502 - 20, results.Count);
 
-        DonchianResult last = r.LastOrDefault();
+        DonchianResult last = results[^1];
         Assert.AreEqual(251.5050m, last.Centerline.Round(4));
         Assert.AreEqual(273.5900m, last.UpperBand.Round(4));
         Assert.AreEqual(229.4200m, last.LowerBand.Round(4));
@@ -96,15 +91,14 @@ public class DonchianTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<DonchianResult> results = Quotes
+        IReadOnlyList<DonchianResult> results = Quotes
             .GetDonchian()
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 20, results.Count);
 
-        DonchianResult last = results.LastOrDefault();
+        DonchianResult last = results[^1];
         Assert.AreEqual(251.5050m, last.Centerline.Round(4));
         Assert.AreEqual(273.5900m, last.UpperBand.Round(4));
         Assert.AreEqual(229.4200m, last.LowerBand.Round(4));

--- a/tests/indicators/a-d/Dpo/Dpo.Tests.cs
+++ b/tests/indicators/a-d/Dpo/Dpo.Tests.cs
@@ -24,8 +24,7 @@ public class DpoTests : SeriesTestBase
         }
 
         // calculate actual data
-        List<DpoResult> act = qot.GetDpo(14)
-            .ToList();
+        IReadOnlyList<DpoResult> act = qot.GetDpo(14);
 
         // assertions
         Assert.AreEqual(exp.Count, act.Count);
@@ -45,10 +44,9 @@ public class DpoTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<DpoResult> results = Quotes
+        IReadOnlyList<DpoResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetDpo(14)
-            .ToList();
+            .GetDpo(14);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(489, results.Count(x => x.Dpo != null));
@@ -57,10 +55,9 @@ public class DpoTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<DpoResult> results = Quotes
+        IReadOnlyList<DpoResult> results = Quotes
             .GetSma(2)
-            .GetDpo(14)
-            .ToList();
+            .GetDpo(14);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(488, results.Count(x => x.Dpo != null));
@@ -69,10 +66,9 @@ public class DpoTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetDpo(14)
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(480, results.Count(x => x.Sma is not null and not double.NaN));
@@ -81,9 +77,8 @@ public class DpoTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<DpoResult> r = BadQuotes
-            .GetDpo(5)
-            .ToList();
+        IReadOnlyList<DpoResult> r = BadQuotes
+            .GetDpo(5);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Dpo is double.NaN));
@@ -92,15 +87,13 @@ public class DpoTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<DpoResult> r0 = Noquotes
-            .GetDpo(5)
-            .ToList();
+        IReadOnlyList<DpoResult> r0 = Noquotes
+            .GetDpo(5);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<DpoResult> r1 = Onequote
-            .GetDpo(5)
-            .ToList();
+        IReadOnlyList<DpoResult> r1 = Onequote
+            .GetDpo(5);
 
         Assert.AreEqual(1, r1.Count);
     }

--- a/tests/indicators/a-d/Dynamic/Dynamic.Tests.cs
+++ b/tests/indicators/a-d/Dynamic/Dynamic.Tests.cs
@@ -6,9 +6,8 @@ public class McGinleyDynamicTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<DynamicResult> results = Quotes
-            .GetDynamic(14)
-            .ToList();
+        IReadOnlyList<DynamicResult> results = Quotes
+            .GetDynamic(14);
 
         // assertions
         Assert.AreEqual(502, results.Count);
@@ -31,10 +30,9 @@ public class McGinleyDynamicTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<DynamicResult> results = Quotes
+        IReadOnlyList<DynamicResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetDynamic(20)
-            .ToList();
+            .GetDynamic(20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(501, results.Count(x => x.Dynamic != null));
@@ -44,10 +42,9 @@ public class McGinleyDynamicTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<DynamicResult> results = Quotes
+        IReadOnlyList<DynamicResult> results = Quotes
             .GetSma(10)
-            .GetDynamic(14)
-            .ToList();
+            .GetDynamic(14);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(492, results.Count(x => x.Dynamic != null));
@@ -56,10 +53,9 @@ public class McGinleyDynamicTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetDynamic(14)
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(492, results.Count(x => x.Sma != null));
@@ -68,9 +64,8 @@ public class McGinleyDynamicTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<DynamicResult> r = BadQuotes
-            .GetDynamic(15)
-            .ToList();
+        IReadOnlyList<DynamicResult> r = BadQuotes
+            .GetDynamic(15);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Dynamic is double.NaN));
@@ -79,15 +74,13 @@ public class McGinleyDynamicTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<DynamicResult> r0 = Noquotes
-            .GetDynamic(14)
-            .ToList();
+        IReadOnlyList<DynamicResult> r0 = Noquotes
+            .GetDynamic(14);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<DynamicResult> r1 = Onequote
-            .GetDynamic(14)
-            .ToList();
+        IReadOnlyList<DynamicResult> r1 = Onequote
+            .GetDynamic(14);
 
         Assert.AreEqual(1, r1.Count);
     }

--- a/tests/indicators/e-k/ElderRay/ElderRay.Tests.cs
+++ b/tests/indicators/e-k/ElderRay/ElderRay.Tests.cs
@@ -6,9 +6,8 @@ public class ElderRayTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<ElderRayResult> results = Quotes
-            .GetElderRay()
-            .ToList();
+        IReadOnlyList<ElderRayResult> results = Quotes
+            .GetElderRay();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -50,10 +49,9 @@ public class ElderRayTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetElderRay()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(481, results.Count(x => x.Sma != null));
@@ -62,9 +60,8 @@ public class ElderRayTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<ElderRayResult> r = BadQuotes
-            .GetElderRay()
-            .ToList();
+        IReadOnlyList<ElderRayResult> r = BadQuotes
+            .GetElderRay();
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.BullPower is double.NaN));
@@ -73,15 +70,13 @@ public class ElderRayTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<ElderRayResult> r0 = Noquotes
-            .GetElderRay()
-            .ToList();
+        IReadOnlyList<ElderRayResult> r0 = Noquotes
+            .GetElderRay();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<ElderRayResult> r1 = Onequote
-            .GetElderRay()
-            .ToList();
+        IReadOnlyList<ElderRayResult> r1 = Onequote
+            .GetElderRay();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -89,15 +84,14 @@ public class ElderRayTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<ElderRayResult> results = Quotes
+        IReadOnlyList<ElderRayResult> results = Quotes
             .GetElderRay()
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - (100 + 13), results.Count);
 
-        ElderRayResult last = results.LastOrDefault();
+        ElderRayResult last = results[^1];
         Assert.AreEqual(246.0129, last.Ema.Round(4));
         Assert.AreEqual(-0.4729, last.BullPower.Round(4));
         Assert.AreEqual(-3.1429, last.BearPower.Round(4));

--- a/tests/indicators/e-k/Ema/Ema.Series.Tests.cs
+++ b/tests/indicators/e-k/Ema/Ema.Series.Tests.cs
@@ -14,9 +14,8 @@ public class EmaTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<EmaResult> results = Quotes
-            .GetEma(20)
-            .ToList();
+        IReadOnlyList<EmaResult> results = Quotes
+            .GetEma(20);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -36,10 +35,9 @@ public class EmaTests : SeriesTestBase
     [TestMethod]
     public void UsePart()
     {
-        List<EmaResult> results = Quotes
+        IReadOnlyList<EmaResult> results = Quotes
             .Use(CandlePart.Open)
-            .GetEma(20)
-            .ToList();
+            .GetEma(20);
 
         // assertions
 
@@ -62,10 +60,9 @@ public class EmaTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<EmaResult> results = Quotes
+        IReadOnlyList<EmaResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetEma(20)
-            .ToList();
+            .GetEma(20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(483, results.Count(x => x.Ema != null));
@@ -75,10 +72,9 @@ public class EmaTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<EmaResult> results = Quotes
+        IReadOnlyList<EmaResult> results = Quotes
             .GetSma(2)
-            .GetEma(20)
-            .ToList();
+            .GetEma(20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(482, results.Count(x => x.Ema != null));
@@ -88,10 +84,9 @@ public class EmaTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetEma(20)
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(474, results.Count(x => x.Sma != null));
@@ -101,10 +96,9 @@ public class EmaTests : SeriesTestBase
     [TestMethod]
     public void ChaineeMore()
     {
-        List<EmaResult> results = Quotes
+        IReadOnlyList<EmaResult> results = Quotes
             .GetRsi()
-            .GetEma(20)
-            .ToList();
+            .GetEma(20);
 
         // assertions
         Assert.AreEqual(502, results.Count);
@@ -128,9 +122,8 @@ public class EmaTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<EmaResult> r = BadQuotes
-            .GetEma(15)
-            .ToList();
+        IReadOnlyList<EmaResult> r = BadQuotes
+            .GetEma(15);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Ema is double.NaN));
@@ -139,15 +132,13 @@ public class EmaTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<EmaResult> r0 = Noquotes
-            .GetEma(10)
-            .ToList();
+        IReadOnlyList<EmaResult> r0 = Noquotes
+            .GetEma(10);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<EmaResult> r1 = Onequote
-            .GetEma(10)
-            .ToList();
+        IReadOnlyList<EmaResult> r1 = Onequote
+            .GetEma(10);
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -155,15 +146,14 @@ public class EmaTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<EmaResult> results = Quotes
+        IReadOnlyList<EmaResult> results = Quotes
             .GetEma(20)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - (20 + 100), results.Count);
 
-        EmaResult last = results.LastOrDefault();
+        EmaResult last = results[^1];
         Assert.AreEqual(249.3519, last.Ema.Round(4));
     }
 

--- a/tests/indicators/e-k/Ema/Ema.Stream.Tests.cs
+++ b/tests/indicators/e-k/Ema/Ema.Stream.Tests.cs
@@ -21,7 +21,7 @@ public class EmaTests : StreamTestBase, ITestChainObserver, ITestChainProvider
         }
 
         // initialize observer
-        var observer = provider
+        EmaHub<Quote> observer = provider
             .ToEma(5);
 
         // fetch initial results (early)
@@ -91,7 +91,7 @@ public class EmaTests : StreamTestBase, ITestChainObserver, ITestChainProvider
         QuoteHub<Quote> provider = new();
 
         // initialize observer
-        var observer = provider
+        EmaHub<SmaResult> observer = provider
             .ToSma(smaPeriods)
             .ToEma(emaPeriods);
 
@@ -144,7 +144,7 @@ public class EmaTests : StreamTestBase, ITestChainObserver, ITestChainProvider
         QuoteHub<Quote> provider = new();
 
         // initialize observer
-        var observer = provider
+        SmaHub<EmaResult> observer = provider
             .ToEma(emaPeriods)
             .ToSma(smaPeriods);
 

--- a/tests/indicators/e-k/Ema/Ema.Stream.Tests.cs
+++ b/tests/indicators/e-k/Ema/Ema.Stream.Tests.cs
@@ -55,9 +55,8 @@ public class EmaTests : StreamTestBase, ITestChainObserver, ITestChainProvider
         quotesList.RemoveAt(400);
 
         // time-series, for comparison
-        List<EmaResult> seriesList = quotesList
-            .GetEma(5)
-            .ToList();
+        var seriesList = quotesList
+            .GetEma(5);
 
         // assert, should equal series
         for (int i = 0; i < length - 1; i++)
@@ -106,11 +105,10 @@ public class EmaTests : StreamTestBase, ITestChainObserver, ITestChainProvider
             = observer.Results;
 
         // time-series, for comparison
-        List<EmaResult> staticList
+        var staticList
            = quotesList
             .GetSma(smaPeriods)
-            .GetEma(emaPeriods)
-            .ToList();
+            .GetEma(emaPeriods);
 
         // assert, should equal series
         for (int i = 0; i < length; i++)
@@ -179,11 +177,10 @@ public class EmaTests : StreamTestBase, ITestChainObserver, ITestChainProvider
             = observer.Results;
 
         // time-series, for comparison
-        List<SmaResult> seriesList
+        IReadOnlyList<SmaResult> seriesList
            = quotesList
             .GetEma(emaPeriods)
-            .GetSma(smaPeriods)
-            .ToList();
+            .GetSma(smaPeriods);
 
         // assert, should equal series
         for (int i = 0; i < length - 1; i++)

--- a/tests/indicators/e-k/Epma/Epma.Tests.cs
+++ b/tests/indicators/e-k/Epma/Epma.Tests.cs
@@ -6,9 +6,8 @@ public class EpmaTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<EpmaResult> results = Quotes
-            .GetEpma(20)
-            .ToList();
+        IReadOnlyList<EpmaResult> results = Quotes
+            .GetEpma(20);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -34,10 +33,9 @@ public class EpmaTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<EpmaResult> results = Quotes
+        IReadOnlyList<EpmaResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetEpma(20)
-            .ToList();
+            .GetEpma(20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(483, results.Count(x => x.Epma != null));
@@ -46,10 +44,9 @@ public class EpmaTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<EpmaResult> results = Quotes
+        IReadOnlyList<EpmaResult> results = Quotes
             .GetSma(2)
-            .GetEpma(20)
-            .ToList();
+            .GetEpma(20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(482, results.Count(x => x.Epma != null));
@@ -58,10 +55,9 @@ public class EpmaTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetEpma(20)
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(474, results.Count(x => x.Sma != null));
@@ -70,9 +66,8 @@ public class EpmaTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<EpmaResult> r = BadQuotes
-            .GetEpma(15)
-            .ToList();
+        IReadOnlyList<EpmaResult> r = BadQuotes
+            .GetEpma(15);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Epma is double.NaN));
@@ -81,15 +76,13 @@ public class EpmaTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<EpmaResult> r0 = Noquotes
-            .GetEpma(5)
-            .ToList();
+        IReadOnlyList<EpmaResult> r0 = Noquotes
+            .GetEpma(5);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<EpmaResult> r1 = Onequote
-            .GetEpma(5)
-            .ToList();
+        IReadOnlyList<EpmaResult> r1 = Onequote
+            .GetEpma(5);
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -97,15 +90,14 @@ public class EpmaTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<EpmaResult> results = Quotes
+        IReadOnlyList<EpmaResult> results = Quotes
             .GetEpma(20)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 19, results.Count);
 
-        EpmaResult last = results.LastOrDefault();
+        EpmaResult last = results[^1];
         Assert.AreEqual(235.8131, last.Epma.Round(4));
     }
 

--- a/tests/indicators/e-k/Fcb/Fcb.Tests.cs
+++ b/tests/indicators/e-k/Fcb/Fcb.Tests.cs
@@ -6,9 +6,8 @@ public class FcbTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<FcbResult> results = Quotes
-            .GetFcb()
-            .ToList();
+        IReadOnlyList<FcbResult> results = Quotes
+            .GetFcb();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -44,9 +43,8 @@ public class FcbTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<FcbResult> r = BadQuotes
-            .GetFcb()
-            .ToList();
+        IReadOnlyList<FcbResult> r = BadQuotes
+            .GetFcb();
 
         Assert.AreEqual(502, r.Count);
     }
@@ -54,15 +52,13 @@ public class FcbTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<FcbResult> r0 = Noquotes
-            .GetFcb()
-            .ToList();
+        IReadOnlyList<FcbResult> r0 = Noquotes
+            .GetFcb();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<FcbResult> r1 = Onequote
-            .GetFcb()
-            .ToList();
+        IReadOnlyList<FcbResult> r1 = Onequote
+            .GetFcb();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -70,15 +66,14 @@ public class FcbTests : SeriesTestBase
     [TestMethod]
     public void Condense()
     {
-        List<FcbResult> results = Quotes
+        IReadOnlyList<FcbResult> results = Quotes
             .GetFcb()
-            .Condense()
-            .ToList();
+            .Condense();
 
         // assertions
         Assert.AreEqual(502 - 5, results.Count);
 
-        FcbResult last = results.LastOrDefault();
+        FcbResult last = results[^1];
         Assert.AreEqual(262.47m, last.UpperBand);
         Assert.AreEqual(229.42m, last.LowerBand);
     }
@@ -86,15 +81,14 @@ public class FcbTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<FcbResult> results = Quotes
+        IReadOnlyList<FcbResult> results = Quotes
             .GetFcb()
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 5, results.Count);
 
-        FcbResult last = results.LastOrDefault();
+        FcbResult last = results[^1];
         Assert.AreEqual(262.47m, last.UpperBand);
         Assert.AreEqual(229.42m, last.LowerBand);
     }

--- a/tests/indicators/e-k/FisherTransform/FisherTransform.Tests.cs
+++ b/tests/indicators/e-k/FisherTransform/FisherTransform.Tests.cs
@@ -6,9 +6,8 @@ public class FisherTransformTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<FisherTransformResult> results = Quotes
-            .GetFisherTransform()
-            .ToList();
+        IReadOnlyList<FisherTransformResult> results = Quotes
+            .GetFisherTransform();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -49,10 +48,9 @@ public class FisherTransformTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<FisherTransformResult> results = Quotes
+        IReadOnlyList<FisherTransformResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetFisherTransform()
-            .ToList();
+            .GetFisherTransform();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(501, results.Count(x => x.Fisher != 0));
@@ -61,10 +59,9 @@ public class FisherTransformTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<FisherTransformResult> results = Quotes
+        IReadOnlyList<FisherTransformResult> results = Quotes
             .GetSma(2)
-            .GetFisherTransform()
-            .ToList();
+            .GetFisherTransform();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(501, results.Count(x => x.Fisher != 0));
@@ -73,10 +70,9 @@ public class FisherTransformTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetFisherTransform()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(493, results.Count(x => x.Sma != null));
@@ -85,9 +81,8 @@ public class FisherTransformTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<FisherTransformResult> r = BadQuotes
-            .GetFisherTransform(9)
-            .ToList();
+        IReadOnlyList<FisherTransformResult> r = BadQuotes
+            .GetFisherTransform(9);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Fisher is double.NaN));
@@ -96,15 +91,13 @@ public class FisherTransformTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<FisherTransformResult> r0 = Noquotes
-            .GetFisherTransform()
-            .ToList();
+        IReadOnlyList<FisherTransformResult> r0 = Noquotes
+            .GetFisherTransform();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<FisherTransformResult> r1 = Onequote
-            .GetFisherTransform()
-            .ToList();
+        IReadOnlyList<FisherTransformResult> r1 = Onequote
+            .GetFisherTransform();
 
         Assert.AreEqual(1, r1.Count);
     }

--- a/tests/indicators/e-k/ForceIndex/ForceIndex.Tests.cs
+++ b/tests/indicators/e-k/ForceIndex/ForceIndex.Tests.cs
@@ -6,7 +6,7 @@ public class ForceIndexTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<ForceIndexResult> r = Quotes.GetForceIndex(13).ToList();
+        IReadOnlyList<ForceIndexResult> r = Quotes.GetForceIndex(13).ToList();
 
         // proper quantities
         Assert.AreEqual(502, r.Count);
@@ -25,10 +25,9 @@ public class ForceIndexTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetForceIndex(13)
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(480, results.Count(x => x.Sma != null));
@@ -37,9 +36,8 @@ public class ForceIndexTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<ForceIndexResult> r = BadQuotes
-            .GetForceIndex()
-            .ToList();
+        IReadOnlyList<ForceIndexResult> r = BadQuotes
+            .GetForceIndex();
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.ForceIndex is double.NaN));
@@ -48,15 +46,13 @@ public class ForceIndexTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<ForceIndexResult> r0 = Noquotes
-            .GetForceIndex(5)
-            .ToList();
+        IReadOnlyList<ForceIndexResult> r0 = Noquotes
+            .GetForceIndex(5);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<ForceIndexResult> r1 = Onequote
-            .GetForceIndex(5)
-            .ToList();
+        IReadOnlyList<ForceIndexResult> r1 = Onequote
+            .GetForceIndex(5);
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -64,15 +60,14 @@ public class ForceIndexTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<ForceIndexResult> results = Quotes
+        IReadOnlyList<ForceIndexResult> results = Quotes
             .GetForceIndex(13)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - (13 + 100), results.Count);
 
-        ForceIndexResult last = results.LastOrDefault();
+        ForceIndexResult last = results[^1];
         Assert.AreEqual(-16824018.428, Math.Round(last.ForceIndex.Value, 3));
     }
 

--- a/tests/indicators/e-k/Fractal/Fractal.Tests.cs
+++ b/tests/indicators/e-k/Fractal/Fractal.Tests.cs
@@ -6,9 +6,8 @@ public class FractalTests : SeriesTestBase
     [TestMethod]
     public override void Standard() // Span 2
     {
-        List<FractalResult> results = Quotes
-            .GetFractal()
-            .ToList();
+        IReadOnlyList<FractalResult> results = Quotes
+            .GetFractal();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -44,9 +43,8 @@ public class FractalTests : SeriesTestBase
     [TestMethod]
     public void StandardSpan4()
     {
-        List<FractalResult> results = Quotes
-            .GetFractal(4, 4)
-            .ToList();
+        IReadOnlyList<FractalResult> results = Quotes
+            .GetFractal(4, 4);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -82,9 +80,8 @@ public class FractalTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<FractalResult> r = BadQuotes
-            .GetFractal()
-            .ToList();
+        IReadOnlyList<FractalResult> r = BadQuotes
+            .GetFractal();
 
         Assert.AreEqual(502, r.Count);
     }
@@ -92,15 +89,13 @@ public class FractalTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<FractalResult> r0 = Noquotes
-            .GetFractal()
-            .ToList();
+        IReadOnlyList<FractalResult> r0 = Noquotes
+            .GetFractal();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<FractalResult> r1 = Onequote
-            .GetFractal()
-            .ToList();
+        IReadOnlyList<FractalResult> r1 = Onequote
+            .GetFractal();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -108,12 +103,11 @@ public class FractalTests : SeriesTestBase
     [TestMethod]
     public void Condense()
     {
-        List<FractalResult> r = Quotes
+        IReadOnlyList<FractalResult> results = Quotes
             .GetFractal()
-            .Condense()
-            .ToList();
+            .Condense();
 
-        Assert.AreEqual(129, r.Count);
+        Assert.AreEqual(129, results.Count);
     }
 
     // bad window span

--- a/tests/indicators/e-k/Gator/Gator.Tests.cs
+++ b/tests/indicators/e-k/Gator/Gator.Tests.cs
@@ -6,9 +6,8 @@ public class GatorTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<GatorResult> results = Quotes
-            .GetGator()
-            .ToList();
+        IReadOnlyList<GatorResult> results = Quotes
+            .GetGator();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -76,10 +75,9 @@ public class GatorTests : SeriesTestBase
     [TestMethod]
     public void FromAlligator()
     {
-        List<GatorResult> results = Quotes
+        IReadOnlyList<GatorResult> results = Quotes
             .GetAlligator()
-            .GetGator()
-            .ToList();
+            .GetGator();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -147,10 +145,9 @@ public class GatorTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<GatorResult> results = Quotes
+        IReadOnlyList<GatorResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetGator()
-            .ToList();
+            .GetGator();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(482, results.Count(x => x.Upper != null));
@@ -159,10 +156,9 @@ public class GatorTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<GatorResult> results = Quotes
+        IReadOnlyList<GatorResult> results = Quotes
             .GetSma(2)
-            .GetGator()
-            .ToList();
+            .GetGator();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(481, results.Count(x => x.Upper != null));
@@ -171,9 +167,8 @@ public class GatorTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<GatorResult> r = BadQuotes
-            .GetGator()
-            .ToList();
+        IReadOnlyList<GatorResult> r = BadQuotes
+            .GetGator();
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Upper is double.NaN));
@@ -182,15 +177,13 @@ public class GatorTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<GatorResult> r0 = Noquotes
-            .GetGator()
-            .ToList();
+        IReadOnlyList<GatorResult> r0 = Noquotes
+            .GetGator();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<GatorResult> r1 = Onequote
-            .GetGator()
-            .ToList();
+        IReadOnlyList<GatorResult> r1 = Onequote
+            .GetGator();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -198,15 +191,14 @@ public class GatorTests : SeriesTestBase
     [TestMethod]
     public void Condense()
     {
-        List<GatorResult> results = Quotes
+        IReadOnlyList<GatorResult> results = Quotes
             .GetGator()
-            .Condense()
-            .ToList();
+            .Condense();
 
         // assertions
         Assert.AreEqual(490, results.Count);
 
-        GatorResult last = results.LastOrDefault();
+        GatorResult last = results[^1];
         Assert.AreEqual(7.4538, Math.Round(last.Upper.Value, 4));
         Assert.AreEqual(-9.2399, Math.Round(last.Lower.Value, 4));
         Assert.IsTrue(last.UpperIsExpanding);
@@ -216,15 +208,14 @@ public class GatorTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<GatorResult> results = Quotes
+        IReadOnlyList<GatorResult> results = Quotes
             .GetGator()
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 150, results.Count);
 
-        GatorResult last = results.LastOrDefault();
+        GatorResult last = results[^1];
         Assert.AreEqual(7.4538, Math.Round(last.Upper.Value, 4));
         Assert.AreEqual(-9.2399, Math.Round(last.Lower.Value, 4));
         Assert.IsTrue(last.UpperIsExpanding);

--- a/tests/indicators/e-k/HeikinAshi/HeikinAshi.Tests.cs
+++ b/tests/indicators/e-k/HeikinAshi/HeikinAshi.Tests.cs
@@ -6,9 +6,8 @@ public class HeikinAshiTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<HeikinAshiResult> results = Quotes
-            .GetHeikinAshi()
-            .ToList();
+        IReadOnlyList<HeikinAshiResult> results = Quotes
+            .GetHeikinAshi();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -31,36 +30,10 @@ public class HeikinAshiTests : SeriesTestBase
     }
 
     [TestMethod]
-    public void ToQuotes()
-    {
-        List<HeikinAshiResult> results = Quotes
-            .GetHeikinAshi()
-            .ToList();
-
-        List<Quote> haQuotes = results
-            .ToQuotes()
-            .ToList();
-
-        for (int i = 0; i < results.Count; i++)
-        {
-            HeikinAshiResult r = results[i];
-            Quote q = haQuotes[i];
-
-            Assert.AreEqual(r.Timestamp, q.Timestamp);
-            Assert.AreEqual(r.Open, q.Open);
-            Assert.AreEqual(r.High, q.High);
-            Assert.AreEqual(r.Low, q.Low);
-            Assert.AreEqual(r.Close, q.Close);
-            Assert.AreEqual(r.Volume, q.Volume);
-        }
-    }
-
-    [TestMethod]
     public override void BadData()
     {
-        List<HeikinAshiResult> r = BadQuotes
-            .GetHeikinAshi()
-            .ToList();
+        IReadOnlyList<HeikinAshiResult> r = BadQuotes
+            .GetHeikinAshi();
 
         Assert.AreEqual(502, r.Count);
     }
@@ -68,15 +41,13 @@ public class HeikinAshiTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<HeikinAshiResult> r0 = Noquotes
-            .GetHeikinAshi()
-            .ToList();
+        IReadOnlyList<HeikinAshiResult> r0 = Noquotes
+            .GetHeikinAshi();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<HeikinAshiResult> r1 = Onequote
-            .GetHeikinAshi()
-            .ToList();
+        IReadOnlyList<HeikinAshiResult> r1 = Onequote
+            .GetHeikinAshi();
 
         Assert.AreEqual(1, r1.Count);
     }

--- a/tests/indicators/e-k/Hma/Hma.Tests.cs
+++ b/tests/indicators/e-k/Hma/Hma.Tests.cs
@@ -6,9 +6,8 @@ public class HmaTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<HmaResult> results = Quotes
-            .GetHma(20)
-            .ToList();
+        IReadOnlyList<HmaResult> results = Quotes
+            .GetHma(20);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -25,10 +24,9 @@ public class HmaTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<HmaResult> results = Quotes
+        IReadOnlyList<HmaResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetHma(20)
-            .ToList();
+            .GetHma(20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(480, results.Count(x => x.Hma != null));
@@ -37,10 +35,9 @@ public class HmaTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<HmaResult> results = Quotes
+        IReadOnlyList<HmaResult> results = Quotes
             .GetSma(2)
-            .GetHma(19)
-            .ToList();
+            .GetHma(19);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(480, results.Count(x => x.Hma != null));
@@ -49,10 +46,9 @@ public class HmaTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetHma(20)
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(471, results.Count(x => x.Sma != null));
@@ -61,9 +57,8 @@ public class HmaTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<HmaResult> r = BadQuotes
-            .GetHma(15)
-            .ToList();
+        IReadOnlyList<HmaResult> r = BadQuotes
+            .GetHma(15);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Hma is double.NaN));
@@ -72,15 +67,13 @@ public class HmaTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<HmaResult> r0 = Noquotes
-            .GetHma(5)
-            .ToList();
+        IReadOnlyList<HmaResult> r0 = Noquotes
+            .GetHma(5);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<HmaResult> r1 = Onequote
-            .GetHma(5)
-            .ToList();
+        IReadOnlyList<HmaResult> r1 = Onequote
+            .GetHma(5);
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -88,15 +81,14 @@ public class HmaTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<HmaResult> results = Quotes
+        IReadOnlyList<HmaResult> results = Quotes
             .GetHma(20)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(480, results.Count);
 
-        HmaResult last = results.LastOrDefault();
+        HmaResult last = results[^1];
         Assert.AreEqual(235.6972, last.Hma.Round(4));
     }
 

--- a/tests/indicators/e-k/HtTrendline/HtTrendline.Tests.cs
+++ b/tests/indicators/e-k/HtTrendline/HtTrendline.Tests.cs
@@ -6,9 +6,8 @@ public class HtTrendlineTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<HtlResult> results = Quotes
-            .GetHtTrendline()
-            .ToList();
+        IReadOnlyList<HtlResult> results = Quotes
+            .GetHtTrendline();
 
         // proper quantities
         // should always be the same number of results as there is quotes
@@ -60,10 +59,9 @@ public class HtTrendlineTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<HtlResult> results = Quotes
+        IReadOnlyList<HtlResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetHtTrendline()
-            .ToList();
+            .GetHtTrendline();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(502, results.Count(x => x.Trendline != null));
@@ -72,10 +70,9 @@ public class HtTrendlineTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<HtlResult> results = Quotes
+        IReadOnlyList<HtlResult> results = Quotes
             .GetSma(2)
-            .GetHtTrendline()
-            .ToList();
+            .GetHtTrendline();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(501, results.Count(x => x.Trendline != null));
@@ -84,10 +81,9 @@ public class HtTrendlineTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetHtTrendline()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(493, results.Count(x => x.Sma != null));
@@ -96,9 +92,8 @@ public class HtTrendlineTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<HtlResult> r = BadQuotes
-            .GetHtTrendline()
-            .ToList();
+        IReadOnlyList<HtlResult> r = BadQuotes
+            .GetHtTrendline();
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Trendline is double.NaN));
@@ -107,15 +102,14 @@ public class HtTrendlineTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<HtlResult> results = Quotes
+        IReadOnlyList<HtlResult> results = Quotes
             .GetHtTrendline()
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 100, results.Count);
 
-        HtlResult last = results.LastOrDefault();
+        HtlResult last = results[^1];
         Assert.AreEqual(252.2172, last.Trendline.Round(4));
         Assert.AreEqual(242.3435, last.SmoothPrice.Round(4));
     }
@@ -125,9 +119,8 @@ public class HtTrendlineTests : SeriesTestBase
     {
         IEnumerable<Quote> penny = Data.GetPenny();
 
-        List<HtlResult> r = penny
-            .GetHtTrendline()
-            .ToList();
+        IReadOnlyList<HtlResult> r = penny
+            .GetHtTrendline();
 
         Assert.AreEqual(533, r.Count);
     }
@@ -135,15 +128,13 @@ public class HtTrendlineTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<HtlResult> r0 = Noquotes
-            .GetHtTrendline()
-            .ToList();
+        IReadOnlyList<HtlResult> r0 = Noquotes
+            .GetHtTrendline();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<HtlResult> r1 = Onequote
-            .GetHtTrendline()
-            .ToList();
+        IReadOnlyList<HtlResult> r1 = Onequote
+            .GetHtTrendline();
 
         Assert.AreEqual(1, r1.Count);
     }

--- a/tests/indicators/e-k/Hurst/Hurst.Tests.cs
+++ b/tests/indicators/e-k/Hurst/Hurst.Tests.cs
@@ -6,9 +6,8 @@ public class HurstTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<HurstResult> results = LongestQuotes
-            .GetHurst(LongestQuotes.Count - 1)
-            .ToList();
+        IReadOnlyList<HurstResult> results = LongestQuotes
+            .GetHurst(LongestQuotes.Count - 1);
 
         // assertions
 
@@ -24,10 +23,9 @@ public class HurstTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<HurstResult> results = Quotes
+        IReadOnlyList<HurstResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetHurst()
-            .ToList();
+            .GetHurst();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(402, results.Count(x => x.HurstExponent != null));
@@ -36,10 +34,9 @@ public class HurstTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetHurst()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(393, results.Count(x => x.Sma != null));
@@ -48,10 +45,9 @@ public class HurstTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<HurstResult> results = Quotes
+        IReadOnlyList<HurstResult> results = Quotes
             .GetSma(10)
-            .GetHurst()
-            .ToList();
+            .GetHurst();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(393, results.Count(x => x.HurstExponent != null));
@@ -60,9 +56,8 @@ public class HurstTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<HurstResult> r = BadQuotes
-            .GetHurst(150)
-            .ToList();
+        IReadOnlyList<HurstResult> r = BadQuotes
+            .GetHurst(150);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.HurstExponent is double.NaN));
@@ -71,15 +66,13 @@ public class HurstTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<HurstResult> r0 = Noquotes
-            .GetHurst()
-            .ToList();
+        IReadOnlyList<HurstResult> r0 = Noquotes
+            .GetHurst();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<HurstResult> r1 = Onequote
-            .GetHurst()
-            .ToList();
+        IReadOnlyList<HurstResult> r1 = Onequote
+            .GetHurst();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -87,14 +80,13 @@ public class HurstTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<HurstResult> results = LongestQuotes.GetHurst(LongestQuotes.Count - 1)
-            .RemoveWarmupPeriods()
-            .ToList();
+        IReadOnlyList<HurstResult> results = LongestQuotes.GetHurst(LongestQuotes.Count - 1)
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(1, results.Count);
 
-        HurstResult last = results.LastOrDefault();
+        HurstResult last = results[^1];
         Assert.AreEqual(0.483563, last.HurstExponent.Round(6));
     }
 

--- a/tests/indicators/e-k/Ichimoku/Ichimoku.Tests.cs
+++ b/tests/indicators/e-k/Ichimoku/Ichimoku.Tests.cs
@@ -10,9 +10,8 @@ public class IchimokuTests : SeriesTestBase
         int kijunPeriods = 26;
         int senkouBPeriods = 52;
 
-        List<IchimokuResult> results = Quotes
-            .GetIchimoku(tenkanPeriods, kijunPeriods, senkouBPeriods)
-            .ToList();
+        IReadOnlyList<IchimokuResult> results = Quotes
+            .GetIchimoku(tenkanPeriods, kijunPeriods, senkouBPeriods);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -55,19 +54,17 @@ public class IchimokuTests : SeriesTestBase
     [TestMethod]
     public void Extended()
     {
-        List<IchimokuResult> r = Quotes
-            .GetIchimoku(3, 13, 40, 0, 0)
-            .ToList();
+        IReadOnlyList<IchimokuResult> results = Quotes
+            .GetIchimoku(3, 13, 40, 0, 0);
 
-        Assert.AreEqual(502, r.Count);
+        Assert.AreEqual(502, results.Count);
     }
 
     [TestMethod]
     public override void BadData()
     {
-        List<IchimokuResult> r = BadQuotes
-            .GetIchimoku()
-            .ToList();
+        IReadOnlyList<IchimokuResult> r = BadQuotes
+            .GetIchimoku();
 
         Assert.AreEqual(502, r.Count);
     }
@@ -75,15 +72,13 @@ public class IchimokuTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<IchimokuResult> r0 = Noquotes
-            .GetIchimoku()
-            .ToList();
+        IReadOnlyList<IchimokuResult> r0 = Noquotes
+            .GetIchimoku();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<IchimokuResult> r1 = Onequote
-            .GetIchimoku()
-            .ToList();
+        IReadOnlyList<IchimokuResult> r1 = Onequote
+            .GetIchimoku();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -91,12 +86,11 @@ public class IchimokuTests : SeriesTestBase
     [TestMethod]
     public void Condense()
     {
-        List<IchimokuResult> r = Quotes
+        IReadOnlyList<IchimokuResult> results = Quotes
             .GetIchimoku()
-            .Condense()
-            .ToList();
+            .Condense();
 
-        Assert.AreEqual(502, r.Count);
+        Assert.AreEqual(502, results.Count);
     }
 
     [TestMethod]

--- a/tests/indicators/e-k/Kama/Kama.Tests.cs
+++ b/tests/indicators/e-k/Kama/Kama.Tests.cs
@@ -10,9 +10,8 @@ public class KamaTests : SeriesTestBase
         int fastPeriods = 2;
         int slowPeriods = 30;
 
-        List<KamaResult> results = Quotes
-            .GetKama(erPeriods, fastPeriods, slowPeriods)
-            .ToList();
+        IReadOnlyList<KamaResult> results = Quotes
+            .GetKama(erPeriods, fastPeriods, slowPeriods);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -52,10 +51,9 @@ public class KamaTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<KamaResult> results = Quotes
+        IReadOnlyList<KamaResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetKama()
-            .ToList();
+            .GetKama();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(493, results.Count(x => x.Kama != null));
@@ -64,10 +62,9 @@ public class KamaTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<KamaResult> results = Quotes
+        IReadOnlyList<KamaResult> results = Quotes
             .GetSma(2)
-            .GetKama()
-            .ToList();
+            .GetKama();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(492, results.Count(x => x.Kama != null));
@@ -76,10 +73,9 @@ public class KamaTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetKama()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(484, results.Count(x => x.Sma != null));
@@ -88,9 +84,8 @@ public class KamaTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<KamaResult> r = BadQuotes
-            .GetKama()
-            .ToList();
+        IReadOnlyList<KamaResult> r = BadQuotes
+            .GetKama();
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Kama is double.NaN));
@@ -99,15 +94,13 @@ public class KamaTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<KamaResult> r0 = Noquotes
-            .GetKama()
-            .ToList();
+        IReadOnlyList<KamaResult> r0 = Noquotes
+            .GetKama();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<KamaResult> r1 = Onequote
-            .GetKama()
-            .ToList();
+        IReadOnlyList<KamaResult> r1 = Onequote
+            .GetKama();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -119,15 +112,14 @@ public class KamaTests : SeriesTestBase
         int fastPeriods = 2;
         int slowPeriods = 30;
 
-        List<KamaResult> results = Quotes
+        IReadOnlyList<KamaResult> results = Quotes
             .GetKama(erPeriods, fastPeriods, slowPeriods)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - Math.Max(erPeriods + 100, erPeriods * 10), results.Count);
 
-        KamaResult last = results.LastOrDefault();
+        KamaResult last = results[^1];
         Assert.AreEqual(0.2214, last.Er.Round(4));
         Assert.AreEqual(240.1138, last.Kama.Round(4));
     }

--- a/tests/indicators/e-k/Keltner/Keltner.Tests.cs
+++ b/tests/indicators/e-k/Keltner/Keltner.Tests.cs
@@ -10,9 +10,8 @@ public class KeltnerTests : SeriesTestBase
         int multiplier = 2;
         int atrPeriods = 10;
 
-        List<KeltnerResult> results = Quotes
-            .GetKeltner(emaPeriods, multiplier, atrPeriods)
-            .ToList();
+        IReadOnlyList<KeltnerResult> results = Quotes
+            .GetKeltner(emaPeriods, multiplier, atrPeriods);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -40,9 +39,8 @@ public class KeltnerTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<KeltnerResult> r = BadQuotes
-            .GetKeltner(10, 3, 15)
-            .ToList();
+        IReadOnlyList<KeltnerResult> r = BadQuotes
+            .GetKeltner(10, 3, 15);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.UpperBand is double.NaN));
@@ -51,15 +49,13 @@ public class KeltnerTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<KeltnerResult> r0 = Noquotes
-            .GetKeltner()
-            .ToList();
+        IReadOnlyList<KeltnerResult> r0 = Noquotes
+            .GetKeltner();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<KeltnerResult> r1 = Onequote
-            .GetKeltner()
-            .ToList();
+        IReadOnlyList<KeltnerResult> r1 = Onequote
+            .GetKeltner();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -71,15 +67,14 @@ public class KeltnerTests : SeriesTestBase
         int multiplier = 2;
         int atrPeriods = 10;
 
-        List<KeltnerResult> results = Quotes
+        IReadOnlyList<KeltnerResult> results = Quotes
             .GetKeltner(emaPeriods, multiplier, atrPeriods)
-            .Condense()
-            .ToList();
+            .Condense();
 
         // assertions
         Assert.AreEqual(483, results.Count);
 
-        KeltnerResult last = results.LastOrDefault();
+        KeltnerResult last = results[^1];
         Assert.AreEqual(262.1873, last.UpperBand.Round(4));
         Assert.AreEqual(249.3519, last.Centerline.Round(4));
         Assert.AreEqual(236.5165, last.LowerBand.Round(4));
@@ -94,15 +89,14 @@ public class KeltnerTests : SeriesTestBase
         int atrPeriods = 10;
         int n = Math.Max(emaPeriods, atrPeriods);
 
-        List<KeltnerResult> results = Quotes
+        IReadOnlyList<KeltnerResult> results = Quotes
             .GetKeltner(emaPeriods, multiplier, atrPeriods)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - Math.Max(2 * n, n + 100), results.Count);
 
-        KeltnerResult last = results.LastOrDefault();
+        KeltnerResult last = results[^1];
         Assert.AreEqual(262.1873, last.UpperBand.Round(4));
         Assert.AreEqual(249.3519, last.Centerline.Round(4));
         Assert.AreEqual(236.5165, last.LowerBand.Round(4));

--- a/tests/indicators/e-k/Kvo/Kvo.Tests.cs
+++ b/tests/indicators/e-k/Kvo/Kvo.Tests.cs
@@ -6,9 +6,8 @@ public class KlingerTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<KvoResult> results =
-            Quotes.GetKvo()
-            .ToList();
+        IReadOnlyList<KvoResult> results =
+            Quotes.GetKvo();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -48,10 +47,9 @@ public class KlingerTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetKvo()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(437, results.Count(x => x.Sma != null));
@@ -60,9 +58,8 @@ public class KlingerTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<KvoResult> r = BadQuotes
-            .GetKvo()
-            .ToList();
+        IReadOnlyList<KvoResult> r = BadQuotes
+            .GetKvo();
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Oscillator is double.NaN));
@@ -71,15 +68,13 @@ public class KlingerTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<KvoResult> r0 = Noquotes
-            .GetKvo()
-            .ToList();
+        IReadOnlyList<KvoResult> r0 = Noquotes
+            .GetKvo();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<KvoResult> r1 = Onequote
-            .GetKvo()
-            .ToList();
+        IReadOnlyList<KvoResult> r1 = Onequote
+            .GetKvo();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -87,15 +82,14 @@ public class KlingerTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<KvoResult> results = Quotes
+        IReadOnlyList<KvoResult> results = Quotes
             .GetKvo()
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - (55 + 150), results.Count);
 
-        KvoResult last = results.LastOrDefault();
+        KvoResult last = results[^1];
         Assert.AreEqual(-539224047, Math.Round(last.Oscillator.Value, 0));
         Assert.AreEqual(-1548306127, Math.Round(last.Signal.Value, 0));
     }

--- a/tests/indicators/m-r/MaEnvelopes/MaEnvelopes.Tests.cs
+++ b/tests/indicators/m-r/MaEnvelopes/MaEnvelopes.Tests.cs
@@ -6,9 +6,8 @@ public class MaEnvelopesTests : SeriesTestBase
     [TestMethod]
     public override void Standard() // SMA
     {
-        List<MaEnvelopeResult> results =
-            Quotes.GetMaEnvelopes(20)
-            .ToList();
+        IReadOnlyList<MaEnvelopeResult> results =
+            Quotes.GetMaEnvelopes(20);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -34,9 +33,8 @@ public class MaEnvelopesTests : SeriesTestBase
     [TestMethod]
     public void Alma()
     {
-        List<MaEnvelopeResult> results =
-            Quotes.GetMaEnvelopes(10, 2.5, MaType.ALMA)
-            .ToList();
+        IReadOnlyList<MaEnvelopeResult> results =
+            Quotes.GetMaEnvelopes(10, 2.5, MaType.ALMA);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -62,9 +60,8 @@ public class MaEnvelopesTests : SeriesTestBase
     [TestMethod]
     public void Dema()
     {
-        List<MaEnvelopeResult> results =
-            Quotes.GetMaEnvelopes(20, 2.5, MaType.DEMA)
-            .ToList();
+        IReadOnlyList<MaEnvelopeResult> results =
+            Quotes.GetMaEnvelopes(20, 2.5, MaType.DEMA);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -90,9 +87,8 @@ public class MaEnvelopesTests : SeriesTestBase
     [TestMethod]
     public void Epma()
     {
-        List<MaEnvelopeResult> results =
-            Quotes.GetMaEnvelopes(20, 2.5, MaType.EPMA)
-            .ToList();
+        IReadOnlyList<MaEnvelopeResult> results =
+            Quotes.GetMaEnvelopes(20, 2.5, MaType.EPMA);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -118,9 +114,8 @@ public class MaEnvelopesTests : SeriesTestBase
     [TestMethod]
     public void Ema()
     {
-        List<MaEnvelopeResult> results =
-            Quotes.GetMaEnvelopes(20, 2.5, MaType.EMA)
-            .ToList();
+        IReadOnlyList<MaEnvelopeResult> results =
+            Quotes.GetMaEnvelopes(20, 2.5, MaType.EMA);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -146,9 +141,8 @@ public class MaEnvelopesTests : SeriesTestBase
     [TestMethod]
     public void Hma()
     {
-        List<MaEnvelopeResult> results =
-            Quotes.GetMaEnvelopes(20, 2.5, MaType.HMA)
-            .ToList();
+        IReadOnlyList<MaEnvelopeResult> results =
+            Quotes.GetMaEnvelopes(20, 2.5, MaType.HMA);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -169,9 +163,8 @@ public class MaEnvelopesTests : SeriesTestBase
     [TestMethod]
     public void Smma()
     {
-        List<MaEnvelopeResult> results =
-            Quotes.GetMaEnvelopes(20, 2.5, MaType.SMMA)
-            .ToList();
+        IReadOnlyList<MaEnvelopeResult> results =
+            Quotes.GetMaEnvelopes(20, 2.5, MaType.SMMA);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -197,9 +190,8 @@ public class MaEnvelopesTests : SeriesTestBase
     [TestMethod]
     public void Tema()
     {
-        List<MaEnvelopeResult> results =
-            Quotes.GetMaEnvelopes(20, 2.5, MaType.TEMA)
-            .ToList();
+        IReadOnlyList<MaEnvelopeResult> results =
+            Quotes.GetMaEnvelopes(20, 2.5, MaType.TEMA);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -225,9 +217,8 @@ public class MaEnvelopesTests : SeriesTestBase
     [TestMethod]
     public void Wma()
     {
-        List<MaEnvelopeResult> results =
-            Quotes.GetMaEnvelopes(20, 2.5, MaType.WMA)
-            .ToList();
+        IReadOnlyList<MaEnvelopeResult> results =
+            Quotes.GetMaEnvelopes(20, 2.5, MaType.WMA);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -248,10 +239,9 @@ public class MaEnvelopesTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<MaEnvelopeResult> results = Quotes
+        IReadOnlyList<MaEnvelopeResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetMaEnvelopes(10)
-            .ToList();
+            .GetMaEnvelopes(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(493, results.Count(x => x.Centerline != null));
@@ -260,10 +250,9 @@ public class MaEnvelopesTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<MaEnvelopeResult> results = Quotes
+        IReadOnlyList<MaEnvelopeResult> results = Quotes
             .GetSma(2)
-            .GetMaEnvelopes(10)
-            .ToList();
+            .GetMaEnvelopes(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(492, results.Count(x => x.Centerline != null));
@@ -272,51 +261,43 @@ public class MaEnvelopesTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<MaEnvelopeResult> a = BadQuotes
-            .GetMaEnvelopes(5, 2.5, MaType.ALMA)
-            .ToList();
+        IReadOnlyList<MaEnvelopeResult> a = BadQuotes
+            .GetMaEnvelopes(5, 2.5, MaType.ALMA);
 
         Assert.AreEqual(502, a.Count);
 
-        List<MaEnvelopeResult> d = BadQuotes
-            .GetMaEnvelopes(5, 2.5, MaType.DEMA)
-            .ToList();
+        IReadOnlyList<MaEnvelopeResult> d = BadQuotes
+            .GetMaEnvelopes(5, 2.5, MaType.DEMA);
 
         Assert.AreEqual(502, d.Count);
 
-        List<MaEnvelopeResult> p = BadQuotes
-            .GetMaEnvelopes(5, 2.5, MaType.EPMA)
-            .ToList();
+        IReadOnlyList<MaEnvelopeResult> p = BadQuotes
+            .GetMaEnvelopes(5, 2.5, MaType.EPMA);
 
         Assert.AreEqual(502, p.Count);
 
-        List<MaEnvelopeResult> e = BadQuotes
-            .GetMaEnvelopes(5, 2.5, MaType.EMA)
-            .ToList();
+        IReadOnlyList<MaEnvelopeResult> e = BadQuotes
+            .GetMaEnvelopes(5, 2.5, MaType.EMA);
 
         Assert.AreEqual(502, e.Count);
 
-        List<MaEnvelopeResult> h = BadQuotes
-            .GetMaEnvelopes(5, 2.5, MaType.HMA)
-            .ToList();
+        IReadOnlyList<MaEnvelopeResult> h = BadQuotes
+            .GetMaEnvelopes(5, 2.5, MaType.HMA);
 
         Assert.AreEqual(502, h.Count);
 
-        List<MaEnvelopeResult> s = BadQuotes
-            .GetMaEnvelopes(5)
-            .ToList();
+        IReadOnlyList<MaEnvelopeResult> s = BadQuotes
+            .GetMaEnvelopes(5);
 
         Assert.AreEqual(502, s.Count);
 
-        List<MaEnvelopeResult> t = BadQuotes
-            .GetMaEnvelopes(5, 2.5, MaType.TEMA)
-            .ToList();
+        IReadOnlyList<MaEnvelopeResult> t = BadQuotes
+            .GetMaEnvelopes(5, 2.5, MaType.TEMA);
 
         Assert.AreEqual(502, t.Count);
 
-        List<MaEnvelopeResult> w = BadQuotes
-            .GetMaEnvelopes(5, 2.5, MaType.WMA)
-            .ToList();
+        IReadOnlyList<MaEnvelopeResult> w = BadQuotes
+            .GetMaEnvelopes(5, 2.5, MaType.WMA);
 
         Assert.AreEqual(502, w.Count);
     }
@@ -324,15 +305,13 @@ public class MaEnvelopesTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<MaEnvelopeResult> r0 = Noquotes
-            .GetMaEnvelopes(10)
-            .ToList();
+        IReadOnlyList<MaEnvelopeResult> r0 = Noquotes
+            .GetMaEnvelopes(10);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<MaEnvelopeResult> r1 = Onequote
-            .GetMaEnvelopes(10)
-            .ToList();
+        IReadOnlyList<MaEnvelopeResult> r1 = Onequote
+            .GetMaEnvelopes(10);
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -340,12 +319,11 @@ public class MaEnvelopesTests : SeriesTestBase
     [TestMethod]
     public void Condense()
     {
-        List<MaEnvelopeResult> r = Quotes
+        IReadOnlyList<MaEnvelopeResult> results = Quotes
             .GetMaEnvelopes(20)
-            .Condense()
-            .ToList();
+            .Condense();
 
-        Assert.AreEqual(483, r.Count);
+        Assert.AreEqual(483, results.Count);
     }
 
     [TestMethod]

--- a/tests/indicators/m-r/Macd/Macd.Tests.cs
+++ b/tests/indicators/m-r/Macd/Macd.Tests.cs
@@ -10,9 +10,8 @@ public class MacdTests : SeriesTestBase
         int slowPeriods = 26;
         int signalPeriods = 9;
 
-        List<MacdResult> results =
-            Quotes.GetMacd(fastPeriods, slowPeriods, signalPeriods)
-            .ToList();
+        IReadOnlyList<MacdResult> results =
+            Quotes.GetMacd(fastPeriods, slowPeriods, signalPeriods);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -46,10 +45,9 @@ public class MacdTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<MacdResult> results = Quotes
+        IReadOnlyList<MacdResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetMacd()
-            .ToList();
+            .GetMacd();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(477, results.Count(x => x.Macd != null));
@@ -58,10 +56,9 @@ public class MacdTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<MacdResult> results = Quotes
+        IReadOnlyList<MacdResult> results = Quotes
             .GetSma(2)
-            .GetMacd()
-            .ToList();
+            .GetMacd();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(476, results.Count(x => x.Macd != null));
@@ -70,10 +67,9 @@ public class MacdTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetMacd()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(468, results.Count(x => x.Sma != null));
@@ -82,9 +78,8 @@ public class MacdTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<MacdResult> r = BadQuotes
-            .GetMacd(10, 20, 5)
-            .ToList();
+        IReadOnlyList<MacdResult> r = BadQuotes
+            .GetMacd(10, 20, 5);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Macd is double.NaN));
@@ -93,15 +88,13 @@ public class MacdTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<MacdResult> r0 = Noquotes
-            .GetMacd()
-            .ToList();
+        IReadOnlyList<MacdResult> r0 = Noquotes
+            .GetMacd();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<MacdResult> r1 = Onequote
-            .GetMacd()
-            .ToList();
+        IReadOnlyList<MacdResult> r1 = Onequote
+            .GetMacd();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -113,15 +106,14 @@ public class MacdTests : SeriesTestBase
         int slowPeriods = 26;
         int signalPeriods = 9;
 
-        List<MacdResult> results = Quotes
+        IReadOnlyList<MacdResult> results = Quotes
             .GetMacd(fastPeriods, slowPeriods, signalPeriods)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - (slowPeriods + signalPeriods + 250), results.Count);
 
-        MacdResult last = results.LastOrDefault();
+        MacdResult last = results[^1];
         Assert.AreEqual(-6.2198, last.Macd.Round(4));
         Assert.AreEqual(-5.8569, last.Signal.Round(4));
         Assert.AreEqual(-0.3629, last.Histogram.Round(4));

--- a/tests/indicators/m-r/Mama/Mama.Tests.cs
+++ b/tests/indicators/m-r/Mama/Mama.Tests.cs
@@ -9,9 +9,8 @@ public class MamaTests : SeriesTestBase
         double fastLimit = 0.5;
         double slowLimit = 0.05;
 
-        List<MamaResult> results = Quotes
-            .GetMama(fastLimit, slowLimit)
-            .ToList();
+        IReadOnlyList<MamaResult> results = Quotes
+            .GetMama(fastLimit, slowLimit);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -50,10 +49,9 @@ public class MamaTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<MamaResult> results = Quotes
+        IReadOnlyList<MamaResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetMama()
-            .ToList();
+            .GetMama();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(497, results.Count(x => x.Mama != null));
@@ -62,10 +60,9 @@ public class MamaTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<MamaResult> results = Quotes
+        IReadOnlyList<MamaResult> results = Quotes
             .GetSma(2)
-            .GetMama()
-            .ToList();
+            .GetMama();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(496, results.Count(x => x.Mama != null));
@@ -74,10 +71,9 @@ public class MamaTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetMama()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(488, results.Count(x => x.Sma != null));
@@ -86,9 +82,8 @@ public class MamaTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<MamaResult> r = BadQuotes
-            .GetMama()
-            .ToList();
+        IReadOnlyList<MamaResult> r = BadQuotes
+            .GetMama();
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Mama is double.NaN));
@@ -97,15 +92,11 @@ public class MamaTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<MamaResult> r0 = Noquotes
-            .GetMama()
-            .ToList();
+        IReadOnlyList<MamaResult> r0 = Noquotes.GetMama();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<MamaResult> r1 = Onequote
-            .GetMama()
-            .ToList();
+        IReadOnlyList<MamaResult> r1 = Onequote.GetMama();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -116,15 +107,14 @@ public class MamaTests : SeriesTestBase
         double fastLimit = 0.5;
         double slowLimit = 0.05;
 
-        List<MamaResult> results = Quotes
+        IReadOnlyList<MamaResult> results = Quotes
             .GetMama(fastLimit, slowLimit)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 50, results.Count);
 
-        MamaResult last = results.LastOrDefault();
+        MamaResult last = results[^1];
         Assert.AreEqual(244.1092, last.Mama.Round(4));
         Assert.AreEqual(252.6139, last.Fama.Round(4));
     }

--- a/tests/indicators/m-r/Marubozu/Marubozu.Tests.cs
+++ b/tests/indicators/m-r/Marubozu/Marubozu.Tests.cs
@@ -6,9 +6,8 @@ public class MarubozuTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<CandleResult> results = Quotes
-            .GetMarubozu()
-            .ToList();
+        IReadOnlyList<CandleResult> results = Quotes
+            .GetMarubozu();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -43,9 +42,8 @@ public class MarubozuTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<CandleResult> r = BadQuotes
-            .GetMarubozu()
-            .ToList();
+        IReadOnlyList<CandleResult> r = BadQuotes
+            .GetMarubozu();
 
         Assert.AreEqual(502, r.Count);
     }
@@ -53,15 +51,13 @@ public class MarubozuTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<CandleResult> r0 = Noquotes
-            .GetMarubozu()
-            .ToList();
+        IReadOnlyList<CandleResult> r0 = Noquotes
+            .GetMarubozu();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<CandleResult> r1 = Onequote
-            .GetMarubozu()
-            .ToList();
+        IReadOnlyList<CandleResult> r1 = Onequote
+            .GetMarubozu();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -69,12 +65,11 @@ public class MarubozuTests : SeriesTestBase
     [TestMethod]
     public void Condense()
     {
-        List<CandleResult> r = Quotes
+        IReadOnlyList<CandleResult> results = Quotes
             .GetMarubozu()
-            .Condense()
-            .ToList();
+            .Condense();
 
-        Assert.AreEqual(6, r.Count);
+        Assert.AreEqual(6, results.Count);
     }
 
     [TestMethod]

--- a/tests/indicators/m-r/Mfi/Mfi.Tests.cs
+++ b/tests/indicators/m-r/Mfi/Mfi.Tests.cs
@@ -6,9 +6,8 @@ public class MfiTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<MfiResult> results = Quotes
-            .GetMfi()
-            .ToList();
+        IReadOnlyList<MfiResult> results = Quotes
+            .GetMfi();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -25,10 +24,9 @@ public class MfiTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetMfi()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(479, results.Count(x => x.Sma != null));
@@ -39,9 +37,8 @@ public class MfiTests : SeriesTestBase
     {
         int lookbackPeriods = 4;
 
-        List<MfiResult> results = Quotes
-            .GetMfi(lookbackPeriods)
-            .ToList();
+        IReadOnlyList<MfiResult> results = Quotes
+            .GetMfi(lookbackPeriods);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -58,9 +55,8 @@ public class MfiTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<MfiResult> r = BadQuotes
-            .GetMfi(15)
-            .ToList();
+        IReadOnlyList<MfiResult> r = BadQuotes
+            .GetMfi(15);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Mfi is double.NaN));
@@ -69,15 +65,13 @@ public class MfiTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<MfiResult> r0 = Noquotes
-            .GetMfi()
-            .ToList();
+        IReadOnlyList<MfiResult> r0 = Noquotes
+            .GetMfi();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<MfiResult> r1 = Onequote
-            .GetMfi()
-            .ToList();
+        IReadOnlyList<MfiResult> r1 = Onequote
+            .GetMfi();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -87,15 +81,14 @@ public class MfiTests : SeriesTestBase
     {
         int lookbackPeriods = 14;
 
-        List<MfiResult> results = Quotes
+        IReadOnlyList<MfiResult> results = Quotes
             .GetMfi(lookbackPeriods)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 14, results.Count);
 
-        MfiResult last = results.LastOrDefault();
+        MfiResult last = results[^1];
         Assert.AreEqual(39.9494, last.Mfi.Round(4));
     }
 

--- a/tests/indicators/m-r/Obv/Obv.Tests.cs
+++ b/tests/indicators/m-r/Obv/Obv.Tests.cs
@@ -6,9 +6,8 @@ public class ObvTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<ObvResult> results = Quotes
-            .GetObv()
-            .ToList();
+        IReadOnlyList<ObvResult> results = Quotes
+            .GetObv();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -24,10 +23,9 @@ public class ObvTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetObv()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(493, results.Count(x => x.Sma != null));
@@ -36,9 +34,8 @@ public class ObvTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<ObvResult> r = BadQuotes
-            .GetObv()
-            .ToList();
+        IReadOnlyList<ObvResult> r = BadQuotes
+            .GetObv();
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => double.IsNaN(x.Obv)));
@@ -47,9 +44,8 @@ public class ObvTests : SeriesTestBase
     [TestMethod]
     public void BigData()
     {
-        List<ObvResult> r = BigQuotes
-            .GetObv()
-            .ToList();
+        IReadOnlyList<ObvResult> r = BigQuotes
+            .GetObv();
 
         Assert.AreEqual(1246, r.Count);
     }
@@ -57,15 +53,13 @@ public class ObvTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<ObvResult> r0 = Noquotes
-            .GetObv()
-            .ToList();
+        IReadOnlyList<ObvResult> r0 = Noquotes
+            .GetObv();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<ObvResult> r1 = Onequote
-            .GetObv()
-            .ToList();
+        IReadOnlyList<ObvResult> r1 = Onequote
+            .GetObv();
 
         Assert.AreEqual(1, r1.Count);
     }

--- a/tests/indicators/m-r/ParabolicSar/ParabolicSar.Tests.cs
+++ b/tests/indicators/m-r/ParabolicSar/ParabolicSar.Tests.cs
@@ -9,7 +9,7 @@ public class ParabolicSarTests : SeriesTestBase
         double acclerationStep = 0.02;
         double maxAccelerationFactor = 0.2;
 
-        List<ParabolicSarResult> results =
+        IReadOnlyList<ParabolicSarResult> results =
             Quotes.GetParabolicSar(acclerationStep, maxAccelerationFactor)
                 .ToList();
 
@@ -42,7 +42,7 @@ public class ParabolicSarTests : SeriesTestBase
         double maxAccelerationFactor = 0.2;
         double initialStep = 0.01;
 
-        List<ParabolicSarResult> results =
+        IReadOnlyList<ParabolicSarResult> results =
             Quotes.GetParabolicSar(
                 acclerationStep, maxAccelerationFactor, initialStep)
                 .ToList();
@@ -76,10 +76,9 @@ public class ParabolicSarTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetParabolicSar()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(479, results.Count(x => x.Sma != null));
@@ -95,7 +94,7 @@ public class ParabolicSarTests : SeriesTestBase
             .OrderBy(x => x.Timestamp)
             .Take(10);
 
-        List<ParabolicSarResult> results =
+        IReadOnlyList<ParabolicSarResult> results =
             insufficientQuotes.GetParabolicSar(acclerationStep, maxAccelerationFactor)
                 .ToList();
 
@@ -109,9 +108,8 @@ public class ParabolicSarTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<ParabolicSarResult> r = BadQuotes
-            .GetParabolicSar(0.2, 0.2, 0.2)
-            .ToList();
+        IReadOnlyList<ParabolicSarResult> r = BadQuotes
+            .GetParabolicSar(0.2, 0.2, 0.2);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Sar is double.NaN));
@@ -120,15 +118,13 @@ public class ParabolicSarTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<ParabolicSarResult> r0 = Noquotes
-            .GetParabolicSar()
-            .ToList();
+        IReadOnlyList<ParabolicSarResult> r0 = Noquotes
+            .GetParabolicSar();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<ParabolicSarResult> r1 = Onequote
-            .GetParabolicSar()
-            .ToList();
+        IReadOnlyList<ParabolicSarResult> r1 = Onequote
+            .GetParabolicSar();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -139,15 +135,14 @@ public class ParabolicSarTests : SeriesTestBase
         double acclerationStep = 0.02;
         double maxAccelerationFactor = 0.2;
 
-        List<ParabolicSarResult> results = Quotes
+        IReadOnlyList<ParabolicSarResult> results = Quotes
             .GetParabolicSar(acclerationStep, maxAccelerationFactor)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(488, results.Count);
 
-        ParabolicSarResult last = results.LastOrDefault();
+        ParabolicSarResult last = results[^1];
         Assert.AreEqual(229.7662, last.Sar.Round(4));
         Assert.AreEqual(false, last.IsReversal);
     }

--- a/tests/indicators/m-r/PivotPoints/PivotPoints.Tests.cs
+++ b/tests/indicators/m-r/PivotPoints/PivotPoints.Tests.cs
@@ -9,9 +9,8 @@ public class PivotPointsTests : SeriesTestBase
         PeriodSize periodSize = PeriodSize.Month;
         PivotPointType pointType = PivotPointType.Standard;
 
-        List<PivotPointsResult> results = Quotes
-            .GetPivotPoints(periodSize, pointType)
-            .ToList();
+        IReadOnlyList<PivotPointsResult> results = Quotes
+            .GetPivotPoints(periodSize, pointType);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -92,8 +91,7 @@ public class PivotPointsTests : SeriesTestBase
         PivotPointType pointType = PivotPointType.Camarilla;
 
         IEnumerable<Quote> h = Data.GetDefault(38);
-        List<PivotPointsResult> results = h.GetPivotPoints(periodSize, pointType)
-            .ToList();
+        IReadOnlyList<PivotPointsResult> results = h.GetPivotPoints(periodSize, pointType);
 
         // proper quantities
         Assert.AreEqual(38, results.Count);
@@ -162,9 +160,8 @@ public class PivotPointsTests : SeriesTestBase
         PeriodSize periodSize = PeriodSize.Month;
         PivotPointType pointType = PivotPointType.Demark;
 
-        List<PivotPointsResult> results = Quotes
-            .GetPivotPoints(periodSize, pointType)
-            .ToList();
+        IReadOnlyList<PivotPointsResult> results = Quotes
+            .GetPivotPoints(periodSize, pointType);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -249,8 +246,7 @@ public class PivotPointsTests : SeriesTestBase
         PivotPointType pointType = PivotPointType.Fibonacci;
 
         IEnumerable<Quote> h = Data.GetIntraday(300);
-        List<PivotPointsResult> results = h.GetPivotPoints(periodSize, pointType)
-            .ToList();
+        IReadOnlyList<PivotPointsResult> results = h.GetPivotPoints(periodSize, pointType);
 
         // proper quantities
         Assert.AreEqual(300, results.Count);
@@ -321,8 +317,7 @@ public class PivotPointsTests : SeriesTestBase
         PivotPointType pointType = PivotPointType.Woodie;
 
         IEnumerable<Quote> h = Data.GetIntraday();
-        List<PivotPointsResult> results = h.GetPivotPoints(periodSize, pointType)
-            .ToList();
+        IReadOnlyList<PivotPointsResult> results = h.GetPivotPoints(periodSize, pointType);
 
         // proper quantities
         Assert.AreEqual(1564, results.Count);
@@ -380,9 +375,8 @@ public class PivotPointsTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<PivotPointsResult> r = BadQuotes
-            .GetPivotPoints(PeriodSize.Week)
-            .ToList();
+        IReadOnlyList<PivotPointsResult> r = BadQuotes
+            .GetPivotPoints(PeriodSize.Week);
 
         Assert.AreEqual(502, r.Count);
     }
@@ -390,15 +384,13 @@ public class PivotPointsTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<PivotPointsResult> r0 = Noquotes
-            .GetPivotPoints(PeriodSize.Week)
-            .ToList();
+        IReadOnlyList<PivotPointsResult> r0 = Noquotes
+            .GetPivotPoints(PeriodSize.Week);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<PivotPointsResult> r1 = Onequote
-            .GetPivotPoints(PeriodSize.Week)
-            .ToList();
+        IReadOnlyList<PivotPointsResult> r1 = Onequote
+            .GetPivotPoints(PeriodSize.Week);
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -409,15 +401,14 @@ public class PivotPointsTests : SeriesTestBase
         PeriodSize periodSize = PeriodSize.Month;
         PivotPointType pointType = PivotPointType.Standard;
 
-        List<PivotPointsResult> results = Quotes
+        IReadOnlyList<PivotPointsResult> results = Quotes
             .GetPivotPoints(periodSize, pointType)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(482, results.Count);
 
-        PivotPointsResult last = results.LastOrDefault();
+        PivotPointsResult last = results[^1];
         Assert.AreEqual(266.6767m, last.PP.Round(4));
         Assert.AreEqual(258.9633m, last.S1.Round(4));
         Assert.AreEqual(248.9667m, last.S2.Round(4));

--- a/tests/indicators/m-r/Pivots/Pivots.Tests.cs
+++ b/tests/indicators/m-r/Pivots/Pivots.Tests.cs
@@ -6,9 +6,8 @@ public class PivotsTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<PivotsResult> results = Quotes
-            .GetPivots(4, 4)
-            .ToList();
+        IReadOnlyList<PivotsResult> results = Quotes
+            .GetPivots(4, 4);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -88,9 +87,8 @@ public class PivotsTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<PivotsResult> r = BadQuotes
-            .GetPivots()
-            .ToList();
+        IReadOnlyList<PivotsResult> r = BadQuotes
+            .GetPivots();
 
         Assert.AreEqual(502, r.Count);
     }
@@ -98,15 +96,13 @@ public class PivotsTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<PivotsResult> r0 = Noquotes
-            .GetPivots()
-            .ToList();
+        IReadOnlyList<PivotsResult> r0 = Noquotes
+            .GetPivots();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<PivotsResult> r1 = Onequote
-            .GetPivots()
-            .ToList();
+        IReadOnlyList<PivotsResult> r1 = Onequote
+            .GetPivots();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -114,12 +110,11 @@ public class PivotsTests : SeriesTestBase
     [TestMethod]
     public void Condense()
     {
-        List<PivotsResult> r = Quotes
+        IReadOnlyList<PivotsResult> results = Quotes
             .GetPivots(4, 4)
-            .Condense()
-            .ToList();
+            .Condense();
 
-        Assert.AreEqual(67, r.Count);
+        Assert.AreEqual(67, results.Count);
     }
 
     [TestMethod]

--- a/tests/indicators/m-r/Pmo/Pmo.Tests.cs
+++ b/tests/indicators/m-r/Pmo/Pmo.Tests.cs
@@ -6,9 +6,8 @@ public class PmoTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<PmoResult> results = Quotes
-            .GetPmo()
-            .ToList();
+        IReadOnlyList<PmoResult> results = Quotes
+            .GetPmo();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -28,10 +27,9 @@ public class PmoTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<PmoResult> results = Quotes
+        IReadOnlyList<PmoResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetPmo()
-            .ToList();
+            .GetPmo();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(448, results.Count(x => x.Pmo != null));
@@ -40,10 +38,9 @@ public class PmoTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<PmoResult> results = Quotes
+        IReadOnlyList<PmoResult> results = Quotes
             .GetSma(2)
-            .GetPmo()
-            .ToList();
+            .GetPmo();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(447, results.Count(x => x.Pmo != null));
@@ -52,10 +49,9 @@ public class PmoTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetPmo()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(439, results.Count(x => x.Sma != null));
@@ -64,9 +60,8 @@ public class PmoTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<PmoResult> r = BadQuotes
-            .GetPmo(25, 15, 5)
-            .ToList();
+        IReadOnlyList<PmoResult> r = BadQuotes
+            .GetPmo(25, 15, 5);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Pmo is double.NaN));
@@ -75,15 +70,13 @@ public class PmoTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<PmoResult> r0 = Noquotes
-            .GetPmo()
-            .ToList();
+        IReadOnlyList<PmoResult> r0 = Noquotes
+            .GetPmo();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<PmoResult> r1 = Onequote
-            .GetPmo()
-            .ToList();
+        IReadOnlyList<PmoResult> r1 = Onequote
+            .GetPmo();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -91,15 +84,14 @@ public class PmoTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<PmoResult> results = Quotes
+        IReadOnlyList<PmoResult> results = Quotes
             .GetPmo()
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - (35 + 20 + 250), results.Count);
 
-        PmoResult last = results.LastOrDefault();
+        PmoResult last = results[^1];
         Assert.AreEqual(-2.7016, last.Pmo.Round(4));
         Assert.AreEqual(-2.3117, last.Signal.Round(4));
     }

--- a/tests/indicators/m-r/Prs/Prs.Tests.cs
+++ b/tests/indicators/m-r/Prs/Prs.Tests.cs
@@ -8,9 +8,8 @@ public class PrsTests : SeriesTestBase
     {
         int lookbackPeriods = 30;
 
-        List<PrsResult> results = OtherQuotes
-            .GetPrs(Quotes, lookbackPeriods)
-            .ToList();
+        IReadOnlyList<PrsResult> results = OtherQuotes
+            .GetPrs(Quotes, lookbackPeriods);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -33,10 +32,9 @@ public class PrsTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<PrsResult> results = OtherQuotes
+        IReadOnlyList<PrsResult> results = OtherQuotes
             .Use(CandlePart.Close)
-            .GetPrs(Quotes.Use(CandlePart.Close), 20)
-            .ToList();
+            .GetPrs(Quotes.Use(CandlePart.Close), 20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(502, results.Count(x => x.Prs != null));
@@ -45,10 +43,9 @@ public class PrsTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = OtherQuotes
+        IReadOnlyList<SmaResult> results = OtherQuotes
             .GetPrs(Quotes, 20)
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(493, results.Count(x => x.Sma != null));
@@ -57,10 +54,9 @@ public class PrsTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<PrsResult> results = Quotes
+        IReadOnlyList<PrsResult> results = Quotes
             .GetSma(2)
-            .GetPrs(OtherQuotes.GetSma(2), 20)
-            .ToList();
+            .GetPrs(OtherQuotes.GetSma(2), 20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(501, results.Count(x => x.Prs != null));
@@ -70,9 +66,8 @@ public class PrsTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<PrsResult> r = BadQuotes
-            .GetPrs(BadQuotes, 15)
-            .ToList();
+        IReadOnlyList<PrsResult> r = BadQuotes
+            .GetPrs(BadQuotes, 15);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Prs is double.NaN));
@@ -81,15 +76,13 @@ public class PrsTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<PrsResult> r0 = Noquotes
-            .GetPrs(Noquotes)
-            .ToList();
+        IReadOnlyList<PrsResult> r0 = Noquotes
+            .GetPrs(Noquotes);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<PrsResult> r1 = Onequote
-            .GetPrs(Onequote)
-            .ToList();
+        IReadOnlyList<PrsResult> r1 = Onequote
+            .GetPrs(Onequote);
 
         Assert.AreEqual(1, r1.Count);
     }

--- a/tests/indicators/m-r/Pvo/Pvo.Tests.cs
+++ b/tests/indicators/m-r/Pvo/Pvo.Tests.cs
@@ -10,9 +10,8 @@ public class PvoTests : SeriesTestBase
         int slowPeriods = 26;
         int signalPeriods = 9;
 
-        List<PvoResult> results =
-            Quotes.GetPvo(fastPeriods, slowPeriods, signalPeriods)
-            .ToList();
+        IReadOnlyList<PvoResult> results =
+            Quotes.GetPvo(fastPeriods, slowPeriods, signalPeriods);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -50,10 +49,9 @@ public class PvoTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetPvo()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(468, results.Count(x => x.Sma != null));
@@ -62,9 +60,8 @@ public class PvoTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<PvoResult> r = BadQuotes
-            .GetPvo(10, 20, 5)
-            .ToList();
+        IReadOnlyList<PvoResult> r = BadQuotes
+            .GetPvo(10, 20, 5);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Pvo is double.NaN));
@@ -73,15 +70,13 @@ public class PvoTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<PvoResult> r0 = Noquotes
-            .GetPvo()
-            .ToList();
+        IReadOnlyList<PvoResult> r0 = Noquotes
+            .GetPvo();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<PvoResult> r1 = Onequote
-            .GetPvo()
-            .ToList();
+        IReadOnlyList<PvoResult> r1 = Onequote
+            .GetPvo();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -93,15 +88,14 @@ public class PvoTests : SeriesTestBase
         int slowPeriods = 26;
         int signalPeriods = 9;
 
-        List<PvoResult> results = Quotes
+        IReadOnlyList<PvoResult> results = Quotes
             .GetPvo(fastPeriods, slowPeriods, signalPeriods)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - (slowPeriods + signalPeriods + 250), results.Count);
 
-        PvoResult last = results.LastOrDefault();
+        PvoResult last = results[^1];
         Assert.AreEqual(10.4395, last.Pvo.Round(4));
         Assert.AreEqual(12.2681, last.Signal.Round(4));
         Assert.AreEqual(-1.8286, last.Histogram.Round(4));

--- a/tests/indicators/m-r/Renko/Renko.Series.Tests.cs
+++ b/tests/indicators/m-r/Renko/Renko.Series.Tests.cs
@@ -6,9 +6,8 @@ public class RenkoTests : SeriesTestBase
     [TestMethod]
     public override void Standard()  // close
     {
-        List<RenkoResult> results = Quotes
-            .GetRenko(2.5m)
-            .ToList();
+        IReadOnlyList<RenkoResult> results = Quotes
+            .GetRenko(2.5m);
 
         // assertions
 
@@ -33,7 +32,7 @@ public class RenkoTests : SeriesTestBase
         Assert.AreEqual(4192959240m, r5.Volume);
         Assert.IsTrue(r5.IsUp);
 
-        RenkoResult last = results.LastOrDefault();
+        RenkoResult last = results[^1];
         Assert.AreEqual(240.5m, last.Open);
         Assert.AreEqual(243.68m, last.High);
         Assert.AreEqual(234.52m, last.Low);
@@ -45,9 +44,8 @@ public class RenkoTests : SeriesTestBase
     [TestMethod]
     public void StandardHighLow()
     {
-        List<RenkoResult> results = Quotes
-            .GetRenko(2.5m, EndType.HighLow)
-            .ToList();
+        IReadOnlyList<RenkoResult> results = Quotes
+            .GetRenko(2.5m, EndType.HighLow);
 
         // assertions
 
@@ -70,7 +68,7 @@ public class RenkoTests : SeriesTestBase
         Assert.AreEqual(100801672m, r25.Volume.Round(0));
         Assert.IsTrue(r25.IsUp);
 
-        RenkoResult last = results.LastOrDefault();
+        RenkoResult last = results[^1];
         Assert.AreEqual(243m, last.Open);
         Assert.AreEqual(246.73m, last.High);
         Assert.AreEqual(241.87m, last.Low);
@@ -82,9 +80,8 @@ public class RenkoTests : SeriesTestBase
     [TestMethod]
     public void Atr()
     {
-        List<RenkoResult> results = Quotes
-            .GetRenkoAtr(14)
-            .ToList();
+        IReadOnlyList<RenkoResult> results = Quotes
+            .GetRenkoAtr(14);
 
         // proper quantities
         Assert.AreEqual(29, results.Count);
@@ -98,7 +95,7 @@ public class RenkoTests : SeriesTestBase
         Assert.AreEqual(2090292272m, r0.Volume.Round(0));
         Assert.IsTrue(r0.IsUp);
 
-        RenkoResult last = results.LastOrDefault();
+        RenkoResult last = results[^1];
         Assert.AreEqual(237.3990m, last.Open.Round(4));
         Assert.AreEqual(246.73m, last.High.Round(4));
         Assert.AreEqual(229.42m, last.Low.Round(4));
@@ -118,9 +115,8 @@ public class RenkoTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<RenkoResult> r = BadQuotes
-            .GetRenko(100m)
-            .ToList();
+        IReadOnlyList<RenkoResult> r = BadQuotes
+            .GetRenko(100m);
 
         Assert.AreNotEqual(0, r.Count);
     }
@@ -128,9 +124,8 @@ public class RenkoTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<RenkoResult> r0 = Noquotes
-            .GetRenko(0.01m)
-            .ToList();
+        IReadOnlyList<RenkoResult> r0 = Noquotes
+            .GetRenko(0.01m);
 
         Assert.AreEqual(0, r0.Count);
     }

--- a/tests/indicators/m-r/Renko/Renko.Stream.Tests.cs
+++ b/tests/indicators/m-r/Renko/Renko.Stream.Tests.cs
@@ -58,9 +58,8 @@ public class RenkoTests : StreamTestBase, ITestChainProvider
         quotesList.RemoveAt(400);
 
         // time-series, for comparison
-        List<RenkoResult> seriesList = quotesList
-            .GetRenko(brickSize, endType)
-            .ToList();
+        IReadOnlyList<RenkoResult> seriesList = quotesList
+            .GetRenko(brickSize, endType);
 
         // assert, should equal series
         for (int i = 0; i < seriesList.Count - 1; i++)
@@ -119,10 +118,9 @@ public class RenkoTests : StreamTestBase, ITestChainProvider
             = observer.Results;
 
         // time-series, for comparison
-        List<SmaResult> seriesList = quotesList
+        IReadOnlyList<SmaResult> seriesList = quotesList
             .GetRenko(brickSize, endType)
-            .GetSma(smaPeriods)
-            .ToList();
+            .GetSma(smaPeriods);
 
         // assert, should equal series
         for (int i = 0; i < seriesList.Count - 1; i++)

--- a/tests/indicators/m-r/Roc/Roc.Tests.cs
+++ b/tests/indicators/m-r/Roc/Roc.Tests.cs
@@ -6,9 +6,8 @@ public class RocTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<RocResult> results = Quotes
-            .GetRoc(20)
-            .ToList();
+        IReadOnlyList<RocResult> results = Quotes
+            .GetRoc(20);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -32,10 +31,9 @@ public class RocTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<RocResult> results = Quotes
+        IReadOnlyList<RocResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetRoc(20)
-            .ToList();
+            .GetRoc(20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(482, results.Count(x => x.Roc != null));
@@ -44,10 +42,9 @@ public class RocTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<RocResult> results = Quotes
+        IReadOnlyList<RocResult> results = Quotes
             .GetSma(2)
-            .GetRoc(20)
-            .ToList();
+            .GetRoc(20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(481, results.Count(x => x.Roc != null));
@@ -56,10 +53,9 @@ public class RocTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetRoc(20)
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(473, results.Count(x => x.Sma != null));
@@ -68,9 +64,8 @@ public class RocTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<RocResult> r = BadQuotes
-            .GetRoc(35)
-            .ToList();
+        IReadOnlyList<RocResult> r = BadQuotes
+            .GetRoc(35);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Roc is double.NaN));
@@ -79,15 +74,13 @@ public class RocTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<RocResult> r0 = Noquotes
-            .GetRoc(5)
-            .ToList();
+        IReadOnlyList<RocResult> r0 = Noquotes
+            .GetRoc(5);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<RocResult> r1 = Onequote
-            .GetRoc(5)
-            .ToList();
+        IReadOnlyList<RocResult> r1 = Onequote
+            .GetRoc(5);
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -95,15 +88,14 @@ public class RocTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<RocResult> results = Quotes
+        IReadOnlyList<RocResult> results = Quotes
             .GetRoc(20)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 20, results.Count);
 
-        RocResult last = results.LastOrDefault();
+        RocResult last = results[^1];
         Assert.AreEqual(-8.2482, last.Roc.Round(4));
     }
 

--- a/tests/indicators/m-r/RocWb/RocWb.Tests.cs
+++ b/tests/indicators/m-r/RocWb/RocWb.Tests.cs
@@ -6,9 +6,8 @@ public class RocWbTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<RocWbResult> results = Quotes
-            .GetRocWb(20, 3, 20)
-            .ToList();
+        IReadOnlyList<RocWbResult> results = Quotes
+            .GetRocWb(20, 3, 20);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -70,10 +69,9 @@ public class RocWbTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<RocWbResult> results = Quotes
+        IReadOnlyList<RocWbResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetRocWb(20, 3, 20)
-            .ToList();
+            .GetRocWb(20, 3, 20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(482, results.Count(x => x.Roc != null));
@@ -82,10 +80,9 @@ public class RocWbTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<RocWbResult> results = Quotes
+        IReadOnlyList<RocWbResult> results = Quotes
             .GetSma(2)
-            .GetRocWb(20, 3, 20)
-            .ToList();
+            .GetRocWb(20, 3, 20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(481, results.Count(x => x.Roc != null));
@@ -94,10 +91,9 @@ public class RocWbTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetRocWb(20, 3, 20)
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(473, results.Count(x => x.Sma != null));
@@ -106,9 +102,8 @@ public class RocWbTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<RocWbResult> r = BadQuotes
-            .GetRocWb(35, 3, 35)
-            .ToList();
+        IReadOnlyList<RocWbResult> r = BadQuotes
+            .GetRocWb(35, 3, 35);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Roc is double.NaN));
@@ -117,15 +112,13 @@ public class RocWbTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<RocWbResult> r0 = Noquotes
-            .GetRocWb(5, 3, 2)
-            .ToList();
+        IReadOnlyList<RocWbResult> r0 = Noquotes
+            .GetRocWb(5, 3, 2);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<RocWbResult> r1 = Onequote
-            .GetRocWb(5, 3, 2)
-            .ToList();
+        IReadOnlyList<RocWbResult> r1 = Onequote
+            .GetRocWb(5, 3, 2);
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -133,15 +126,14 @@ public class RocWbTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<RocWbResult> results = Quotes
+        IReadOnlyList<RocWbResult> results = Quotes
             .GetRocWb(20, 3, 20)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - (20 + 3 + 100), results.Count);
 
-        RocWbResult last = results.LastOrDefault();
+        RocWbResult last = results[^1];
         Assert.AreEqual(-8.2482, Math.Round(last.Roc.Value, 4));
         Assert.AreEqual(-8.3390, Math.Round(last.RocEma.Value, 4));
         Assert.AreEqual(6.1294, Math.Round(last.UpperBand.Value, 4));

--- a/tests/indicators/m-r/RollingPivots/RollingPivots.Tests.cs
+++ b/tests/indicators/m-r/RollingPivots/RollingPivots.Tests.cs
@@ -10,9 +10,8 @@ public class RollingPivotsTests : SeriesTestBase
         int offsetPeriods = 9;
         PivotPointType pointType = PivotPointType.Standard;
 
-        List<RollingPivotsResult> results =
-            Quotes.GetRollingPivots(windowPeriods, offsetPeriods, pointType)
-            .ToList();
+        IReadOnlyList<RollingPivotsResult> results =
+            Quotes.GetRollingPivots(windowPeriods, offsetPeriods, pointType);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -84,9 +83,8 @@ public class RollingPivotsTests : SeriesTestBase
 
         IEnumerable<Quote> h = Data.GetDefault(38);
 
-        List<RollingPivotsResult> results = h
-            .GetRollingPivots(windowPeriods, offsetPeriods, pointType)
-            .ToList();
+        IReadOnlyList<RollingPivotsResult> results = h
+            .GetRollingPivots(windowPeriods, offsetPeriods, pointType);
 
         // proper quantities
         Assert.AreEqual(38, results.Count);
@@ -156,9 +154,8 @@ public class RollingPivotsTests : SeriesTestBase
         int offsetPeriods = 10;
         PivotPointType pointType = PivotPointType.Demark;
 
-        List<RollingPivotsResult> results = Quotes
-            .GetRollingPivots(windowPeriods, offsetPeriods, pointType)
-            .ToList();
+        IReadOnlyList<RollingPivotsResult> results = Quotes
+            .GetRollingPivots(windowPeriods, offsetPeriods, pointType);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -241,9 +238,8 @@ public class RollingPivotsTests : SeriesTestBase
 
         IEnumerable<Quote> h = Data.GetIntraday(300);
 
-        List<RollingPivotsResult> results =
-            h.GetRollingPivots(windowPeriods, offsetPeriods, pointType)
-            .ToList();
+        IReadOnlyList<RollingPivotsResult> results =
+            h.GetRollingPivots(windowPeriods, offsetPeriods, pointType);
 
         // proper quantities
         Assert.AreEqual(300, results.Count);
@@ -316,9 +312,8 @@ public class RollingPivotsTests : SeriesTestBase
 
         IEnumerable<Quote> h = Data.GetIntraday();
 
-        List<RollingPivotsResult> results = h
-            .GetRollingPivots(windowPeriods, offsetPeriods, pointType)
-            .ToList();
+        IReadOnlyList<RollingPivotsResult> results = h
+            .GetRollingPivots(windowPeriods, offsetPeriods, pointType);
 
         // proper quantities
         Assert.AreEqual(1564, results.Count);
@@ -376,9 +371,8 @@ public class RollingPivotsTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<RollingPivotsResult> r = BadQuotes
-            .GetRollingPivots(5, 5)
-            .ToList();
+        IReadOnlyList<RollingPivotsResult> r = BadQuotes
+            .GetRollingPivots(5, 5);
 
         Assert.AreEqual(502, r.Count);
     }
@@ -386,15 +380,13 @@ public class RollingPivotsTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<RollingPivotsResult> r0 = Noquotes
-            .GetRollingPivots(5, 2)
-            .ToList();
+        IReadOnlyList<RollingPivotsResult> r0 = Noquotes
+            .GetRollingPivots(5, 2);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<RollingPivotsResult> r1 = Onequote
-            .GetRollingPivots(5, 2)
-            .ToList();
+        IReadOnlyList<RollingPivotsResult> r1 = Onequote
+            .GetRollingPivots(5, 2);
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -406,15 +398,14 @@ public class RollingPivotsTests : SeriesTestBase
         int offsetPeriods = 9;
         PivotPointType pointType = PivotPointType.Standard;
 
-        List<RollingPivotsResult> results = Quotes
+        IReadOnlyList<RollingPivotsResult> results = Quotes
             .GetRollingPivots(windowPeriods, offsetPeriods, pointType)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - (windowPeriods + offsetPeriods), results.Count);
 
-        RollingPivotsResult last = results.LastOrDefault();
+        RollingPivotsResult last = results[^1];
         Assert.AreEqual(260.0267m, last.PP.Round(4));
         Assert.AreEqual(246.4633m, last.S1.Round(4));
         Assert.AreEqual(238.7767m, last.S2.Round(4));

--- a/tests/indicators/m-r/Rsi/Rsi.Tests.cs
+++ b/tests/indicators/m-r/Rsi/Rsi.Tests.cs
@@ -6,9 +6,8 @@ public class RsiTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<RsiResult> results = Quotes
-            .GetRsi()
-            .ToList();
+        IReadOnlyList<RsiResult> results = Quotes
+            .GetRsi();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -32,9 +31,8 @@ public class RsiTests : SeriesTestBase
     public void SmallLookback()
     {
         int lookbackPeriods = 1;
-        List<RsiResult> results = Quotes
-            .GetRsi(lookbackPeriods)
-            .ToList();
+        IReadOnlyList<RsiResult> results = Quotes
+            .GetRsi(lookbackPeriods);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -53,9 +51,8 @@ public class RsiTests : SeriesTestBase
     {
         IEnumerable<Quote> btc = Data.GetBitcoin();
 
-        List<RsiResult> r = btc
-            .GetRsi(1)
-            .ToList();
+        IReadOnlyList<RsiResult> r = btc
+            .GetRsi(1);
 
         Assert.AreEqual(1246, r.Count);
     }
@@ -63,10 +60,9 @@ public class RsiTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<RsiResult> results = Quotes
+        IReadOnlyList<RsiResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetRsi()
-            .ToList();
+            .GetRsi();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(488, results.Count(x => x.Rsi != null));
@@ -75,10 +71,9 @@ public class RsiTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<RsiResult> results = Quotes
+        IReadOnlyList<RsiResult> results = Quotes
             .GetSma(2)
-            .GetRsi()
-            .ToList();
+            .GetRsi();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(487, results.Count(x => x.Rsi != null));
@@ -87,10 +82,9 @@ public class RsiTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetRsi()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(479, results.Count(x => x.Sma != null));
@@ -108,9 +102,8 @@ public class RsiTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<RsiResult> r = BadQuotes
-            .GetRsi(20)
-            .ToList();
+        IReadOnlyList<RsiResult> r = BadQuotes
+            .GetRsi(20);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Rsi is double.NaN));
@@ -119,15 +112,13 @@ public class RsiTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<RsiResult> r0 = Noquotes
-            .GetRsi()
-            .ToList();
+        IReadOnlyList<RsiResult> r0 = Noquotes
+            .GetRsi();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<RsiResult> r1 = Onequote
-            .GetRsi()
-            .ToList();
+        IReadOnlyList<RsiResult> r1 = Onequote
+            .GetRsi();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -135,15 +126,14 @@ public class RsiTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<RsiResult> results = Quotes
+        IReadOnlyList<RsiResult> results = Quotes
             .GetRsi()
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 10 * 14, results.Count);
 
-        RsiResult last = results.LastOrDefault();
+        RsiResult last = results[^1];
         Assert.AreEqual(42.0773, last.Rsi.Round(4));
     }
 

--- a/tests/indicators/s-z/Slope/Slope.Tests.cs
+++ b/tests/indicators/s-z/Slope/Slope.Tests.cs
@@ -6,9 +6,8 @@ public class SlopeTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<SlopeResult> results = Quotes
-            .GetSlope(20)
-            .ToList();
+        IReadOnlyList<SlopeResult> results = Quotes
+            .GetSlope(20);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -42,10 +41,9 @@ public class SlopeTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<SlopeResult> results = Quotes
+        IReadOnlyList<SlopeResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetSlope(20)
-            .ToList();
+            .GetSlope(20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(483, results.Count(x => x.Slope != null));
@@ -54,10 +52,9 @@ public class SlopeTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<SlopeResult> results = Quotes
+        IReadOnlyList<SlopeResult> results = Quotes
             .GetSma(2)
-            .GetSlope(20)
-            .ToList();
+            .GetSlope(20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(482, results.Count(x => x.Slope != null));
@@ -66,10 +63,9 @@ public class SlopeTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetSlope(20)
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(474, results.Count(x => x.Sma != null));
@@ -78,9 +74,8 @@ public class SlopeTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<SlopeResult> r = BadQuotes
-            .GetSlope(15)
-            .ToList();
+        IReadOnlyList<SlopeResult> r = BadQuotes
+            .GetSlope(15);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Slope is double.NaN));
@@ -89,9 +84,8 @@ public class SlopeTests : SeriesTestBase
     [TestMethod]
     public void BigData()
     {
-        List<SlopeResult> r = BigQuotes
-            .GetSlope(250)
-            .ToList();
+        IReadOnlyList<SlopeResult> r = BigQuotes
+            .GetSlope(250);
 
         Assert.AreEqual(1246, r.Count);
     }
@@ -99,15 +93,13 @@ public class SlopeTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<SlopeResult> r0 = Noquotes
-            .GetSlope(5)
-            .ToList();
+        IReadOnlyList<SlopeResult> r0 = Noquotes
+            .GetSlope(5);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<SlopeResult> r1 = Onequote
-            .GetSlope(5)
-            .ToList();
+        IReadOnlyList<SlopeResult> r1 = Onequote
+            .GetSlope(5);
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -115,15 +107,14 @@ public class SlopeTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<SlopeResult> results = Quotes
+        IReadOnlyList<SlopeResult> results = Quotes
             .GetSlope(20)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 19, results.Count);
 
-        SlopeResult last = results.LastOrDefault();
+        SlopeResult last = results[^1];
         Assert.AreEqual(-1.689143, last.Slope.Round(6));
         Assert.AreEqual(1083.7629, last.Intercept.Round(4));
         Assert.AreEqual(0.7955, last.RSquared.Round(4));

--- a/tests/indicators/s-z/Sma/Sma.Series.Tests.cs
+++ b/tests/indicators/s-z/Sma/Sma.Series.Tests.cs
@@ -6,9 +6,8 @@ public class SmaTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<SmaResult> results = Quotes
-            .GetSma(20)
-            .ToList();
+        IReadOnlyList<SmaResult> results = Quotes
+            .GetSma(20);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -26,10 +25,9 @@ public class SmaTests : SeriesTestBase
     [TestMethod]
     public void CandlePartOpen()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .Use(CandlePart.Open)
-            .GetSma(20)
-            .ToList();
+            .GetSma(20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(483, results.Count(x => x.Sma != null));
@@ -46,10 +44,9 @@ public class SmaTests : SeriesTestBase
     [TestMethod]
     public void CandlePartVolume()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .Use(CandlePart.Volume)
-            .GetSma(20)
-            .ToList();
+            .GetSma(20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(483, results.Count(x => x.Sma != null));
@@ -69,10 +66,9 @@ public class SmaTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<EmaResult> results = Quotes
+        IReadOnlyList<EmaResult> results = Quotes
             .GetSma(10)
-            .GetEma(10)
-            .ToList();
+            .GetEma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(484, results.Count(x => x.Ema != null));
@@ -81,9 +77,8 @@ public class SmaTests : SeriesTestBase
     [TestMethod]
     public void NaN()
     {
-        List<SmaResult> r = Data.GetBtcUsdNan()
-            .GetSma(50)
-            .ToList();
+        IReadOnlyList<SmaResult> r = Data.GetBtcUsdNan()
+            .GetSma(50);
 
         Assert.AreEqual(0, r.Count(x => x.Sma is double.NaN));
     }
@@ -91,9 +86,8 @@ public class SmaTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<SmaResult> r = BadQuotes
-            .GetSma(15)
-            .ToList();
+        IReadOnlyList<SmaResult> r = BadQuotes
+            .GetSma(15);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Sma is double.NaN));
@@ -102,15 +96,13 @@ public class SmaTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<SmaResult> r0 = Noquotes
-            .GetSma(5)
-            .ToList();
+        IReadOnlyList<SmaResult> r0 = Noquotes
+            .GetSma(5);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<SmaResult> r1 = Onequote
-            .GetSma(5)
-            .ToList();
+        IReadOnlyList<SmaResult> r1 = Onequote
+            .GetSma(5);
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -118,14 +110,13 @@ public class SmaTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetSma(20)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 19, results.Count);
-        Assert.AreEqual(251.8600, results.LastOrDefault().Sma.Round(4));
+        Assert.AreEqual(251.8600, results[^1].Sma.Round(4));
     }
 
     [TestMethod]

--- a/tests/indicators/s-z/Sma/Sma.Stream.Tests.cs
+++ b/tests/indicators/s-z/Sma/Sma.Stream.Tests.cs
@@ -55,10 +55,9 @@ public class SmaTests : StreamTestBase, ITestChainObserver, ITestChainProvider
         quotesList.RemoveAt(400);
 
         // time-series, for comparison
-        List<SmaResult> seriesList
+        IReadOnlyList<SmaResult> seriesList
            = quotesList
-            .GetSma(5)
-            .ToList();
+            .GetSma(5);
 
         // assert, should equal series
         for (int i = 0; i < length - 1; i++)
@@ -109,11 +108,10 @@ public class SmaTests : StreamTestBase, ITestChainObserver, ITestChainProvider
             observer.Results;
 
         // time-series, for comparison
-        List<SmaResult> staticList
+        IReadOnlyList<SmaResult> staticList
            = quotesList
             .Use(CandlePart.OC2)
-            .GetSma(11)
-            .ToList();
+            .GetSma(11);
 
         // assert, should equal series
         for (int i = 0; i < length; i++)
@@ -167,11 +165,10 @@ public class SmaTests : StreamTestBase, ITestChainObserver, ITestChainProvider
             = observer.Results;
 
         // time-series, for comparison
-        List<EmaResult> seriesList
+        IReadOnlyList<EmaResult> seriesList
            = quotesList
             .GetSma(smaPeriods)
-            .GetEma(emaPeriods)
-            .ToList();
+            .GetEma(emaPeriods);
 
         // assert, should equal series
         for (int i = 0; i < length - 1; i++)

--- a/tests/indicators/s-z/SmaAnalysis/SmaAnalysis.Tests.cs
+++ b/tests/indicators/s-z/SmaAnalysis/SmaAnalysis.Tests.cs
@@ -6,9 +6,8 @@ public class SmaAnalysisTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<SmaAnalysis> results = Quotes
-            .GetSmaAnalysis(20)
-            .ToList();
+        IReadOnlyList<SmaAnalysis> results = Quotes
+            .GetSmaAnalysis(20);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -25,10 +24,9 @@ public class SmaAnalysisTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<SmaAnalysis> results = Quotes
+        IReadOnlyList<SmaAnalysis> results = Quotes
             .Use(CandlePart.Close)
-            .GetSmaAnalysis(20)
-            .ToList();
+            .GetSmaAnalysis(20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(483, results.Count(x => x.Sma != null));
@@ -37,10 +35,9 @@ public class SmaAnalysisTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<SmaAnalysis> results = Quotes
+        IReadOnlyList<SmaAnalysis> results = Quotes
             .GetSma(2)
-            .GetSmaAnalysis(20)
-            .ToList();
+            .GetSmaAnalysis(20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(482, results.Count(x => x.Sma != null));
@@ -49,10 +46,9 @@ public class SmaAnalysisTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<EmaResult> results = Quotes
+        IReadOnlyList<EmaResult> results = Quotes
             .GetSmaAnalysis(10)
-            .GetEma(10)
-            .ToList();
+            .GetEma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(484, results.Count(x => x.Ema != null));
@@ -61,9 +57,8 @@ public class SmaAnalysisTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<SmaAnalysis> r = BadQuotes
-            .GetSmaAnalysis(15)
-            .ToList();
+        IReadOnlyList<SmaAnalysis> r = BadQuotes
+            .GetSmaAnalysis(15);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Mape is double.NaN));
@@ -72,15 +67,13 @@ public class SmaAnalysisTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<SmaAnalysis> r0 = Noquotes
-            .GetSmaAnalysis(6)
-            .ToList();
+        IReadOnlyList<SmaAnalysis> r0 = Noquotes
+            .GetSmaAnalysis(6);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<SmaAnalysis> r1 = Onequote
-            .GetSmaAnalysis(6)
-            .ToList();
+        IReadOnlyList<SmaAnalysis> r1 = Onequote
+            .GetSmaAnalysis(6);
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -88,14 +81,13 @@ public class SmaAnalysisTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<SmaAnalysis> results = Quotes
+        IReadOnlyList<SmaAnalysis> results = Quotes
             .GetSmaAnalysis(20)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 19, results.Count);
-        Assert.AreEqual(251.8600, Math.Round(results.LastOrDefault().Sma.Value, 4));
+        Assert.AreEqual(251.8600, Math.Round(results[^1].Sma.Value, 4));
     }
 
     // bad lookback period

--- a/tests/indicators/s-z/Smi/Smi.Tests.cs
+++ b/tests/indicators/s-z/Smi/Smi.Tests.cs
@@ -6,9 +6,8 @@ public class SmiTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<SmiResult> results = Quotes
-            .GetSmi(14, 20, 5)
-            .ToList();
+        IReadOnlyList<SmiResult> results = Quotes
+            .GetSmi(14, 20, 5);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -48,10 +47,9 @@ public class SmiTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetSmi(14, 20, 5)
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(480, results.Count(x => x.Sma != null));
@@ -60,9 +58,8 @@ public class SmiTests : SeriesTestBase
     [TestMethod]
     public void NoSignal()
     {
-        List<SmiResult> results = Quotes
-            .GetSmi(5, 20, 20, 1)
-            .ToList();
+        IReadOnlyList<SmiResult> results = Quotes
+            .GetSmi(5, 20, 20, 1);
 
         // signal equals oscillator
         SmiResult r1 = results[487];
@@ -75,9 +72,8 @@ public class SmiTests : SeriesTestBase
     [TestMethod]
     public void SmallPeriods()
     {
-        List<SmiResult> results = Quotes
-            .GetSmi(1, 1, 1, 5)
-            .ToList();
+        IReadOnlyList<SmiResult> results = Quotes
+            .GetSmi(1, 1, 1, 5);
 
         // sample values
         SmiResult r51 = results[51];
@@ -96,9 +92,8 @@ public class SmiTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<SmiResult> r = BadQuotes
-            .GetSmi(5, 5, 1, 5)
-            .ToList();
+        IReadOnlyList<SmiResult> r = BadQuotes
+            .GetSmi(5, 5, 1, 5);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Smi is double.NaN));
@@ -107,15 +102,13 @@ public class SmiTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<SmiResult> r0 = Noquotes
-            .GetSmi(5, 5)
-            .ToList();
+        IReadOnlyList<SmiResult> r0 = Noquotes
+            .GetSmi(5, 5);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<SmiResult> r1 = Onequote
-            .GetSmi(5, 3, 3)
-            .ToList();
+        IReadOnlyList<SmiResult> r1 = Onequote
+            .GetSmi(5, 3, 3);
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -123,15 +116,14 @@ public class SmiTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<SmiResult> results = Quotes
+        IReadOnlyList<SmiResult> results = Quotes
             .GetSmi(14, 20, 5)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(501 - (14 + 100), results.Count);
 
-        SmiResult last = results.LastOrDefault();
+        SmiResult last = results[^1];
         Assert.AreEqual(-52.6560, last.Smi.Round(4));
         Assert.AreEqual(-54.1903, last.Signal.Round(4));
     }

--- a/tests/indicators/s-z/Smma/Smma.Tests.cs
+++ b/tests/indicators/s-z/Smma/Smma.Tests.cs
@@ -6,9 +6,8 @@ public class SmmaTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<SmmaResult> results = Quotes
-            .GetSmma(20)
-            .ToList();
+        IReadOnlyList<SmmaResult> results = Quotes
+            .GetSmma(20);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -29,10 +28,9 @@ public class SmmaTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<SmmaResult> results = Quotes
+        IReadOnlyList<SmmaResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetSmma(20)
-            .ToList();
+            .GetSmma(20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(483, results.Count(x => x.Smma != null));
@@ -41,10 +39,9 @@ public class SmmaTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<SmmaResult> results = Quotes
+        IReadOnlyList<SmmaResult> results = Quotes
             .GetSma(2)
-            .GetSmma(20)
-            .ToList();
+            .GetSmma(20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(482, results.Count(x => x.Smma != null));
@@ -53,10 +50,9 @@ public class SmmaTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetSmma(20)
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(474, results.Count(x => x.Sma != null));
@@ -65,9 +61,8 @@ public class SmmaTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<SmmaResult> r = BadQuotes
-            .GetSmma(15)
-            .ToList();
+        IReadOnlyList<SmmaResult> r = BadQuotes
+            .GetSmma(15);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Smma is double.NaN));
@@ -76,15 +71,13 @@ public class SmmaTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<SmmaResult> r0 = Noquotes
-            .GetSmma(5)
-            .ToList();
+        IReadOnlyList<SmmaResult> r0 = Noquotes
+            .GetSmma(5);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<SmmaResult> r1 = Onequote
-            .GetSmma(5)
-            .ToList();
+        IReadOnlyList<SmmaResult> r1 = Onequote
+            .GetSmma(5);
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -92,14 +85,13 @@ public class SmmaTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<SmmaResult> results = Quotes
+        IReadOnlyList<SmmaResult> results = Quotes
             .GetSmma(20)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - (20 + 100), results.Count);
-        Assert.AreEqual(255.67462, Math.Round(results.LastOrDefault().Smma.Value, 5));
+        Assert.AreEqual(255.67462, Math.Round(results[^1].Smma.Value, 5));
     }
 
     // bad lookback period

--- a/tests/indicators/s-z/StarcBands/StarcBands.Tests.cs
+++ b/tests/indicators/s-z/StarcBands/StarcBands.Tests.cs
@@ -10,9 +10,8 @@ public class StarcBandsTests : SeriesTestBase
         int multiplier = 2;
         int atrPeriods = 14;
 
-        List<StarcBandsResult> results = Quotes
-            .GetStarcBands(smaPeriods, multiplier, atrPeriods)
-            .ToList();
+        IReadOnlyList<StarcBandsResult> results = Quotes
+            .GetStarcBands(smaPeriods, multiplier, atrPeriods);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -50,9 +49,8 @@ public class StarcBandsTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<StarcBandsResult> r = BadQuotes
-            .GetStarcBands(10, 3, 15)
-            .ToList();
+        IReadOnlyList<StarcBandsResult> r = BadQuotes
+            .GetStarcBands(10, 3, 15);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.UpperBand is double.NaN));
@@ -61,15 +59,13 @@ public class StarcBandsTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<StarcBandsResult> r0 = Noquotes
-            .GetStarcBands(10)
-            .ToList();
+        IReadOnlyList<StarcBandsResult> r0 = Noquotes
+            .GetStarcBands(10);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<StarcBandsResult> r1 = Onequote
-            .GetStarcBands(10)
-            .ToList();
+        IReadOnlyList<StarcBandsResult> r1 = Onequote
+            .GetStarcBands(10);
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -82,15 +78,14 @@ public class StarcBandsTests : SeriesTestBase
         int atrPeriods = 14;
         int lookbackPeriods = Math.Max(smaPeriods, atrPeriods);
 
-        List<StarcBandsResult> results = Quotes
+        IReadOnlyList<StarcBandsResult> results = Quotes
             .GetStarcBands(smaPeriods, multiplier, atrPeriods)
-            .Condense()
-            .ToList();
+            .Condense();
 
         // assertions
         Assert.AreEqual(502 - lookbackPeriods + 1, results.Count);
 
-        StarcBandsResult last = results.LastOrDefault();
+        StarcBandsResult last = results[^1];
         Assert.AreEqual(251.8600, last.Centerline.Round(4));
         Assert.AreEqual(264.1595, last.UpperBand.Round(4));
         Assert.AreEqual(239.5605, last.LowerBand.Round(4));
@@ -104,15 +99,14 @@ public class StarcBandsTests : SeriesTestBase
         int atrPeriods = 14;
         int lookbackPeriods = Math.Max(smaPeriods, atrPeriods);
 
-        List<StarcBandsResult> results = Quotes
+        IReadOnlyList<StarcBandsResult> results = Quotes
             .GetStarcBands(smaPeriods, multiplier, atrPeriods)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - (lookbackPeriods + 150), results.Count);
 
-        StarcBandsResult last = results.LastOrDefault();
+        StarcBandsResult last = results[^1];
         Assert.AreEqual(251.8600, last.Centerline.Round(4));
         Assert.AreEqual(264.1595, last.UpperBand.Round(4));
         Assert.AreEqual(239.5605, last.LowerBand.Round(4));

--- a/tests/indicators/s-z/Stc/Stc.Tests.cs
+++ b/tests/indicators/s-z/Stc/Stc.Tests.cs
@@ -10,9 +10,8 @@ public class StcTests : SeriesTestBase
         int fastPeriods = 12;
         int slowPeriods = 26;
 
-        List<StcResult> results = Quotes
-            .GetStc(cyclePeriods, fastPeriods, slowPeriods)
-            .ToList();
+        IReadOnlyList<StcResult> results = Quotes
+            .GetStc(cyclePeriods, fastPeriods, slowPeriods);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -31,17 +30,16 @@ public class StcTests : SeriesTestBase
         StcResult r249 = results[249];
         Assert.AreEqual(27.7340, r249.Stc.Round(4));
 
-        StcResult last = results.LastOrDefault();
+        StcResult last = results[^1];
         Assert.AreEqual(19.2544, last.Stc.Round(4));
     }
 
     [TestMethod]
     public void UseReusable()
     {
-        List<StcResult> results = Quotes
+        IReadOnlyList<StcResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetStc(9, 12, 26)
-            .ToList();
+            .GetStc(9, 12, 26);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(467, results.Count(x => x.Stc != null));
@@ -50,10 +48,9 @@ public class StcTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<StcResult> results = Quotes
+        IReadOnlyList<StcResult> results = Quotes
             .GetSma(2)
-            .GetStc(9, 12, 26)
-            .ToList();
+            .GetStc(9, 12, 26);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(466, results.Count(x => x.Stc != null));
@@ -62,10 +59,9 @@ public class StcTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetStc(9, 12, 26)
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(458, results.Count(x => x.Sma != null));
@@ -74,9 +70,8 @@ public class StcTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<StcResult> r = BadQuotes
-            .GetStc()
-            .ToList();
+        IReadOnlyList<StcResult> r = BadQuotes
+            .GetStc();
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Stc is double.NaN));
@@ -85,15 +80,13 @@ public class StcTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<StcResult> r0 = Noquotes
-            .GetStc()
-            .ToList();
+        IReadOnlyList<StcResult> r0 = Noquotes
+            .GetStc();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<StcResult> r1 = Onequote
-            .GetStc()
-            .ToList();
+        IReadOnlyList<StcResult> r1 = Onequote
+            .GetStc();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -105,9 +98,8 @@ public class StcTests : SeriesTestBase
 
         RandomGbm quotes = new(58);
 
-        List<StcResult> results = quotes
-            .GetStc()
-            .ToList();
+        IReadOnlyList<StcResult> results = quotes
+            .GetStc();
 
         Assert.AreEqual(58, results.Count);
     }
@@ -119,15 +111,14 @@ public class StcTests : SeriesTestBase
         int fastPeriods = 12;
         int slowPeriods = 26;
 
-        List<StcResult> results = Quotes
+        IReadOnlyList<StcResult> results = Quotes
             .GetStc(cyclePeriods, fastPeriods, slowPeriods)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - (slowPeriods + cyclePeriods + 250), results.Count);
 
-        StcResult last = results.LastOrDefault();
+        StcResult last = results[^1];
         Assert.AreEqual(19.2544, last.Stc.Round(4));
     }
 

--- a/tests/indicators/s-z/StdDev/StdDev.Tests.cs
+++ b/tests/indicators/s-z/StdDev/StdDev.Tests.cs
@@ -6,9 +6,8 @@ public class StdDevTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<StdDevResult> results = Quotes
-            .GetStdDev(10)
-            .ToList();
+        IReadOnlyList<StdDevResult> results = Quotes
+            .GetStdDev(10);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -40,10 +39,9 @@ public class StdDevTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<StdDevResult> results = Quotes
+        IReadOnlyList<StdDevResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetStdDev(10)
-            .ToList();
+            .GetStdDev(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(493, results.Count(x => x.StdDev != null));
@@ -52,10 +50,9 @@ public class StdDevTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<StdDevResult> results = Quotes
+        IReadOnlyList<StdDevResult> results = Quotes
             .GetSma(2)
-            .GetStdDev(10)
-            .ToList();
+            .GetStdDev(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(492, results.Count(x => x.StdDev != null));
@@ -64,10 +61,9 @@ public class StdDevTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetStdDev(10)
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(484, results.Count(x => x.Sma != null));
@@ -76,9 +72,8 @@ public class StdDevTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<StdDevResult> r = BadQuotes
-            .GetStdDev(15)
-            .ToList();
+        IReadOnlyList<StdDevResult> r = BadQuotes
+            .GetStdDev(15);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.StdDev is double.NaN));
@@ -87,9 +82,8 @@ public class StdDevTests : SeriesTestBase
     [TestMethod]
     public void BigData()
     {
-        List<StdDevResult> r = BigQuotes
-            .GetStdDev(200)
-            .ToList();
+        IReadOnlyList<StdDevResult> r = BigQuotes
+            .GetStdDev(200);
 
         Assert.AreEqual(1246, r.Count);
     }
@@ -97,15 +91,13 @@ public class StdDevTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<StdDevResult> r0 = Noquotes
-            .GetStdDev(10)
-            .ToList();
+        IReadOnlyList<StdDevResult> r0 = Noquotes
+            .GetStdDev(10);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<StdDevResult> r1 = Onequote
-            .GetStdDev(10)
-            .ToList();
+        IReadOnlyList<StdDevResult> r1 = Onequote
+            .GetStdDev(10);
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -113,15 +105,14 @@ public class StdDevTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<StdDevResult> results = Quotes
+        IReadOnlyList<StdDevResult> results = Quotes
             .GetStdDev(10)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 9, results.Count);
 
-        StdDevResult last = results.LastOrDefault();
+        StdDevResult last = results[^1];
         Assert.AreEqual(5.4738, last.StdDev.Round(4));
         Assert.AreEqual(242.4100, last.Mean.Round(4));
         Assert.AreEqual(0.524312, last.ZScore.Round(6));

--- a/tests/indicators/s-z/StdDevChannels/StdDevChannels.Tests.cs
+++ b/tests/indicators/s-z/StdDevChannels/StdDevChannels.Tests.cs
@@ -9,9 +9,8 @@ public class StdDevChannelsTests : SeriesTestBase
         int lookbackPeriods = 20;
         double standardDeviations = 2;
 
-        List<StdDevChannelsResult> results =
-            Quotes.GetStdDevChannels(lookbackPeriods, standardDeviations)
-            .ToList();
+        IReadOnlyList<StdDevChannelsResult> results =
+            Quotes.GetStdDevChannels(lookbackPeriods, standardDeviations);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -68,9 +67,8 @@ public class StdDevChannelsTests : SeriesTestBase
     {
         // null provided for lookback period
 
-        List<StdDevChannelsResult> results =
-            Quotes.GetStdDevChannels(null)
-            .ToList();
+        IReadOnlyList<StdDevChannelsResult> results =
+            Quotes.GetStdDevChannels(null);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -100,10 +98,9 @@ public class StdDevChannelsTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<StdDevChannelsResult> results = Quotes
+        IReadOnlyList<StdDevChannelsResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetStdDevChannels()
-            .ToList();
+            .GetStdDevChannels();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(500, results.Count(x => x.Centerline != null));
@@ -112,10 +109,9 @@ public class StdDevChannelsTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<StdDevChannelsResult> results = Quotes
+        IReadOnlyList<StdDevChannelsResult> results = Quotes
             .GetSma(2)
-            .GetStdDevChannels()
-            .ToList();
+            .GetStdDevChannels();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(500, results.Count(x => x.Centerline != null));
@@ -124,9 +120,8 @@ public class StdDevChannelsTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<StdDevChannelsResult> r = BadQuotes
-            .GetStdDevChannels()
-            .ToList();
+        IReadOnlyList<StdDevChannelsResult> r = BadQuotes
+            .GetStdDevChannels();
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.UpperChannel is double.NaN));
@@ -135,15 +130,13 @@ public class StdDevChannelsTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<StdDevChannelsResult> r0 = Noquotes
-            .GetStdDevChannels()
-            .ToList();
+        IReadOnlyList<StdDevChannelsResult> r0 = Noquotes
+            .GetStdDevChannels();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<StdDevChannelsResult> r1 = Onequote
-            .GetStdDevChannels()
-            .ToList();
+        IReadOnlyList<StdDevChannelsResult> r1 = Onequote
+            .GetStdDevChannels();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -154,14 +147,13 @@ public class StdDevChannelsTests : SeriesTestBase
         int lookbackPeriods = 20;
         double standardDeviations = 2;
 
-        List<StdDevChannelsResult> results = Quotes
+        IReadOnlyList<StdDevChannelsResult> results = Quotes
             .GetStdDevChannels(lookbackPeriods, standardDeviations)
-            .Condense()
-            .ToList();
+            .Condense();
 
         // assertions
         Assert.AreEqual(500, results.Count);
-        StdDevChannelsResult last = results.LastOrDefault();
+        StdDevChannelsResult last = results[^1];
         Assert.AreEqual(235.8131, last.Centerline.Round(4));
         Assert.AreEqual(257.6536, last.UpperChannel.Round(4));
         Assert.AreEqual(213.9727, last.LowerChannel.Round(4));
@@ -174,14 +166,13 @@ public class StdDevChannelsTests : SeriesTestBase
         int lookbackPeriods = 20;
         double standardDeviations = 2;
 
-        List<StdDevChannelsResult> results = Quotes
+        IReadOnlyList<StdDevChannelsResult> results = Quotes
             .GetStdDevChannels(lookbackPeriods, standardDeviations)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(500, results.Count);
-        StdDevChannelsResult last = results.LastOrDefault();
+        StdDevChannelsResult last = results[^1];
         Assert.AreEqual(235.8131, last.Centerline.Round(4));
         Assert.AreEqual(257.6536, last.UpperChannel.Round(4));
         Assert.AreEqual(213.9727, last.LowerChannel.Round(4));

--- a/tests/indicators/s-z/Stoch/Stoch.Tests.cs
+++ b/tests/indicators/s-z/Stoch/Stoch.Tests.cs
@@ -10,9 +10,8 @@ public class StochTests : SeriesTestBase
         int signalPeriods = 3;
         int smoothPeriods = 3;
 
-        List<StochResult> results = Quotes
-            .GetStoch(lookbackPeriods, signalPeriods, smoothPeriods)
-            .ToList();
+        IReadOnlyList<StochResult> results = Quotes
+            .GetStoch(lookbackPeriods, signalPeriods, smoothPeriods);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -72,9 +71,8 @@ public class StochTests : SeriesTestBase
     [TestMethod]
     public void Extended() // with extra parameters
     {
-        List<StochResult> results =
-            Quotes.GetStoch(9, 3, 3, 5, 4, MaType.SMMA)
-            .ToList();
+        IReadOnlyList<StochResult> results =
+            Quotes.GetStoch(9, 3, 3, 5, 4, MaType.SMMA);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -116,10 +114,9 @@ public class StochTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetStoch()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(478, results.Count(x => x.Sma != null));
@@ -132,9 +129,8 @@ public class StochTests : SeriesTestBase
         const int signalPeriods = 1;
         const int smoothPeriods = 3;
 
-        List<StochResult> results = Quotes
-            .GetStoch(lookbackPeriods, signalPeriods, smoothPeriods)
-            .ToList();
+        IReadOnlyList<StochResult> results = Quotes
+            .GetStoch(lookbackPeriods, signalPeriods, smoothPeriods);
 
         // signal equals oscillator
         StochResult r1 = results[487];
@@ -151,9 +147,8 @@ public class StochTests : SeriesTestBase
         int signalPeriods = 10;
         int smoothPeriods = 1;
 
-        List<StochResult> results = Quotes
-            .GetStoch(lookbackPeriods, signalPeriods, smoothPeriods)
-            .ToList();
+        IReadOnlyList<StochResult> results = Quotes
+            .GetStoch(lookbackPeriods, signalPeriods, smoothPeriods);
 
         // sample values
         StochResult r1 = results[487];
@@ -172,9 +167,8 @@ public class StochTests : SeriesTestBase
         int signalPeriods = 10;
         int smoothPeriods = 1;
 
-        List<StochResult> results = Quotes
-            .GetStoch(lookbackPeriods, signalPeriods, smoothPeriods)
-            .ToList();
+        IReadOnlyList<StochResult> results = Quotes
+            .GetStoch(lookbackPeriods, signalPeriods, smoothPeriods);
 
         // sample values
         StochResult r1 = results[70];
@@ -187,9 +181,8 @@ public class StochTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<StochResult> r = BadQuotes
-            .GetStoch(15)
-            .ToList();
+        IReadOnlyList<StochResult> r = BadQuotes
+            .GetStoch(15);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Oscillator is double.NaN));
@@ -198,15 +191,13 @@ public class StochTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<StochResult> r0 = Noquotes
-            .GetStoch()
-            .ToList();
+        IReadOnlyList<StochResult> r0 = Noquotes
+            .GetStoch();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<StochResult> r1 = Onequote
-            .GetStoch()
-            .ToList();
+        IReadOnlyList<StochResult> r1 = Onequote
+            .GetStoch();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -218,15 +209,14 @@ public class StochTests : SeriesTestBase
         int signalPeriods = 3;
         int smoothPeriods = 3;
 
-        List<StochResult> results = Quotes
+        IReadOnlyList<StochResult> results = Quotes
             .GetStoch(lookbackPeriods, signalPeriods, smoothPeriods)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - (lookbackPeriods + smoothPeriods - 2), results.Count);
 
-        StochResult last = results.LastOrDefault();
+        StochResult last = results[^1];
         Assert.AreEqual(43.1353, last.Oscillator.Round(4));
         Assert.AreEqual(35.5674, last.Signal.Round(4));
         Assert.AreEqual(58.2712, last.PercentJ.Round(4));
@@ -239,10 +229,9 @@ public class StochTests : SeriesTestBase
         int signalPeriods = 3;
         int smoothPeriods = 3;
 
-        List<StochResult> results = Data
+        IReadOnlyList<StochResult> results = Data
             .GetRandom(2500)
-            .GetStoch(lookbackPeriods, signalPeriods, smoothPeriods)
-            .ToList();
+            .GetStoch(lookbackPeriods, signalPeriods, smoothPeriods);
 
         // test boundary condition
 

--- a/tests/indicators/s-z/StochRsi/StochRsi.Tests.cs
+++ b/tests/indicators/s-z/StochRsi/StochRsi.Tests.cs
@@ -11,9 +11,8 @@ public class StochRsiTests : SeriesTestBase
         int signalPeriods = 3;
         int smoothPeriods = 1;
 
-        List<StochRsiResult> results =
-            Quotes.GetStochRsi(rsiPeriods, stochPeriods, signalPeriods, smoothPeriods)
-            .ToList();
+        IReadOnlyList<StochRsiResult> results =
+            Quotes.GetStochRsi(rsiPeriods, stochPeriods, signalPeriods, smoothPeriods);
 
         // assertions
 
@@ -48,9 +47,8 @@ public class StochRsiTests : SeriesTestBase
         int signalPeriods = 3;
         int smoothPeriods = 3;
 
-        List<StochRsiResult> results =
-            Quotes.GetStochRsi(rsiPeriods, stochPeriods, signalPeriods, smoothPeriods)
-            .ToList();
+        IReadOnlyList<StochRsiResult> results =
+            Quotes.GetStochRsi(rsiPeriods, stochPeriods, signalPeriods, smoothPeriods);
 
         // assertions
 
@@ -80,10 +78,9 @@ public class StochRsiTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<StochRsiResult> results = Quotes
+        IReadOnlyList<StochRsiResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetStochRsi(14, 14, 3)
-            .ToList();
+            .GetStochRsi(14, 14, 3);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(475, results.Count(x => x.StochRsi != null));
@@ -93,10 +90,9 @@ public class StochRsiTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<StochRsiResult> results = Quotes
+        IReadOnlyList<StochRsiResult> results = Quotes
             .GetSma(2)
-            .GetStochRsi(14, 14, 3)
-            .ToList();
+            .GetStochRsi(14, 14, 3);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(474, results.Count(x => x.StochRsi != null));
@@ -105,10 +101,9 @@ public class StochRsiTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetStochRsi(14, 14, 3, 3)
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(464, results.Count(x => x.Sma != null));
@@ -117,9 +112,8 @@ public class StochRsiTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<StochRsiResult> r = BadQuotes
-            .GetStochRsi(15, 20, 3, 2)
-            .ToList();
+        IReadOnlyList<StochRsiResult> r = BadQuotes
+            .GetStochRsi(15, 20, 3, 2);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.StochRsi is double.NaN));
@@ -128,15 +122,13 @@ public class StochRsiTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<StochRsiResult> r0 = Noquotes
-            .GetStochRsi(10, 20, 3)
-            .ToList();
+        IReadOnlyList<StochRsiResult> r0 = Noquotes
+            .GetStochRsi(10, 20, 3);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<StochRsiResult> r1 = Onequote
-            .GetStochRsi(8, 13, 2)
-            .ToList();
+        IReadOnlyList<StochRsiResult> r1 = Onequote
+            .GetStochRsi(8, 13, 2);
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -149,16 +141,15 @@ public class StochRsiTests : SeriesTestBase
         int signalPeriods = 3;
         int smoothPeriods = 3;
 
-        List<StochRsiResult> results = Quotes
+        IReadOnlyList<StochRsiResult> results = Quotes
             .GetStochRsi(rsiPeriods, stochPeriods, signalPeriods, smoothPeriods)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         int removeQty = rsiPeriods + stochPeriods + smoothPeriods + 100;
         Assert.AreEqual(502 - removeQty, results.Count);
 
-        StochRsiResult last = results.LastOrDefault();
+        StochRsiResult last = results[^1];
         Assert.AreEqual(89.8385, last.StochRsi.Round(4));
         Assert.AreEqual(73.4176, last.Signal.Round(4));
     }

--- a/tests/indicators/s-z/SuperTrend/SuperTrend.Tests.cs
+++ b/tests/indicators/s-z/SuperTrend/SuperTrend.Tests.cs
@@ -9,9 +9,8 @@ public class SuperTrendTests : SeriesTestBase
         const int lookbackPeriods = 14;
         const double multiplier = 3;
 
-        List<SuperTrendResult> results = Quotes
-            .GetSuperTrend(lookbackPeriods, multiplier)
-            .ToList();
+        IReadOnlyList<SuperTrendResult> results = Quotes
+            .GetSuperTrend(lookbackPeriods, multiplier);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -54,9 +53,8 @@ public class SuperTrendTests : SeriesTestBase
     {
         IEnumerable<Quote> h = Data.GetBitcoin();
 
-        List<SuperTrendResult> results = h
-            .GetSuperTrend()
-            .ToList();
+        IReadOnlyList<SuperTrendResult> results = h
+            .GetSuperTrend();
 
         Assert.AreEqual(1246, results.Count);
 
@@ -67,9 +65,8 @@ public class SuperTrendTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<SuperTrendResult> r = BadQuotes
-            .GetSuperTrend(7)
-            .ToList();
+        IReadOnlyList<SuperTrendResult> r = BadQuotes
+            .GetSuperTrend(7);
 
         Assert.AreEqual(502, r.Count);
     }
@@ -77,15 +74,13 @@ public class SuperTrendTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<SuperTrendResult> r0 = Noquotes
-            .GetSuperTrend()
-            .ToList();
+        IReadOnlyList<SuperTrendResult> r0 = Noquotes
+            .GetSuperTrend();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<SuperTrendResult> r1 = Onequote
-            .GetSuperTrend()
-            .ToList();
+        IReadOnlyList<SuperTrendResult> r1 = Onequote
+            .GetSuperTrend();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -96,15 +91,14 @@ public class SuperTrendTests : SeriesTestBase
         int lookbackPeriods = 14;
         double multiplier = 3;
 
-        List<SuperTrendResult> results = Quotes
+        IReadOnlyList<SuperTrendResult> results = Quotes
             .GetSuperTrend(lookbackPeriods, multiplier)
-            .Condense()
-            .ToList();
+            .Condense();
 
         // assertions
         Assert.AreEqual(488, results.Count);
 
-        SuperTrendResult last = results.LastOrDefault();
+        SuperTrendResult last = results[^1];
         Assert.AreEqual(250.7954m, last.SuperTrend.Round(4));
         Assert.AreEqual(last.SuperTrend, last.UpperBand);
         Assert.AreEqual(null, last.LowerBand);
@@ -116,15 +110,14 @@ public class SuperTrendTests : SeriesTestBase
         int lookbackPeriods = 14;
         double multiplier = 3;
 
-        List<SuperTrendResult> results = Quotes
+        IReadOnlyList<SuperTrendResult> results = Quotes
             .GetSuperTrend(lookbackPeriods, multiplier)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(488, results.Count);
 
-        SuperTrendResult last = results.LastOrDefault();
+        SuperTrendResult last = results[^1];
         Assert.AreEqual(250.7954m, last.SuperTrend.Round(4));
         Assert.AreEqual(last.SuperTrend, last.UpperBand);
         Assert.AreEqual(null, last.LowerBand);

--- a/tests/indicators/s-z/T3/T3.Tests.cs
+++ b/tests/indicators/s-z/T3/T3.Tests.cs
@@ -6,9 +6,8 @@ public class T3Tests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<T3Result> results = Quotes
-            .GetT3()
-            .ToList();
+        IReadOnlyList<T3Result> results = Quotes
+            .GetT3();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -37,10 +36,9 @@ public class T3Tests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<T3Result> results = Quotes
+        IReadOnlyList<T3Result> results = Quotes
             .Use(CandlePart.Close)
-            .GetT3()
-            .ToList();
+            .GetT3();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(502, results.Count(x => x.T3 != null));
@@ -49,10 +47,9 @@ public class T3Tests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<T3Result> results = Quotes
+        IReadOnlyList<T3Result> results = Quotes
             .GetSma(2)
-            .GetT3()
-            .ToList();
+            .GetT3();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(501, results.Count(x => x.T3 != null));
@@ -61,10 +58,9 @@ public class T3Tests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetT3()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
     }
@@ -72,9 +68,8 @@ public class T3Tests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<T3Result> r = BadQuotes
-            .GetT3()
-            .ToList();
+        IReadOnlyList<T3Result> r = BadQuotes
+            .GetT3();
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.T3 is double.NaN));
@@ -83,15 +78,13 @@ public class T3Tests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<T3Result> r0 = Noquotes
-            .GetT3()
-            .ToList();
+        IReadOnlyList<T3Result> r0 = Noquotes
+            .GetT3();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<T3Result> r1 = Onequote
-            .GetT3()
-            .ToList();
+        IReadOnlyList<T3Result> r1 = Onequote
+            .GetT3();
 
         Assert.AreEqual(1, r1.Count);
     }

--- a/tests/indicators/s-z/Tema/Tema.Tests.cs
+++ b/tests/indicators/s-z/Tema/Tema.Tests.cs
@@ -6,9 +6,8 @@ public class TemaTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<TemaResult> results = Quotes
-            .GetTema(20)
-            .ToList();
+        IReadOnlyList<TemaResult> results = Quotes
+            .GetTema(20);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -31,10 +30,9 @@ public class TemaTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<TemaResult> results = Quotes
+        IReadOnlyList<TemaResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetTema(20)
-            .ToList();
+            .GetTema(20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(483, results.Count(x => x.Tema != null));
@@ -43,10 +41,9 @@ public class TemaTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<TemaResult> results = Quotes
+        IReadOnlyList<TemaResult> results = Quotes
             .GetSma(2)
-            .GetTema(20)
-            .ToList();
+            .GetTema(20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(482, results.Count(x => x.Tema != null));
@@ -55,10 +52,9 @@ public class TemaTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetTema(20)
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(474, results.Count(x => x.Sma != null));
@@ -67,9 +63,8 @@ public class TemaTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<TemaResult> r = BadQuotes
-            .GetTema(15)
-            .ToList();
+        IReadOnlyList<TemaResult> r = BadQuotes
+            .GetTema(15);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Tema is double.NaN));
@@ -78,15 +73,13 @@ public class TemaTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<TemaResult> r0 = Noquotes
-            .GetTema(5)
-            .ToList();
+        IReadOnlyList<TemaResult> r0 = Noquotes
+            .GetTema(5);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<TemaResult> r1 = Onequote
-            .GetTema(5)
-            .ToList();
+        IReadOnlyList<TemaResult> r1 = Onequote
+            .GetTema(5);
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -94,15 +87,14 @@ public class TemaTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<TemaResult> results = Quotes
+        IReadOnlyList<TemaResult> results = Quotes
             .GetTema(20)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - (3 * 20 + 100), results.Count);
 
-        TemaResult last = results.LastOrDefault();
+        TemaResult last = results[^1];
         Assert.AreEqual(238.7690, last.Tema.Round(4));
     }
 

--- a/tests/indicators/s-z/Tr/Tr.Tests.cs
+++ b/tests/indicators/s-z/Tr/Tr.Tests.cs
@@ -6,9 +6,8 @@ public class TrTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<TrResult> results = Quotes
-            .GetTr()
-            .ToList();
+        IReadOnlyList<TrResult> results = Quotes
+            .GetTr();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -41,14 +40,12 @@ public class TrTests : SeriesTestBase
     public void Chainor()
     {
         // same as ATR
-        List<SmmaResult> results = Quotes
+        IReadOnlyList<SmmaResult> results = Quotes
             .GetTr()
-            .GetSmma(14)
-            .ToList();
+            .GetSmma(14);
 
-        List<AtrResult> atrResults = Quotes
-            .GetAtr()
-            .ToList();
+        IReadOnlyList<AtrResult> atrResults = Quotes
+            .GetAtr();
 
         for (int i = 0; i < results.Count; i++)
         {
@@ -63,9 +60,8 @@ public class TrTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<TrResult> r = BadQuotes
-            .GetTr()
-            .ToList();
+        IReadOnlyList<TrResult> r = BadQuotes
+            .GetTr();
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Tr is double.NaN));
@@ -74,15 +70,13 @@ public class TrTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<TrResult> r0 = Noquotes
-            .GetTr()
-            .ToList();
+        IReadOnlyList<TrResult> r0 = Noquotes
+            .GetTr();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<TrResult> r1 = Onequote
-            .GetTr()
-            .ToList();
+        IReadOnlyList<TrResult> r1 = Onequote
+            .GetTr();
 
         Assert.AreEqual(1, r1.Count);
     }

--- a/tests/indicators/s-z/Trix/Trix.Tests.cs
+++ b/tests/indicators/s-z/Trix/Trix.Tests.cs
@@ -6,9 +6,8 @@ public class TrixTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<TrixResult> results = Quotes
-            .GetTrix(20)
-            .ToList();
+        IReadOnlyList<TrixResult> results = Quotes
+            .GetTrix(20);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -36,10 +35,9 @@ public class TrixTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<TrixResult> results = Quotes
+        IReadOnlyList<TrixResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetTrix(20)
-            .ToList();
+            .GetTrix(20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(482, results.Count(x => x.Trix != null));
@@ -48,10 +46,9 @@ public class TrixTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<TrixResult> results = Quotes
+        IReadOnlyList<TrixResult> results = Quotes
             .GetSma(2)
-            .GetTrix(20)
-            .ToList();
+            .GetTrix(20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(481, results.Count(x => x.Trix != null));
@@ -60,10 +57,9 @@ public class TrixTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetTrix(20)
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(473, results.Count(x => x.Sma != null));
@@ -72,9 +68,8 @@ public class TrixTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<TrixResult> r = BadQuotes
-            .GetTrix(15)
-            .ToList();
+        IReadOnlyList<TrixResult> r = BadQuotes
+            .GetTrix(15);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Trix is double.NaN));
@@ -83,15 +78,13 @@ public class TrixTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<TrixResult> r0 = Noquotes
-            .GetTrix(5)
-            .ToList();
+        IReadOnlyList<TrixResult> r0 = Noquotes
+            .GetTrix(5);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<TrixResult> r1 = Onequote
-            .GetTrix(5)
-            .ToList();
+        IReadOnlyList<TrixResult> r1 = Onequote
+            .GetTrix(5);
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -99,15 +92,14 @@ public class TrixTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<TrixResult> results = Quotes
+        IReadOnlyList<TrixResult> results = Quotes
             .GetTrix(20)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - (3 * 20 + 100), results.Count);
 
-        TrixResult last = results.LastOrDefault();
+        TrixResult last = results[^1];
         Assert.AreEqual(263.3216, last.Ema3.Round(4));
         Assert.AreEqual(-0.230742, last.Trix.Round(6));
     }

--- a/tests/indicators/s-z/Tsi/Tsi.Tests.cs
+++ b/tests/indicators/s-z/Tsi/Tsi.Tests.cs
@@ -6,9 +6,8 @@ public class TsiTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<TsiResult> results = Quotes
-            .GetTsi()
-            .ToList();
+        IReadOnlyList<TsiResult> results = Quotes
+            .GetTsi();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -44,10 +43,9 @@ public class TsiTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<TsiResult> results = Quotes
+        IReadOnlyList<TsiResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetTsi()
-            .ToList();
+            .GetTsi();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(465, results.Count(x => x.Tsi != null));
@@ -56,10 +54,9 @@ public class TsiTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<TsiResult> results = Quotes
+        IReadOnlyList<TsiResult> results = Quotes
             .GetSma(2)
-            .GetTsi()
-            .ToList();
+            .GetTsi();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(464, results.Count(x => x.Tsi != null));
@@ -68,10 +65,9 @@ public class TsiTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetTsi()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(456, results.Count(x => x.Sma != null));
@@ -80,9 +76,8 @@ public class TsiTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<TsiResult> r = BadQuotes
-            .GetTsi()
-            .ToList();
+        IReadOnlyList<TsiResult> r = BadQuotes
+            .GetTsi();
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Tsi is double.NaN));
@@ -91,9 +86,8 @@ public class TsiTests : SeriesTestBase
     [TestMethod]
     public void BigData()
     {
-        List<TsiResult> r = BigQuotes
-            .GetTsi()
-            .ToList();
+        IReadOnlyList<TsiResult> r = BigQuotes
+            .GetTsi();
 
         Assert.AreEqual(1246, r.Count);
     }
@@ -101,15 +95,13 @@ public class TsiTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<TsiResult> r0 = Noquotes
-            .GetTsi()
-            .ToList();
+        IReadOnlyList<TsiResult> r0 = Noquotes
+            .GetTsi();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<TsiResult> r1 = Onequote
-            .GetTsi()
-            .ToList();
+        IReadOnlyList<TsiResult> r1 = Onequote
+            .GetTsi();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -117,15 +109,14 @@ public class TsiTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<TsiResult> results = Quotes
+        IReadOnlyList<TsiResult> results = Quotes
             .GetTsi()
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - (25 + 13 + 250), results.Count);
 
-        TsiResult last = results.LastOrDefault();
+        TsiResult last = results[^1];
         Assert.AreEqual(-28.3513, last.Tsi.Round(4));
         Assert.AreEqual(-29.3597, last.Signal.Round(4));
     }

--- a/tests/indicators/s-z/UlcerIndex/UlcerIndex.Tests.cs
+++ b/tests/indicators/s-z/UlcerIndex/UlcerIndex.Tests.cs
@@ -6,9 +6,8 @@ public class UlcerIndexTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<UlcerIndexResult> results = Quotes
-            .GetUlcerIndex()
-            .ToList();
+        IReadOnlyList<UlcerIndexResult> results = Quotes
+            .GetUlcerIndex();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -22,10 +21,9 @@ public class UlcerIndexTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<UlcerIndexResult> results = Quotes
+        IReadOnlyList<UlcerIndexResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetUlcerIndex()
-            .ToList();
+            .GetUlcerIndex();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(489, results.Count(x => x.UlcerIndex != null));
@@ -34,10 +32,9 @@ public class UlcerIndexTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<UlcerIndexResult> results = Quotes
+        IReadOnlyList<UlcerIndexResult> results = Quotes
             .GetSma(2)
-            .GetUlcerIndex()
-            .ToList();
+            .GetUlcerIndex();
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(488, results.Count(x => x.UlcerIndex != null));
@@ -46,10 +43,9 @@ public class UlcerIndexTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetUlcerIndex()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(480, results.Count(x => x.Sma != null));
@@ -58,9 +54,8 @@ public class UlcerIndexTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<UlcerIndexResult> r = BadQuotes
-            .GetUlcerIndex(15)
-            .ToList();
+        IReadOnlyList<UlcerIndexResult> r = BadQuotes
+            .GetUlcerIndex(15);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.UlcerIndex is double.NaN));
@@ -69,15 +64,13 @@ public class UlcerIndexTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<UlcerIndexResult> r0 = Noquotes
-            .GetUlcerIndex()
-            .ToList();
+        IReadOnlyList<UlcerIndexResult> r0 = Noquotes
+            .GetUlcerIndex();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<UlcerIndexResult> r1 = Onequote
-            .GetUlcerIndex()
-            .ToList();
+        IReadOnlyList<UlcerIndexResult> r1 = Onequote
+            .GetUlcerIndex();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -85,15 +78,14 @@ public class UlcerIndexTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<UlcerIndexResult> results = Quotes
+        IReadOnlyList<UlcerIndexResult> results = Quotes
             .GetUlcerIndex()
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 13, results.Count);
 
-        UlcerIndexResult last = results.LastOrDefault();
+        UlcerIndexResult last = results[^1];
         Assert.AreEqual(5.7255, last.UlcerIndex.Round(4));
     }
 

--- a/tests/indicators/s-z/Ultimate/Ultimate.Tests.cs
+++ b/tests/indicators/s-z/Ultimate/Ultimate.Tests.cs
@@ -6,9 +6,8 @@ public class UltimateTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<UltimateResult> results = Quotes
-            .GetUltimate()
-            .ToList();
+        IReadOnlyList<UltimateResult> results = Quotes
+            .GetUltimate();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -28,10 +27,9 @@ public class UltimateTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetUltimate()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(465, results.Count(x => x.Sma != null));
@@ -40,9 +38,8 @@ public class UltimateTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<UltimateResult> r = BadQuotes
-            .GetUltimate(1, 2, 3)
-            .ToList();
+        IReadOnlyList<UltimateResult> r = BadQuotes
+            .GetUltimate(1, 2, 3);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Ultimate is double.NaN));
@@ -51,15 +48,13 @@ public class UltimateTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<UltimateResult> r0 = Noquotes
-            .GetUltimate()
-            .ToList();
+        IReadOnlyList<UltimateResult> r0 = Noquotes
+            .GetUltimate();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<UltimateResult> r1 = Onequote
-            .GetUltimate()
-            .ToList();
+        IReadOnlyList<UltimateResult> r1 = Onequote
+            .GetUltimate();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -67,15 +62,14 @@ public class UltimateTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<UltimateResult> results = Quotes
+        IReadOnlyList<UltimateResult> results = Quotes
             .GetUltimate()
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 28, results.Count);
 
-        UltimateResult last = results.LastOrDefault();
+        UltimateResult last = results[^1];
         Assert.AreEqual(49.5257, last.Ultimate.Round(4));
     }
 

--- a/tests/indicators/s-z/VolatilityStop/VolatilityStop.Tests.cs
+++ b/tests/indicators/s-z/VolatilityStop/VolatilityStop.Tests.cs
@@ -6,9 +6,8 @@ public class VolatilityStopTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<VolatilityStopResult> results =
-            Quotes.GetVolatilityStop(14)
-            .ToList();
+        IReadOnlyList<VolatilityStopResult> results =
+            Quotes.GetVolatilityStop(14);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -54,7 +53,7 @@ public class VolatilityStopTests : SeriesTestBase
         Assert.AreEqual(249.7460, r284.LowerBand.Round(4));
         Assert.IsNull(r284.UpperBand);
 
-        VolatilityStopResult last = results.LastOrDefault();
+        VolatilityStopResult last = results[^1];
         Assert.AreEqual(249.2423, last.Sar.Round(4));
         Assert.AreEqual(false, last.IsStop);
         Assert.AreEqual(249.2423, last.UpperBand.Round(4));
@@ -64,10 +63,9 @@ public class VolatilityStopTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetVolatilityStop()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(439, results.Count(x => x.Sma != null));
@@ -76,9 +74,8 @@ public class VolatilityStopTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<VolatilityStopResult> r = BadQuotes
-            .GetVolatilityStop()
-            .ToList();
+        IReadOnlyList<VolatilityStopResult> r = BadQuotes
+            .GetVolatilityStop();
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Sar is double.NaN));
@@ -87,15 +84,13 @@ public class VolatilityStopTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<VolatilityStopResult> r0 = Noquotes
-            .GetVolatilityStop()
-            .ToList();
+        IReadOnlyList<VolatilityStopResult> r0 = Noquotes
+            .GetVolatilityStop();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<VolatilityStopResult> r1 = Onequote
-            .GetVolatilityStop()
-            .ToList();
+        IReadOnlyList<VolatilityStopResult> r1 = Onequote
+            .GetVolatilityStop();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -103,15 +98,14 @@ public class VolatilityStopTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<VolatilityStopResult> results = Quotes
+        IReadOnlyList<VolatilityStopResult> results = Quotes
             .GetVolatilityStop(14)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(402, results.Count);
 
-        VolatilityStopResult last = results.LastOrDefault();
+        VolatilityStopResult last = results[^1];
         Assert.AreEqual(249.2423, last.Sar.Round(4));
         Assert.AreEqual(false, last.IsStop);
     }

--- a/tests/indicators/s-z/Vortex/Vortex.Tests.cs
+++ b/tests/indicators/s-z/Vortex/Vortex.Tests.cs
@@ -6,9 +6,8 @@ public class VortexTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<VortexResult> results = Quotes
-            .GetVortex(14)
-            .ToList();
+        IReadOnlyList<VortexResult> results = Quotes
+            .GetVortex(14);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -39,9 +38,8 @@ public class VortexTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<VortexResult> r = BadQuotes
-            .GetVortex(20)
-            .ToList();
+        IReadOnlyList<VortexResult> r = BadQuotes
+            .GetVortex(20);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Pvi is double.NaN));
@@ -50,15 +48,13 @@ public class VortexTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<VortexResult> r0 = Noquotes
-            .GetVortex(5)
-            .ToList();
+        IReadOnlyList<VortexResult> r0 = Noquotes
+            .GetVortex(5);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<VortexResult> r1 = Onequote
-            .GetVortex(5)
-            .ToList();
+        IReadOnlyList<VortexResult> r1 = Onequote
+            .GetVortex(5);
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -66,15 +62,14 @@ public class VortexTests : SeriesTestBase
     [TestMethod]
     public void Condense()
     {
-        List<VortexResult> results = Quotes
+        IReadOnlyList<VortexResult> results = Quotes
             .GetVortex(14)
-            .Condense()
-            .ToList();
+            .Condense();
 
         // assertions
         Assert.AreEqual(502 - 14, results.Count);
 
-        VortexResult last = results.LastOrDefault();
+        VortexResult last = results[^1];
         Assert.AreEqual(0.8712, last.Pvi.Round(4));
         Assert.AreEqual(1.1163, last.Nvi.Round(4));
     }
@@ -82,15 +77,14 @@ public class VortexTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<VortexResult> results = Quotes
+        IReadOnlyList<VortexResult> results = Quotes
             .GetVortex(14)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 14, results.Count);
 
-        VortexResult last = results.LastOrDefault();
+        VortexResult last = results[^1];
         Assert.AreEqual(0.8712, last.Pvi.Round(4));
         Assert.AreEqual(1.1163, last.Nvi.Round(4));
     }

--- a/tests/indicators/s-z/Vwap/Vwap.Tests.cs
+++ b/tests/indicators/s-z/Vwap/Vwap.Tests.cs
@@ -3,15 +3,14 @@ namespace Series;
 [TestClass]
 public class VwapTests : SeriesTestBase
 {
-    private readonly IEnumerable<Quote> _intraday = Data.GetIntraday()
+    private readonly IEnumerable<Quote> intraday = Data.GetIntraday()
         .OrderBy(x => x.Timestamp)
         .Take(391);
 
     [TestMethod]
     public override void Standard()
     {
-        List<VwapResult> results = _intraday.GetVwap()
-            .ToList();
+        IReadOnlyList<VwapResult> results = intraday.GetVwap();
 
         // proper quantities
         Assert.AreEqual(391, results.Count);
@@ -37,9 +36,8 @@ public class VwapTests : SeriesTestBase
         DateTime startDate =
             DateTime.ParseExact("2020-12-15 10:00", "yyyy-MM-dd h:mm", englishCulture);
 
-        List<VwapResult> results = _intraday
-            .GetVwap(startDate)
-            .ToList();
+        IReadOnlyList<VwapResult> results = intraday
+            .GetVwap(startDate);
 
         // proper quantities
         Assert.AreEqual(391, results.Count);
@@ -62,10 +60,9 @@ public class VwapTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetVwap()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(493, results.Count(x => x.Sma != null));
@@ -74,9 +71,8 @@ public class VwapTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<VwapResult> r = BadQuotes
-            .GetVwap()
-            .ToList();
+        IReadOnlyList<VwapResult> r = BadQuotes
+            .GetVwap();
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Vwap is double.NaN));
@@ -85,15 +81,13 @@ public class VwapTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<VwapResult> r0 = Noquotes
-            .GetVwap()
-            .ToList();
+        IReadOnlyList<VwapResult> r0 = Noquotes
+            .GetVwap();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<VwapResult> r1 = Onequote
-            .GetVwap()
-            .ToList();
+        IReadOnlyList<VwapResult> r1 = Onequote
+            .GetVwap();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -102,30 +96,28 @@ public class VwapTests : SeriesTestBase
     public void Removed()
     {
         // no start date
-        List<VwapResult> results = _intraday
+        IReadOnlyList<VwapResult> results = intraday
             .GetVwap()
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(391, results.Count);
 
-        VwapResult last = results.LastOrDefault();
+        VwapResult last = results[^1];
         Assert.AreEqual(368.1804, last.Vwap.Round(4));
 
         // with start date
         DateTime startDate =
         DateTime.ParseExact("2020-12-15 10:00", "yyyy-MM-dd h:mm", englishCulture);
 
-        List<VwapResult> sdResults = _intraday
+        IReadOnlyList<VwapResult> sdResults = intraday
             .GetVwap(startDate)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(361, sdResults.Count);
 
-        VwapResult sdLast = sdResults.LastOrDefault();
+        VwapResult sdLast = sdResults[^1];
         Assert.AreEqual(368.2908, sdLast.Vwap.Round(4));
     }
 

--- a/tests/indicators/s-z/Vwma/Vwma.Tests.cs
+++ b/tests/indicators/s-z/Vwma/Vwma.Tests.cs
@@ -6,9 +6,8 @@ public class VwmaTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<VwmaResult> results = Quotes
-            .GetVwma(10)
-            .ToList();
+        IReadOnlyList<VwmaResult> results = Quotes
+            .GetVwma(10);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -28,10 +27,9 @@ public class VwmaTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetVwma(10)
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(484, results.Count(x => x.Sma != null));
@@ -40,9 +38,8 @@ public class VwmaTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<VwmaResult> r = BadQuotes
-            .GetVwma(15)
-            .ToList();
+        IReadOnlyList<VwmaResult> r = BadQuotes
+            .GetVwma(15);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Vwma is double.NaN));
@@ -51,15 +48,13 @@ public class VwmaTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<VwmaResult> r0 = Noquotes
-            .GetVwma(4)
-            .ToList();
+        IReadOnlyList<VwmaResult> r0 = Noquotes
+            .GetVwma(4);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<VwmaResult> r1 = Onequote
-            .GetVwma(4)
-            .ToList();
+        IReadOnlyList<VwmaResult> r1 = Onequote
+            .GetVwma(4);
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -67,15 +62,14 @@ public class VwmaTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<VwmaResult> results = Quotes
+        IReadOnlyList<VwmaResult> results = Quotes
             .GetVwma(10)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 9, results.Count);
 
-        VwmaResult last = results.LastOrDefault();
+        VwmaResult last = results[^1];
         Assert.AreEqual(242.101548, last.Vwma.Round(6));
     }
 

--- a/tests/indicators/s-z/WilliamsR/WilliamsR.Tests.cs
+++ b/tests/indicators/s-z/WilliamsR/WilliamsR.Tests.cs
@@ -6,9 +6,8 @@ public class WilliamsRTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<WilliamsResult> results = Quotes
-            .GetWilliamsR()
-            .ToList();
+        IReadOnlyList<WilliamsResult> results = Quotes
+            .GetWilliamsR();
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -37,10 +36,9 @@ public class WilliamsRTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetWilliamsR()
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(480, results.Count(x => x.Sma != null));
@@ -49,9 +47,8 @@ public class WilliamsRTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<WilliamsResult> results = BadQuotes
-            .GetWilliamsR(20)
-            .ToList();
+        IReadOnlyList<WilliamsResult> results = BadQuotes
+            .GetWilliamsR(20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(0, results.Count(x => x.WilliamsR is double.NaN));
@@ -60,15 +57,13 @@ public class WilliamsRTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<WilliamsResult> r0 = Noquotes
-            .GetWilliamsR()
-            .ToList();
+        IReadOnlyList<WilliamsResult> r0 = Noquotes
+            .GetWilliamsR();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<WilliamsResult> r1 = Onequote
-            .GetWilliamsR()
-            .ToList();
+        IReadOnlyList<WilliamsResult> r1 = Onequote
+            .GetWilliamsR();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -76,25 +71,23 @@ public class WilliamsRTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<WilliamsResult> results = Quotes
+        IReadOnlyList<WilliamsResult> results = Quotes
             .GetWilliamsR()
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 13, results.Count);
 
-        WilliamsResult last = results.LastOrDefault();
+        WilliamsResult last = results[^1];
         Assert.AreEqual(-52.0121, last.WilliamsR.Round(4));
     }
 
     [TestMethod]
     public void Boundary()
     {
-        List<WilliamsResult> results = Data
+        IReadOnlyList<WilliamsResult> results = Data
             .GetRandom(2500)
-            .GetWilliamsR()
-            .ToList();
+            .GetWilliamsR();
 
         // analyze boundary
         for (int i = 0; i < results.Count; i++)
@@ -118,13 +111,12 @@ public class WilliamsRTests : SeriesTestBase
             .Select(Imports.QuoteFromCsv)
             .OrderByDescending(x => x.Timestamp);
 
-        List<Quote> quotesList = test1127.ToList();
+        IReadOnlyList<Quote> quotesList = test1127.ToList();
         int length = quotesList.Count;
 
         // get indicators
-        List<WilliamsResult> resultsList = quotesList
-            .GetWilliamsR()
-            .ToList();
+        IReadOnlyList<WilliamsResult> resultsList = quotesList
+            .GetWilliamsR();
 
         Console.WriteLine($"%R from {length} quotes.");
 

--- a/tests/indicators/s-z/Wma/Wma.Tests.cs
+++ b/tests/indicators/s-z/Wma/Wma.Tests.cs
@@ -6,9 +6,8 @@ public class WmaTests : SeriesTestBase
     [TestMethod]
     public override void Standard()
     {
-        List<WmaResult> results = Quotes
-            .GetWma(20)
-            .ToList();
+        IReadOnlyList<WmaResult> results = Quotes
+            .GetWma(20);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -25,10 +24,9 @@ public class WmaTests : SeriesTestBase
     [TestMethod]
     public void UseReusable()
     {
-        List<WmaResult> results = Quotes
+        IReadOnlyList<WmaResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetWma(20)
-            .ToList();
+            .GetWma(20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(483, results.Count(x => x.Wma != null));
@@ -37,10 +35,9 @@ public class WmaTests : SeriesTestBase
     [TestMethod]
     public void Chainee()
     {
-        List<WmaResult> results = Quotes
+        IReadOnlyList<WmaResult> results = Quotes
             .GetSma(2)
-            .GetWma(20)
-            .ToList();
+            .GetWma(20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(482, results.Count(x => x.Wma != null));
@@ -49,10 +46,9 @@ public class WmaTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetWma(20)
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(474, results.Count(x => x.Sma != null));
@@ -61,14 +57,12 @@ public class WmaTests : SeriesTestBase
     [TestMethod]
     public void Chaining()
     {
-        List<WmaResult> standard = Quotes
-            .GetWma(17)
-            .ToList();
+        IReadOnlyList<WmaResult> standard = Quotes
+            .GetWma(17);
 
-        List<WmaResult> results = Quotes
+        IReadOnlyList<WmaResult> results = Quotes
             .Use(CandlePart.Close)
-            .GetWma(17)
-            .ToList();
+            .GetWma(17);
 
         // assertions
         for (int i = 0; i < results.Count; i++)
@@ -84,9 +78,8 @@ public class WmaTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<WmaResult> r = BadQuotes
-            .GetWma(15)
-            .ToList();
+        IReadOnlyList<WmaResult> r = BadQuotes
+            .GetWma(15);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Wma is double.NaN));
@@ -95,15 +88,13 @@ public class WmaTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<WmaResult> r0 = Noquotes
-            .GetWma(5)
-            .ToList();
+        IReadOnlyList<WmaResult> r0 = Noquotes
+            .GetWma(5);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<WmaResult> r1 = Onequote
-            .GetWma(5)
-            .ToList();
+        IReadOnlyList<WmaResult> r1 = Onequote
+            .GetWma(5);
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -111,15 +102,14 @@ public class WmaTests : SeriesTestBase
     [TestMethod]
     public void Removed()
     {
-        List<WmaResult> results = Quotes
+        IReadOnlyList<WmaResult> results = Quotes
             .GetWma(20)
-            .RemoveWarmupPeriods()
-            .ToList();
+            .RemoveWarmupPeriods();
 
         // assertions
         Assert.AreEqual(502 - 19, results.Count);
 
-        WmaResult last = results.LastOrDefault();
+        WmaResult last = results[^1];
         Assert.AreEqual(246.5110, last.Wma.Round(4));
     }
 

--- a/tests/indicators/s-z/ZigZag/ZigZag.Tests.cs
+++ b/tests/indicators/s-z/ZigZag/ZigZag.Tests.cs
@@ -8,9 +8,8 @@ public class ZigZagTests : SeriesTestBase
     [TestMethod]
     public override void Standard() // on Close
     {
-        List<ZigZagResult> results =
-            Quotes.GetZigZag(EndType.Close, 3)
-            .ToList();
+        IReadOnlyList<ZigZagResult> results =
+            Quotes.GetZigZag(EndType.Close, 3);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -60,9 +59,8 @@ public class ZigZagTests : SeriesTestBase
     [TestMethod]
     public void StandardHighLow()
     {
-        List<ZigZagResult> results =
-            Quotes.GetZigZag(EndType.HighLow, 3)
-            .ToList();
+        IReadOnlyList<ZigZagResult> results =
+            Quotes.GetZigZag(EndType.HighLow, 3);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -112,10 +110,9 @@ public class ZigZagTests : SeriesTestBase
     [TestMethod]
     public void Chainor()
     {
-        List<SmaResult> results = Quotes
+        IReadOnlyList<SmaResult> results = Quotes
             .GetZigZag(EndType.Close, 3)
-            .GetSma(10)
-            .ToList();
+            .GetSma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(225, results.Count(x => x.Sma != null));
@@ -130,9 +127,8 @@ public class ZigZagTests : SeriesTestBase
         IReadOnlyCollection<Quote> quotes = JsonConvert
             .DeserializeObject<IReadOnlyCollection<Quote>>(json);
 
-        List<ZigZagResult> results = quotes
-            .GetZigZag()
-            .ToList();
+        IReadOnlyList<ZigZagResult> results = quotes
+            .GetZigZag();
 
         Assert.AreEqual(0, results.Count(x => x.PointType != null));
     }
@@ -143,13 +139,11 @@ public class ZigZagTests : SeriesTestBase
         // thresholds are never met
         string json = File.ReadAllText("./s-z/ZigZag/data.issue632.json");
 
-        List<Quote> quotesList = JsonConvert
-            .DeserializeObject<IReadOnlyCollection<Quote>>(json)
-            .ToList();
+        IReadOnlyCollection<Quote> quotesList = JsonConvert
+            .DeserializeObject<IReadOnlyCollection<Quote>>(json);
 
-        List<ZigZagResult> resultsList = quotesList
-            .GetZigZag()
-            .ToList();
+        IReadOnlyList<ZigZagResult> resultsList = quotesList
+            .GetZigZag();
 
         Assert.AreEqual(17, resultsList.Count);
     }
@@ -157,15 +151,13 @@ public class ZigZagTests : SeriesTestBase
     [TestMethod]
     public override void BadData()
     {
-        List<ZigZagResult> r1 = BadQuotes
-            .GetZigZag()
-            .ToList();
+        IReadOnlyList<ZigZagResult> r1 = BadQuotes
+            .GetZigZag();
 
         Assert.AreEqual(502, r1.Count);
 
-        List<ZigZagResult> r2 = BadQuotes
-            .GetZigZag(EndType.HighLow)
-            .ToList();
+        IReadOnlyList<ZigZagResult> r2 = BadQuotes
+            .GetZigZag(EndType.HighLow);
 
         Assert.AreEqual(502, r2.Count);
     }
@@ -173,15 +165,13 @@ public class ZigZagTests : SeriesTestBase
     [TestMethod]
     public override void NoQuotes()
     {
-        List<ZigZagResult> r0 = Noquotes
-            .GetZigZag()
-            .ToList();
+        IReadOnlyList<ZigZagResult> r0 = Noquotes
+            .GetZigZag();
 
         Assert.AreEqual(0, r0.Count);
 
-        List<ZigZagResult> r1 = Onequote
-            .GetZigZag()
-            .ToList();
+        IReadOnlyList<ZigZagResult> r1 = Onequote
+            .GetZigZag();
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -189,10 +179,9 @@ public class ZigZagTests : SeriesTestBase
     [TestMethod]
     public void Condense()
     {
-        List<ZigZagResult> results = Quotes
+        IReadOnlyList<ZigZagResult> results = Quotes
             .GetZigZag(EndType.Close, 3)
-            .Condense()
-            .ToList();
+            .Condense();
 
         // assertions
         Assert.AreEqual(14, results.Count);
@@ -203,17 +192,16 @@ public class ZigZagTests : SeriesTestBase
     {
         string json = File.ReadAllText("./s-z/ZigZag/data.schrodinger.json");
 
-        List<Quote> h = JsonConvert
+        IOrderedEnumerable<Quote> h = JsonConvert
             .DeserializeObject<IReadOnlyCollection<Quote>>(json)
-            .OrderBy(x => x.Timestamp)
-            .ToList();
+            .OrderBy(x => x.Timestamp);
 
-        List<ZigZagResult> r1 = h.GetZigZag(EndType.Close, 0.25m).ToList();
+        IReadOnlyList<ZigZagResult> r1 = h.GetZigZag(EndType.Close, 0.25m).ToList();
         Assert.AreEqual(342, r1.Count);
 
         // first period has High/Low that exceeds threhold
         // where it is both a H and L pivot simultaenously
-        List<ZigZagResult> r2 = h.GetZigZag(EndType.HighLow, 3).ToList();
+        IReadOnlyList<ZigZagResult> r2 = h.GetZigZag(EndType.HighLow, 3).ToList();
         Assert.AreEqual(342, r2.Count);
     }
 

--- a/tests/other/CustomIndicator.Tests.cs
+++ b/tests/other/CustomIndicator.Tests.cs
@@ -36,10 +36,11 @@ public static class CustomIndicator
         }
 
         // initialize
-        List<MyResult> results = new(source.Count);
+        int length = source.Count;
+        List<MyResult> results = new(length);
 
         // roll through source values
-        for (int i = 0; i < source.Count; i++)
+        for (int i = 0; i < length; i++)
         {
             T s = source[i];
 

--- a/tests/other/CustomIndicator.Tests.cs
+++ b/tests/other/CustomIndicator.Tests.cs
@@ -15,7 +15,7 @@ public sealed record MyResult : IReusable
 public static class CustomIndicator
 {
     // SERIES, from CHAIN
-    public static IEnumerable<MyResult> GetIndicator<T>(
+    public static IReadOnlyList<MyResult> GetIndicator<T>(
         this IEnumerable<T> source,
         int lookbackPeriods)
         where T : IReusable
@@ -85,9 +85,8 @@ public class CustomIndicatorTests
     [TestMethod]
     public void Standard()
     {
-        List<MyResult> results = quotes
-            .GetIndicator(20)
-            .ToList();
+        IReadOnlyList<MyResult> results = quotes
+            .GetIndicator(20);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -105,10 +104,9 @@ public class CustomIndicatorTests
     [TestMethod]
     public void CandlePartOpen()
     {
-        List<MyResult> results = quotes
+        IReadOnlyList<MyResult> results = quotes
             .Use(CandlePart.Open)
-            .GetIndicator(20)
-            .ToList();
+            .GetIndicator(20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(483, results.Count(x => x.Sma != null));
@@ -125,10 +123,9 @@ public class CustomIndicatorTests
     [TestMethod]
     public void CandlePartVolume()
     {
-        List<MyResult> results = quotes
+        IReadOnlyList<MyResult> results = quotes
             .Use(CandlePart.Volume)
-            .GetIndicator(20)
-            .ToList();
+            .GetIndicator(20);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(483, results.Count(x => x.Sma != null));
@@ -148,10 +145,9 @@ public class CustomIndicatorTests
     [TestMethod]
     public void Chainor()
     {
-        List<EmaResult> results = quotes
+        IReadOnlyList<EmaResult> results = quotes
             .GetIndicator(10)
-            .GetEma(10)
-            .ToList();
+            .GetEma(10);
 
         Assert.AreEqual(502, results.Count);
         Assert.AreEqual(484, results.Count(x => x.Ema != null));
@@ -183,9 +179,8 @@ public class CustomIndicatorTests
     [TestMethod]
     public void NaN()
     {
-        List<MyResult> r = Data.GetBtcUsdNan()
-            .GetIndicator(50)
-            .ToList();
+        IReadOnlyList<MyResult> r = Data.GetBtcUsdNan()
+            .GetIndicator(50);
 
         Assert.AreEqual(0, r.Count(x => x.Sma is double.NaN));
     }
@@ -193,9 +188,8 @@ public class CustomIndicatorTests
     [TestMethod]
     public void BadData()
     {
-        List<MyResult> r = badQuotes
-            .GetIndicator(15)
-            .ToList();
+        IReadOnlyList<MyResult> r = badQuotes
+            .GetIndicator(15);
 
         Assert.AreEqual(502, r.Count);
         Assert.AreEqual(0, r.Count(x => x.Sma is double.NaN));
@@ -204,15 +198,13 @@ public class CustomIndicatorTests
     [TestMethod]
     public void NoQuotesExist()
     {
-        List<MyResult> r0 = noquotes
-            .GetIndicator(5)
-            .ToList();
+        IReadOnlyList<MyResult> r0 = noquotes
+            .GetIndicator(5);
 
         Assert.AreEqual(0, r0.Count);
 
-        List<MyResult> r1 = onequote
-            .GetIndicator(5)
-            .ToList();
+        IReadOnlyList<MyResult> r1 = onequote
+            .GetIndicator(5);
 
         Assert.AreEqual(1, r1.Count);
     }
@@ -220,13 +212,12 @@ public class CustomIndicatorTests
     [TestMethod]
     public void Removed()
     {
-        List<MyResult> results = quotes
+        IReadOnlyList<MyResult> results = quotes
             .GetIndicator(20)
-            .RemoveWarmupPeriods(19)
-            .ToList();
+            .RemoveWarmupPeriods(19);
 
         Assert.AreEqual(502 - 19, results.Count);
-        Assert.AreEqual(251.8600, Math.Round(results.LastOrDefault().Sma.Value, 4));
+        Assert.AreEqual(251.8600, Math.Round(results[^1].Sma.Value, 4));
     }
 
     // bad lookback period

--- a/tests/other/PublicApi.Tests.cs
+++ b/tests/other/PublicApi.Tests.cs
@@ -61,9 +61,9 @@ public class PublicClassTests
     [TestMethod]
     public void ReadQuoteClass()
     {
-        IEnumerable<Quote> h = quotes.Validate();
+        IReadOnlyList<Quote> h = quotes.Validate();
 
-        Quote f = h.FirstOrDefault();
+        Quote f = h[0];
         Console.WriteLine($"Quote:{f}");
     }
 
@@ -82,9 +82,8 @@ public class PublicClassTests
             })
             .ToList();
 
-        List<EmaResult> results = myGenericHistory
-            .GetEma(20)
-            .ToList();
+        IReadOnlyList<EmaResult> results = myGenericHistory
+            .GetEma(20);
 
         // proper quantities
         Assert.AreEqual(502, results.Count);
@@ -159,9 +158,8 @@ public class PublicClassTests
             })
             .ToList();
 
-        List<Quote> quotesList = myGenericHistory
-            .Aggregate(PeriodSize.TwoHours)
-            .ToList();
+        IReadOnlyList<Quote> quotesList = myGenericHistory
+            .Aggregate(PeriodSize.TwoHours);
 
         // proper quantities
         Assert.AreEqual(20, quotesList.Count);
@@ -186,9 +184,8 @@ public class PublicClassTests
             })
             .ToList();
 
-        List<Quote> quotesList = myGenericHistory
-            .Aggregate(TimeSpan.FromHours(2))
-            .ToList();
+        IReadOnlyList<Quote> quotesList = myGenericHistory
+            .Aggregate(TimeSpan.FromHours(2));
 
         // proper quantities
         Assert.AreEqual(20, quotesList.Count);


### PR DESCRIPTION
#### done when

- [x] Change primary time-series output type from `IEnumerable` to `IReadOnlyList`
- [x] Fix/remove unnecessary internal conversions to `List`
- [x] fix: related issues with Examples solution
- [x] update unit tests accordingly

> [!NOTE]
> This is a non-breaking change, externally, since we were returning the lower-level `IEnumerable`; though it's advisable to update usage accordingly.
