### PR TITLE
docs: Add inline convergence info link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Stock Indicators for .NET** is a C# [library package](https://www.nuget.org/packages/Skender.Stock.Indicators) that produces financial market technical indicators.  Send in historical price quotes and get back desired indicators such as moving averages, Relative Strength Index, Stochastic Oscillator, Parabolic SAR, etc.  Nothing more.
 
-Build your private technical analysis, trading algorithms, machine learning, charting, or other intelligent market software with this library and your own [OHLCV](https://dotnet.stockindicators.dev/guide/#historical-quotes) price quotes sources for equities, commodities, forex, cryptocurrencies, and others.  [Stock Indicators for Python](https://python.stockindicators.dev/) is also available.
+Build your technical analysis, trading algorithms, machine learning, charting, or other intelligent market software with this library and your own [OHLCV](https://dotnet.stockindicators.dev/guide/#historical-quotes) price quotes sources for equities, commodities, forex, cryptocurrencies, and others.  [Stock Indicators for Python](https://python.stockindicators.dev/) is also available.
 
 Visit our project site for more information:
 

--- a/docs/GemFile.lock
+++ b/docs/GemFile.lock
@@ -43,7 +43,7 @@ GEM
     faraday (2.10.0)
       faraday-net_http (>= 2.0, < 3.2)
       logger
-    faraday-net_http (3.1.0)
+    faraday-net_http (3.1.1)
       net-http
     faraday-retry (2.2.1)
       faraday (~> 2.0)
@@ -246,9 +246,9 @@ GEM
     mutex_m (0.2.0)
     net-http (0.4.1)
       uri
-    nokogiri (1.16.6-x64-mingw-ucrt)
+    nokogiri (1.16.7-x64-mingw-ucrt)
       racc (~> 1.4)
-    nokogiri (1.16.6-x86_64-linux)
+    nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)

--- a/docs/_includes/head-style.html
+++ b/docs/_includes/head-style.html
@@ -1,7 +1,7 @@
 <style>
   /* general site styles */
   html {
-    font-family: "Google Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-family: "Rubik", "Google Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   }
 
   * {
@@ -21,6 +21,7 @@
   h4,
   h5,
   h6 {
+    font-family: "Rubik", "Google Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
     margin-top: 2rem;
     margin-bottom: 1rem;
     font-weight: 700;
@@ -113,6 +114,8 @@
   }
 
   .project-name {
+    font-family: "Rubik", "Google Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    color: rgba(230, 199, 76, 0.85);
     margin: 0;
     font-weight: 700;
   }
@@ -124,7 +127,7 @@
 
   .project-name a:hover {
     text-decoration: none;
-    color: #bdbdbd;
+    color: rgba(230, 199, 76, 1.00);
   }
 
   @media screen and (min-width: 1024px) {

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -8,8 +8,8 @@
   <link rel="preconnect" href="https://github.githubassets.com">
   <link rel="preconnect" href="https://img.shields.io">
   {%- endif -%}
-  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500&display=swap" as="style"
-    type="text/css" crossorigin>
+  <link defer rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Rubik:wght@400..600&display=swap" />
+  <link defer rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@400;500&display=swap" />
 
   {%- include head-style.html -%}
 

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -1,4 +1,4 @@
-<header role="banner" class="page-header">
+<header class="page-header" role="banner">
 
   <div class="project-name">
     <a href="{{ '/' | absolute_url }}">

--- a/docs/_indicators/Adx.md
+++ b/docs/_indicators/Adx.md
@@ -26,7 +26,7 @@ IEnumerable<AdxResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `2×N+100` periods of `quotes` to allow for smoothing convergence.  We generally recommend you use at least `2×N+250` data points prior to the intended usage date for better precision.
+You must have at least `2×N+100` periods of `quotes` to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.  We generally recommend you use at least `2×N+250` data points prior to the intended usage date for better precision.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/Alligator.md
+++ b/docs/_indicators/Alligator.md
@@ -36,7 +36,7 @@ IEnumerable<AlligatorResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `JP+JO+100` periods of `quotes` to cover the convergence periods. Since this uses a smoothing technique, we recommend you use at least `JP+JO+250` data points prior to the intended usage date for better precision.
+You must have at least `JP+JO+100` periods of `quotes` to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods. Since this uses a smoothing technique, we recommend you use at least `JP+JO+250` data points prior to the intended usage date for better precision.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/Atr.md
+++ b/docs/_indicators/Atr.md
@@ -34,7 +34,7 @@ IEnumerable<TrResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `N+100` periods of `quotes` to cover the convergence periods.  Since this uses a smoothing technique, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.
+You must have at least `N+100` periods of `quotes` to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.  Since this uses a smoothing technique, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/AtrStop.md
+++ b/docs/_indicators/AtrStop.md
@@ -30,7 +30,7 @@ IEnumerable<AtrStopResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `N+100` periods of `quotes` to cover the convergence periods.  Since this uses a smoothing technique, we recommend you use at least `N+250` periods prior to the intended usage date for optimal precision.
+You must have at least `N+100` periods of `quotes` to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.  Since this uses a smoothing technique, we recommend you use at least `N+250` periods prior to the intended usage date for optimal precision.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/ChaikinOsc.md
+++ b/docs/_indicators/ChaikinOsc.md
@@ -28,7 +28,7 @@ IEnumerable<ChaikinOscResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `2×S` or `S+100` periods of `quotes`, whichever is more,  to cover the convergence periods.  Since this uses a smoothing technique, we recommend you use at least `S+250` data points prior to the intended usage date for better precision.
+You must have at least `2×S` or `S+100` periods of `quotes`, whichever is more,  to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.  Since this uses a smoothing technique, we recommend you use at least `S+250` data points prior to the intended usage date for better precision.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/ConnorsRsi.md
+++ b/docs/_indicators/ConnorsRsi.md
@@ -30,7 +30,7 @@ IEnumerable<ConnorsRsiResult> results =
 
 ### Historical quotes requirements
 
-`N` is the greater of `R+100`, `S`, and `P+2`.  You must have at least `N` periods of `quotes` to cover the convergence periods.  Since this uses a smoothing technique, we recommend you use at least `N+150` data points prior to the intended usage date for better precision.
+`N` is the greater of `R+100`, `S`, and `P+2`.  You must have at least `N` periods of `quotes` to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.  Since this uses a smoothing technique, we recommend you use at least `N+150` data points prior to the intended usage date for better precision.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/Dema.md
+++ b/docs/_indicators/Dema.md
@@ -28,7 +28,7 @@ IEnumerable<DemaResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `3×N` or `2×N+100` periods of `quotes`, whichever is more, to cover the convergence periods.  Since this uses a smoothing technique, we recommend you use at least `2×N+250` data points prior to the intended usage date for better precision.
+You must have at least `3×N` or `2×N+100` periods of `quotes`, whichever is more, to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.  Since this uses a smoothing technique, we recommend you use at least `2×N+250` data points prior to the intended usage date for better precision.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/Dynamic.md
+++ b/docs/_indicators/Dynamic.md
@@ -28,7 +28,7 @@ IEnumerable<DynamicResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `2` periods of `quotes`, to cover the initialization periods.  Since this uses a smoothing technique, we recommend you use at least `4×N` data points prior to the intended usage date for better precision.
+You must have at least `2` periods of `quotes`, to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.  Since this uses a smoothing technique, we recommend you use at least `4×N` data points prior to the intended usage date for better precision.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/ElderRay.md
+++ b/docs/_indicators/ElderRay.md
@@ -26,7 +26,7 @@ IEnumerable<ElderRayResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `2×N` or `N+100` periods of `quotes`, whichever is more, to cover the convergence periods.  Since this uses a smoothing technique, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.
+You must have at least `2×N` or `N+100` periods of `quotes`, whichever is more, to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.  Since this uses a smoothing technique, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/Ema.md
+++ b/docs/_indicators/Ema.md
@@ -26,7 +26,7 @@ IEnumerable<EmaResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `2×N` or `N+100` periods of `quotes`, whichever is more, to cover the convergence periods.  Since this uses a smoothing technique, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.
+You must have at least `2×N` or `N+100` periods of `quotes`, whichever is more, to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.  Since this uses a smoothing technique, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/FisherTransform.md
+++ b/docs/_indicators/FisherTransform.md
@@ -26,7 +26,7 @@ IEnumerable<FisherTransformResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `N` periods of `quotes` to cover the warmup periods.
+You must have at least `N` periods of `quotes` to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/ForceIndex.md
+++ b/docs/_indicators/ForceIndex.md
@@ -26,7 +26,7 @@ IEnumerable<ForceIndexResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `N+100` for `2×N` periods of `quotes`, whichever is more, to cover the convergence periods.  Since this uses a smoothing technique for EMA, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.
+You must have at least `N+100` for `2×N` periods of `quotes`, whichever is more, to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.  Since this uses a smoothing technique for EMA, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/Gator.md
+++ b/docs/_indicators/Gator.md
@@ -27,7 +27,7 @@ IEnumerable<GatorResult> results = quotes
 
 ## Historical quotes requirements
 
-If using default settings, you must have at least 121 periods of `quotes`. Since this uses a smoothing technique, we recommend you use at least 271 data points prior to the intended usage date for better precision.  If using a custom Alligator configuration, see [Alligator documentation]({{site.baseurl}}/indicators/Alligator/#historical-quotes-requirements) for historical quotes requirements.
+If using default settings, you must have at least 121 periods of `quotes` to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods. Since this uses a smoothing technique, we recommend you use at least 271 data points prior to the intended usage date for better precision.  If using a custom Alligator configuration, see [Alligator documentation]({{site.baseurl}}/indicators/Alligator/#historical-quotes-requirements) for historical quotes requirements.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/HtTrendline.md
+++ b/docs/_indicators/HtTrendline.md
@@ -22,7 +22,7 @@ IEnumerable<HtlResult> results =
 
 ## Historical quotes requirements
 
-You must have at least `100` periods of `quotes` to cover the warmup periods.
+You must have at least `100` periods of `quotes` to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/Kama.md
+++ b/docs/_indicators/Kama.md
@@ -30,7 +30,7 @@ IEnumerable<KamaResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `6×E` or `E+100` periods of `quotes`, whichever is more, to cover the convergence periods.  Since this uses a smoothing technique, we recommend you use at least `10×E` data points prior to the intended usage date for better precision.
+You must have at least `6×E` or `E+100` periods of `quotes`, whichever is more, to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.  Since this uses a smoothing technique, we recommend you use at least `10×E` data points prior to the intended usage date for better precision.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/Keltner.md
+++ b/docs/_indicators/Keltner.md
@@ -30,7 +30,7 @@ IEnumerable<KeltnerResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `2×N` or `N+100` periods of `quotes`, whichever is more, where `N` is the greater of `E` or `A` periods, to cover the convergence periods.  Since this uses a smoothing technique, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.
+You must have at least `2×N` or `N+100` periods of `quotes`, whichever is more, where `N` is the greater of `E` or `A` periods, to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.  Since this uses a smoothing technique, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/Kvo.md
+++ b/docs/_indicators/Kvo.md
@@ -30,7 +30,7 @@ IEnumerable<KvoResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `L+100` periods of `quotes` to cover the warmup periods.  Since this uses a smoothing technique, we recommend you use at least `L+150` data points prior to the intended usage date for better precision.
+You must have at least `L+100` periods of `quotes` to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.  Since this uses a smoothing technique, we recommend you use at least `L+150` data points prior to the intended usage date for better precision.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/Macd.md
+++ b/docs/_indicators/Macd.md
@@ -30,7 +30,7 @@ IEnumerable<MacdResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `2×(S+P)` or `S+P+100` worth of `quotes`, whichever is more, to cover the convergence periods.  Since this uses a smoothing technique, we recommend you use at least `S+P+250` data points prior to the intended usage date for better precision.
+You must have at least `2×(S+P)` or `S+P+100` worth of `quotes`, whichever is more, to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.  Since this uses a smoothing technique, we recommend you use at least `S+P+250` data points prior to the intended usage date for better precision.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/Mama.md
+++ b/docs/_indicators/Mama.md
@@ -28,7 +28,7 @@ IEnumerable<MamaResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `50` periods of `quotes` to cover the warmup periods.
+You must have at least `50` periods of `quotes` to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/Pmo.md
+++ b/docs/_indicators/Pmo.md
@@ -30,7 +30,7 @@ IEnumerable<PmoResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `N` periods of `quotes`, where `N` is the greater of `T+S`,`2×T`, or `T+100` to cover the convergence periods.  Since this uses multiple smoothing operations, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.
+You must have at least `N` periods of `quotes`, where `N` is the greater of `T+S`,`2×T`, or `T+100` to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.  Since this uses multiple smoothing operations, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/Pvo.md
+++ b/docs/_indicators/Pvo.md
@@ -30,7 +30,7 @@ IEnumerable<PvoResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `2×(S+P)` or `S+P+100` worth of `quotes`, whichever is more, to cover the convergence periods.  Since this uses a smoothing technique, we recommend you use at least `S+P+250` data points prior to the intended usage date for better precision.
+You must have at least `2×(S+P)` or `S+P+100` worth of `quotes`, whichever is more, to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.  Since this uses a smoothing technique, we recommend you use at least `S+P+250` data points prior to the intended usage date for better precision.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/Rsi.md
+++ b/docs/_indicators/Rsi.md
@@ -26,7 +26,7 @@ IEnumerable<RsiResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `N+100` periods of `quotes` to cover the convergence periods.  Since this uses a smoothing technique, we recommend you use at least `10×N` data points prior to the intended usage date for better precision.
+You must have at least `N+100` periods of `quotes` to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.  Since this uses a smoothing technique, we recommend you use at least `10×N` data points prior to the intended usage date for better precision.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/Smi.md
+++ b/docs/_indicators/Smi.md
@@ -33,7 +33,7 @@ IEnumerable<SmiResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `N+100` periods of `quotes` to cover the convergence periods.
+You must have at least `N+100` periods of `quotes` to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/Smma.md
+++ b/docs/_indicators/Smma.md
@@ -26,7 +26,7 @@ IEnumerable<SmmaResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `2×N` or `N+100` periods of `quotes`, whichever is more, to cover the convergence periods.  Since this uses a smoothing technique, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.
+You must have at least `2×N` or `N+100` periods of `quotes`, whichever is more, to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.  Since this uses a smoothing technique, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/StarcBands.md
+++ b/docs/_indicators/StarcBands.md
@@ -30,7 +30,7 @@ IEnumerable<StarcBandsResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `S` or `A+100` periods of `quotes`, whichever is more, to cover the convergence periods.  Since this uses a smoothing technique, we recommend you use at least `A+150` data points prior to the intended usage date for better precision.
+You must have at least `S` or `A+100` periods of `quotes`, whichever is more, to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.  Since this uses a smoothing technique, we recommend you use at least `A+150` data points prior to the intended usage date for better precision.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/Stc.md
+++ b/docs/_indicators/Stc.md
@@ -30,7 +30,7 @@ IEnumerable<StcResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `2×(S+C)` or `S+C+100` worth of `quotes`, whichever is more, to cover the convergence periods.  Since this uses a smoothing technique, we recommend you use at least `S+C+250` data points prior to the intended usage date for better precision.
+You must have at least `2×(S+C)` or `S+C+100` worth of `quotes`, whichever is more, to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.  Since this uses a smoothing technique, we recommend you use at least `S+C+250` data points prior to the intended usage date for better precision.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/Stoch.md
+++ b/docs/_indicators/Stoch.md
@@ -41,7 +41,7 @@ IEnumerable<StochResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `N+S` periods of `quotes` to cover the warmup periods.
+You must have at least `N+S` periods of `quotes` to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/StochRsi.md
+++ b/docs/_indicators/StochRsi.md
@@ -35,7 +35,7 @@ The original Stochastic RSI formula uses a the Fast variant of the Stochastic ca
 
 ### Historical quotes requirements
 
-You must have at least `N` periods of `quotes`, where `N` is the greater of `R+S+M` and `R+100` to cover the convergence periods.  Since this uses a smoothing technique in the underlying RSI value, we recommend you use at least `10×R` periods prior to the intended usage date for better precision.
+You must have at least `N` periods of `quotes`, where `N` is the greater of `R+S+M` and `R+100` to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.  Since this uses a smoothing technique in the underlying RSI value, we recommend you use at least `10×R` periods prior to the intended usage date for better precision.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/SuperTrend.md
+++ b/docs/_indicators/SuperTrend.md
@@ -28,7 +28,7 @@ IEnumerable<SuperTrendResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `N+100` periods of `quotes` to cover the convergence periods.  Since this uses a smoothing technique, we recommend you use at least `N+250` periods prior to the intended usage date for optimal precision.
+You must have at least `N+100` periods of `quotes` to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.  Since this uses a smoothing technique, we recommend you use at least `N+250` periods prior to the intended usage date for optimal precision.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/T3.md
+++ b/docs/_indicators/T3.md
@@ -28,7 +28,7 @@ IEnumerable<T3Result> results =
 
 ### Historical quotes requirements
 
-You must have at least `6×(N-1)+100` periods of `quotes` to cover the convergence periods.  Since this uses a smoothing technique, we recommend you use at least `6×(N-1)+250` data points prior to the intended usage date for better precision.
+You must have at least `6×(N-1)+100` periods of `quotes` to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.  Since this uses a smoothing technique, we recommend you use at least `6×(N-1)+250` data points prior to the intended usage date for better precision.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/Tema.md
+++ b/docs/_indicators/Tema.md
@@ -28,7 +28,7 @@ IEnumerable<TemaResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `4×N` or `3×N+100` periods of `quotes`, whichever is more, to cover the convergence periods.  Since this uses a smoothing technique, we recommend you use at least `3×N+250` data points prior to the intended usage date for better precision.
+You must have at least `4×N` or `3×N+100` periods of `quotes`, whichever is more, to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.  Since this uses a smoothing technique, we recommend you use at least `3×N+250` data points prior to the intended usage date for better precision.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/Trix.md
+++ b/docs/_indicators/Trix.md
@@ -32,7 +32,7 @@ IEnumerable<TrixResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `4×N` or `3×N+100` periods of `quotes`, whichever is more, to cover the convergence periods.  Since this uses a smoothing technique, we recommend you use at least `3×N+250` data points prior to the intended usage date for better precision.
+You must have at least `4×N` or `3×N+100` periods of `quotes`, whichever is more, to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.  Since this uses a smoothing technique, we recommend you use at least `3×N+250` data points prior to the intended usage date for better precision.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/Tsi.md
+++ b/docs/_indicators/Tsi.md
@@ -31,7 +31,7 @@ IEnumerable<TsiResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `N+M+100` periods of `quotes` to cover the convergence periods.  Since this uses a two EMA smoothing techniques, we recommend you use at least `N+M+250` data points prior to the intended usage date for better precision.
+You must have at least `N+M+100` periods of `quotes` to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.  Since this uses a two EMA smoothing techniques, we recommend you use at least `N+M+250` data points prior to the intended usage date for better precision.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/_indicators/VolatilityStop.md
+++ b/docs/_indicators/VolatilityStop.md
@@ -28,7 +28,7 @@ IEnumerable<VolatilityStopResult> results =
 
 ### Historical quotes requirements
 
-You must have at least `N+100` periods of `quotes` to cover the convergence periods.  Since the underlying ATR uses a smoothing technique, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.  Initial values prior to the first reversal are not accurate and are excluded from the results.  Therefore, provide sufficient quotes to capture prior trend reversals.
+You must have at least `N+100` periods of `quotes` to cover the [warmup and convergence]({{site.github.repository_url}}/discussions/688) periods.  Since the underlying ATR uses a smoothing technique, we recommend you use at least `N+250` data points prior to the intended usage date for better precision.  Initial values prior to the first reversal are not accurate and are excluded from the results.  Therefore, provide sufficient quotes to capture prior trend reversals.
 
 `quotes` is a collection of generic `TQuote` historical price quotes.  It should have a consistent frequency (day, hour, minute, etc).  See [the Guide]({{site.baseurl}}/guide/#historical-quotes) for more information.
 

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -298,6 +298,7 @@ a {
     border-left: 0.3rem solid $border-color;
     background-color: $code-bg-color;
 
+    font-family: "Google Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
     color: $blockquote-text-color;
     font-size: 1rem;
 

--- a/docs/pages/home.md
+++ b/docs/pages/home.md
@@ -17,7 +17,7 @@ lazy-images: true
 
 **Stock Indicators for .NET** is a C# [library package](https://www.nuget.org/packages/Skender.Stock.Indicators) that produces financial market technical indicators.  Send in historical price quotes and get back desired indicators such as moving averages, Relative Strength Index, Stochastic Oscillator, Parabolic SAR, etc.  Nothing more.
 
-Build your private technical analysis, trading algorithms, machine learning, charting, or other intelligent market software with this library and your own [OHLCV]({{site.baseurl}}/guide/#historical-quotes) price quotes sources for equities, commodities, forex, cryptocurrencies, and others.  [Stock Indicators for Python](https://python.stockindicators.dev/) is also available.
+Build your technical analysis, trading algorithms, machine learning, charting, or other intelligent market software with this library and your own [OHLCV]({{site.baseurl}}/guide/#historical-quotes) price quotes sources for equities, commodities, forex, cryptocurrencies, and others.  [Stock Indicators for Python](https://python.stockindicators.dev/) is also available.
 
 Explore more information:
 
@@ -36,7 +36,7 @@ You'll get all of the industry standard indicators out-of-the-box.  Additionally
 
 <img alt="sample indicators shown in chart"
   data-src="examples.webp"
-  style="aspect-ratio:900/748;"
+  height="748" width="900"
   class = "lazyload" />
 
 ## Easy to use in your application

--- a/tests/other/Convergence.Tests.cs
+++ b/tests/other/Convergence.Tests.cs
@@ -22,6 +22,21 @@ public class ConvergenceTests : TestBase
     }
 
     [TestMethod]
+    public void Alligator()
+    {
+        foreach (int qty in QuotesQuantities)
+        {
+            IEnumerable<Quote> quotes = TestData.GetLongish(qty);
+            IEnumerable<AlligatorResult> r = quotes.GetAlligator();
+
+            AlligatorResult l = r.LastOrDefault();
+            Console.WriteLine(
+                "ALLIGATOR(13,8,5) on {0:d} with {1,4} periods: Jaw {2:N8}",
+                l.Date, quotes.Count(), l.Jaw);
+        }
+    }
+
+    [TestMethod]
     public void Atr()
     {
         foreach (int qty in QuotesQuantities)
@@ -123,6 +138,21 @@ public class ConvergenceTests : TestBase
             Console.WriteLine(
                 "FT(10) on {0:d} with {1,4} periods: {2:N8}",
                 l.Date, quotes.Count(), l.Fisher);
+        }
+    }
+
+    [TestMethod]
+    public void Gator()
+    {
+        foreach (int qty in QuotesQuantities)
+        {
+            IEnumerable<Quote> quotes = TestData.GetLongish(qty);
+            IEnumerable<GatorResult> r = quotes.GetGator();
+
+            GatorResult l = r.LastOrDefault();
+            Console.WriteLine(
+                "GATOR() on {0:d} with {1,4} periods: Upper {2:N8}  Lower {3:N8}",
+                l.Date, quotes.Count(), l.Upper, l.Lower);
         }
     }
 


### PR DESCRIPTION
#### done when

- [x] add indicator page link to #688 to help clarify concept of warmup and convergence
- [x] chore: update doc site packages
- [x] other: minor updates to fonts, colors
