### PR TITLE
docs: CF Pages indexing exclusion

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -15,6 +15,7 @@ jobs:
 
     environment:
       name: stockindicators.dev
+      url: https://dotnet.stockindicators.dev
 
     steps:
       - name: Checkout source

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -25,7 +25,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           working-directory: docs
-          ruby-version: 3.2
+          ruby-version: 3.3
 
       - name: Define tag
         id: tag

--- a/docs/GemFile.lock
+++ b/docs/GemFile.lock
@@ -40,7 +40,7 @@ GEM
     ethon (0.16.0)
       ffi (>= 1.15.0)
     execjs (2.9.1)
-    faraday (2.10.0)
+    faraday (2.10.1)
       faraday-net_http (>= 2.0, < 3.2)
       logger
     faraday-net_http (3.1.1)
@@ -260,7 +260,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.3.2)
+    rexml (3.3.4)
       strscan
     rouge (3.30.0)
     rubyzip (2.3.2)
@@ -285,7 +285,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.8.0)
     uri (0.13.0)
-    wdm (0.1.1)
+    wdm (0.2.0)
     webrick (1.8.1)
 
 PLATFORMS

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -60,6 +60,9 @@ exclude:
     "vendor",
   ]
 
+include:
+  - _headers
+
 permalink: pretty
 
 defaults:

--- a/docs/_headers
+++ b/docs/_headers
@@ -1,0 +1,2 @@
+https://:project.pages.dev/*
+  X-Robots-Tag: noindex


### PR DESCRIPTION
Since we're using a custom domain name, we don't want the underlying *.pages.dev to be indexed in search engines. This add the `noindex` header value when accessed as *.pages.dev
