### PR TITLE
ci: Fix for breaking `upload-artifact`

### DIFF
--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -89,6 +89,7 @@ jobs:
         with:
           name: packages
           path: NuGet
+          include-hidden-files: true
 
       - name: Summary output
         run: |


### PR DESCRIPTION
Breaking change from [upload-artifact](https://github.com/actions/upload-artifact) v4.4.0 that now requires explicit need to place `include-hidden-files: true` under `with:` block.