### PR TITLE
chore: Code cleanup

### DIFF
--- a/src/_common/Generics/Transforms.cs
+++ b/src/_common/Generics/Transforms.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 
 // GENERIC TRANSFORMS
 
-public static class Transforms
+internal static class Transforms
 {
     // TO COLLECTION
     internal static Collection<T> ToCollection<T>(this IEnumerable<T> source)

--- a/src/_common/ObsoleteV2.cs
+++ b/src/_common/ObsoleteV2.cs
@@ -10,7 +10,7 @@ public static partial class Indicator
 
     // 2.4.1
     [ExcludeFromCodeCoverage]
-    [Obsolete("Rename 'ToBasicTuple(..)' to 'ToTuple(..)' to fix.", false)]
+    [Obsolete("'ToBasicTuple(..)' was deprecated.", false)]
     public static List<(DateTime, double)> ToBasicTuple<TQuote>(
         this IEnumerable<TQuote> quotes,
         CandlePart candlePart)


### PR DESCRIPTION
Minor code cleanup

- remove public interface to internal-only `Transform` class
- fix incorrectly stated `ToTuple()` obsolete attribute
