### PR TITLE
ci: Deploy `staging` to GitHub packages

### DIFF
--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -145,12 +145,10 @@ jobs:
           name: packages
           path: NuGet
 
-      - name: Publish to Azure Artifacts (staging)
+      - name: Publish to GitHub Packages (staging)
         if: inputs.environment == 'staging'
         run: |
-          dotnet new nugetconfig --force
-          nuget sources Add -Name "AzureArtifacts" -Source ${{ vars.NUGET_PUBLISH_URL }} -UserName DaveSkender -Password ${{ secrets.NUGET_TOKEN }} -NonInteractive -ConfigFile nuget.config
-          nuget push NuGet/*.nupkg -src AzureArtifacts -ApiKey AZ -NonInteractive -ConfigFile nuget.config
+          dotnet nuget push NuGet/*.nupkg --source "https://nuget.pkg.github.com/DaveSkender/index.json" --api-key ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to NuGet.org
         if: inputs.environment == 'nuget.org'

--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -146,20 +146,6 @@ jobs:
           name: packages
           path: NuGet
 
-      - name: Delete existing package (staging)
-        if: inputs.environment == 'staging'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PACKAGE_NAME="Skender.Stock.Indicators"
-          VERSION=$(ls NuGet/*.nupkg | grep -oP '(?<=Skender.Stock.Indicators\.)\d+\.\d+\.\d+(?=\.nupkg)')
-          echo "Detected version: $VERSION"
-
-          # Attempt to delete the existing package version
-          curl -X DELETE \
-            -H "Authorization: Bearer $GITHUB_TOKEN" \
-            "https://api.github.com/users/DaveSkender/packages/nuget/$PACKAGE_NAME/versions/$VERSION" || echo "No existing package to delete."
-
       - name: Publish to GitHub Packages (staging)
         if: inputs.environment == 'staging'
         run: |

--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -148,6 +148,7 @@ jobs:
       - name: Publish to GitHub Packages (staging)
         if: inputs.environment == 'staging'
         run: |
+          dotnet nuget add source --username DaveSkender --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/DaveSkender/index.json"
           dotnet nuget push NuGet/*.nupkg --source "https://nuget.pkg.github.com/DaveSkender/index.json" --api-key ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to NuGet.org

--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -108,8 +108,8 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      packages: write
       contents: write
+      packages: write
 
     environment:
       name: ${{ inputs.environment }}
@@ -146,10 +146,24 @@ jobs:
           name: packages
           path: NuGet
 
+      - name: Delete existing package (staging)
+        if: inputs.environment == 'staging'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PACKAGE_NAME="Skender.Stock.Indicators"
+          VERSION=$(ls NuGet/*.nupkg | grep -oP '(?<=Skender.Stock.Indicators\.)\d+\.\d+\.\d+(?=\.nupkg)')
+          echo "Detected version: $VERSION"
+
+          # Attempt to delete the existing package version
+          curl -X DELETE \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            "https://api.github.com/users/DaveSkender/packages/nuget/$PACKAGE_NAME/versions/$VERSION" || echo "No existing package to delete."
+
       - name: Publish to GitHub Packages (staging)
         if: inputs.environment == 'staging'
         run: |
-          dotnet nuget push NuGet/*.nupkg --source "https://nuget.pkg.github.com/DaveSkender/index.json" --api-key ${{ secrets.GITHUB_TOKEN }}
+            dotnet nuget push NuGet/*.nupkg --source "https://nuget.pkg.github.com/DaveSkender/index.json" --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
 
       - name: Publish to NuGet.org
         if: inputs.environment == 'nuget.org'

--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -108,6 +108,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
+      packages: write
       contents: write
 
     environment:
@@ -134,7 +135,7 @@ jobs:
           dotnet-quality: "ga"
 
       - name: Setup NuGet
-        uses: nuget/setup-nuget@v1
+        uses: nuget/setup-nuget@v2
         with:
           nuget-api-key: ${{ secrets.NUGET_TOKEN }}
           nuget-version: '6.x'
@@ -148,7 +149,6 @@ jobs:
       - name: Publish to GitHub Packages (staging)
         if: inputs.environment == 'staging'
         run: |
-          dotnet nuget add source --username DaveSkender --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/DaveSkender/index.json"
           dotnet nuget push NuGet/*.nupkg --source "https://nuget.pkg.github.com/DaveSkender/index.json" --api-key ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to NuGet.org


### PR DESCRIPTION
Update the NuGet package deployment GitHub action to deploy to GitHub repo packages when the `staging` environment is selected.

* Remove the step named "Publish to Azure Artifacts (staging)".
* Add a new step named "Publish to GitHub Packages (staging)".
* Configure the new step to deploy to GitHub Packages when the `staging` environment is selected.
