### PR TITLE
ci: Fix PR title linter

### DIFF
--- a/.github/workflows/lint-pull-request.yml
+++ b/.github/workflows/lint-pull-request.yml
@@ -1,7 +1,7 @@
 name: Pull request
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited


### PR DESCRIPTION
This workflow must use `pull_request_target` for OSS projects that use Forks.