### PR TITLE
chore: MCP server configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -43,5 +43,5 @@
       ]
     }
   },
-  "postCreateCommand": "dotnet restore"
+  "postCreateCommand": ".devcontainer/startup.sh"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -35,7 +35,9 @@
         "markdownlint.config": {
           "MD033": false,
           "MD025": false
-        }
+        },
+        "chat.mcp.enabled": true,
+        "chat.mcp.discovery.enabled": true
       },
       "extensions": [
         "ms-dotnettools.csdevkit",

--- a/.devcontainer/startup.sh
+++ b/.devcontainer/startup.sh
@@ -10,6 +10,24 @@ echo "🔍 Verifying Node.js environment..."
 node --version
 npm --version
 
+# Install uv package manager if not available
+echo "📦 Installing uv package manager for Fetch MCP server..."
+if ! command -v uv &> /dev/null; then
+  curl -fsSL https://pkg.astral.sh/uv-installer.sh | bash
+  echo "✅ uv installed successfully"
+else
+  echo "✅ uv already installed"
+fi
+
+# Add uv to PATH if not already there
+if ! command -v uvx &> /dev/null; then
+  export PATH="$HOME/.cargo/bin:$PATH"
+  echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> ~/.bashrc
+  echo "✅ uvx now available in PATH"
+else
+  echo "✅ uvx already in PATH"
+fi
+
 # Restore .NET packages (at end to avoid conflicts)
 echo "📦 Restoring .NET packages..."
 dotnet restore
@@ -17,10 +35,12 @@ dotnet restore
 echo "✅ Dev container setup complete!"
 echo ""
 echo "📋 Available MCP servers:"
-echo "  - Memory MCP Server (configured in .vscode/mcp.json)"
-echo "  - Server will be downloaded via npx when needed"
+echo "  - Memory MCP Server (configured in .vscode/mcp.json, via npx)"
+echo "  - Fetch MCP Server (configured in .vscode/mcp.json, via uvx)"
+echo "  - Sequential Thinking MCP Server (configured in .vscode/mcp.json, via npx)"
+echo "  - File System MCP Server (configured in .vscode/mcp.json, via npx)"
 echo ""
-echo "�� Next steps:"
-echo "  - Open GitHub Copilot Chat to test memory functionality"
-echo "  - See .github/instructions/mcp-memory-server.md for details"
+echo "🔍 Next steps:"
+echo "  - Open GitHub Copilot Chat to test MCP server functionality"
+echo "  - See .github/instructions/mcp-servers.md for details"
 echo ""

--- a/.devcontainer/startup.sh
+++ b/.devcontainer/startup.sh
@@ -8,7 +8,7 @@ echo "🚀 Starting Stock Indicators dev container setup..."
 # Verify Node.js and npm are available
 echo "🔍 Verifying Node.js environment..."
 node --version
-npm --version
+npm install -g npm@latest
 
 # Install uv package manager if not available
 echo "📦 Installing uv package manager for Fetch MCP server..."

--- a/.devcontainer/startup.sh
+++ b/.devcontainer/startup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Dev Container Startup Script for Stock Indicators
+# Handles initialization of development dependencies
+
+echo "🚀 Starting Stock Indicators dev container setup..."
+
+# Verify Node.js and npm are available
+echo "🔍 Verifying Node.js environment..."
+node --version
+npm --version
+
+# Restore .NET packages (at end to avoid conflicts)
+echo "📦 Restoring .NET packages..."
+dotnet restore
+
+echo "✅ Dev container setup complete!"
+echo ""
+echo "📋 Available MCP servers:"
+echo "  - Memory MCP Server (configured in .vscode/mcp.json)"
+echo "  - Server will be downloaded via npx when needed"
+echo ""
+echo "�� Next steps:"
+echo "  - Open GitHub Copilot Chat to test memory functionality"
+echo "  - See .github/instructions/mcp-memory-server.md for details"
+echo ""

--- a/.github/instructions/mcp-servers.md
+++ b/.github/instructions/mcp-servers.md
@@ -1,0 +1,61 @@
+# MCP Servers
+
+This workspace is configured with a Memory MCP server that provides persistent memory capabilities for GitHub Copilot Chat.
+
+## Configuration
+
+The Memory MCP server is configured in `.vscode/mcp.json` and will be automatically started by VS Code when using GitHub Copilot Chat.
+
+### Files
+
+- `.vscode/mcp.json` - MCP server configuration for VS Code
+
+### Server Package
+
+- `@modelcontextprotocol/server-memory` - Executed via `npx` (no local installation needed)
+
+# Memory MCP Server Configuration
+
+This workspace is configured with a Memory MCP server that provides persistent memory capabilities for GitHub Copilot Chat.
+
+## Configuration
+
+The Memory MCP server is configured in `.vscode/mcp.json` and will be automatically started by VS Code when using GitHub Copilot Chat.
+
+### Files
+
+- `.vscode/mcp.json` - MCP server configuration for VS Code
+
+### Server Package
+
+- `@modelcontextprotocol/server-memory` - Executed via `npx` (no local installation needed)
+
+## Usage
+
+Once configured, the Memory MCP server will:
+
+1. Automatically start when you use GitHub Copilot Chat
+2. Provide persistent memory across chat sessions
+3. Remember context and information you share during conversations
+
+## Memory Storage
+
+The server stores memory data in memory files within the workspace. This allows for persistent context across VS Code sessions.
+
+## Verification
+
+The Memory MCP server is confirmed working! You can test it by:
+
+1. **Knowledge Graph Operations**: The server provides persistent memory through a knowledge graph
+2. **Configuration Updated**: Fixed schema to use `"servers"` instead of `"mcpServers"` in `.vscode/mcp.json`
+3. **No Global Installation Required**: Verified that global npm installation was removed and `npx` handles package execution automatically
+4. **Dev Container Ready**: Added `.devcontainer/startup.sh` for proper initialization
+
+To verify the setup is working:
+
+1. Open GitHub Copilot Chat
+2. Ask it to remember something specific about your project
+3. Close and reopen VS Code
+4. Ask Copilot about what you asked it to remember
+
+The memory should persist across sessions if the MCP server is working correctly.

--- a/.github/instructions/mcp-servers.md
+++ b/.github/instructions/mcp-servers.md
@@ -1,36 +1,41 @@
 # MCP Servers
 
-This workspace is configured with a Memory MCP server that provides persistent memory capabilities for GitHub Copilot Chat.
+This workspace is configured with the following MCP servers:
 
-## Configuration
+1. Memory MCP server that provides persistent memory capabilities for GitHub Copilot Chat
+2. Fetch MCP server that provides web content retrieval capabilities for GitHub Copilot Chat
+3. Sequential Thinking MCP server that provides step-by-step reasoning capabilities for GitHub Copilot Chat
+4. File System MCP server that provides file system capabilities for GitHub Copilot Chat
 
-The Memory MCP server is configured in `.vscode/mcp.json` and will be automatically started by VS Code when using GitHub Copilot Chat.
+## General Configuration
 
-### Files
+All MCP servers are configured in `.vscode/mcp.json` and will be automatically started by VS Code when using GitHub Copilot Chat.
+
+### Configuration Files
 
 - `.vscode/mcp.json` - MCP server configuration for VS Code
+- `.vscode/settings.json` - Settings that enable MCP functionality
 
-### Server Package
+### Server Packages
 
-- `@modelcontextprotocol/server-memory` - Executed via `npx` (no local installation needed)
+- `@modelcontextprotocol/server-memory` - Memory MCP server executed via `npx` (no local installation needed)
+- `mcp-server-fetch` - Fetch MCP server executed via `uvx` (installed automatically via startup.sh)
+- `@mcp/sequential-thinking` - Sequential Thinking MCP server executed via `npx` (no local installation needed)
+- `@mcp/filesystem` - File System MCP server executed via `npx` (no local installation needed)
 
 # Memory MCP Server Configuration
 
 This workspace is configured with a Memory MCP server that provides persistent memory capabilities for GitHub Copilot Chat.
 
-## Configuration
+## Memory Server Configuration
 
 The Memory MCP server is configured in `.vscode/mcp.json` and will be automatically started by VS Code when using GitHub Copilot Chat.
 
-### Files
-
-- `.vscode/mcp.json` - MCP server configuration for VS Code
-
-### Server Package
+### Memory Server Package
 
 - `@modelcontextprotocol/server-memory` - Executed via `npx` (no local installation needed)
 
-## Usage
+## Memory Server Usage
 
 Once configured, the Memory MCP server will:
 
@@ -42,7 +47,7 @@ Once configured, the Memory MCP server will:
 
 The server stores memory data in memory files within the workspace. This allows for persistent context across VS Code sessions.
 
-## Verification
+## Memory Server Verification
 
 The Memory MCP server is confirmed working! You can test it by:
 
@@ -59,3 +64,128 @@ To verify the setup is working:
 4. Ask Copilot about what you asked it to remember
 
 The memory should persist across sessions if the MCP server is working correctly.
+
+# Fetch MCP Server Configuration
+
+This workspace is configured with a Fetch MCP server that provides web content retrieval capabilities for GitHub Copilot Chat.
+
+## Fetch Server Configuration
+
+The Fetch MCP server is configured in `.vscode/mcp.json` and will be automatically started by VS Code when using GitHub Copilot Chat.
+
+### Fetch Server Package
+
+- `mcp-server-fetch` - Executed via `uvx` (installed automatically via startup.sh)
+
+### Fetch Server Requirements
+
+The Fetch MCP server requires the uv package manager:
+
+1. **uv Installation**: The `.devcontainer/startup.sh` script automatically installs uv during container startup
+2. **PATH Configuration**: The startup script adds `$HOME/.cargo/bin` to the PATH to make `uvx` available
+3. **Automatic Execution**: When used, uvx will automatically download and run `mcp-server-fetch`
+
+## Fetch Server Usage
+
+Once configured, the Fetch MCP server will:
+
+1. Automatically start when you use GitHub Copilot Chat
+2. Enable Copilot to retrieve content from web resources
+3. Provide up-to-date information from online documentation and resources
+4. Support non-mutating web content operations through the MCP protocol
+
+## Fetch Server Functionality
+
+The Fetch MCP server provides several web content tools:
+
+1. **Web Page Retrieval**: Get content from web pages to answer questions
+2. **API Documentation Access**: Access and search API documentation
+3. **Code Examples**: Find code examples from online resources
+4. **Library Information**: Get information about libraries and frameworks
+
+## Fetch Server Verification
+
+To verify the Fetch MCP server is working correctly:
+
+1. Open GitHub Copilot Chat
+2. Ask it questions that require up-to-date web information, such as:
+   - "What is the latest version of .NET?"
+   - "How do I use the latest HTTP client in C#?"
+   - "Find me documentation about stock indicators"
+3. Copilot should be able to provide accurate information from web resources
+
+Note that the Fetch MCP server is read-only (non-mutating) and cannot make changes to web resources.
+
+# Sequential Thinking MCP Server Configuration
+
+This workspace is configured with a Sequential Thinking MCP server that provides step-by-step reasoning capabilities for GitHub Copilot Chat.
+
+## Sequential Thinking Server Configuration
+
+The Sequential Thinking MCP server is configured in `.vscode/mcp.json` and will be automatically started by VS Code when using GitHub Copilot Chat.
+
+### Sequential Thinking Server Package
+
+- `@mcp/sequential-thinking` - Executed via `npx` (no local installation needed)
+
+## Sequential Thinking Server Usage
+
+Once configured, the Sequential Thinking MCP server will:
+
+1. Automatically start when you use GitHub Copilot Chat
+2. Provide step-by-step reasoning capabilities to Copilot Chat
+3. Assist in breaking down complex problems and generating solutions
+
+## Sequential Thinking Server Functionality
+
+The Sequential Thinking MCP server provides step-by-step reasoning tools:
+
+1. **Problem Analysis**: Analyze and understand complex problems
+2. **Solution Generation**: Generate solutions by breaking down problems into smaller parts
+3. **Code Generation**: Assist in writing code by providing step-by-step guidance
+4. **Debugging Assistance**: Help identify and fix issues in code
+
+## Sequential Thinking Server Verification
+
+To verify the Sequential Thinking MCP server is working correctly:
+
+1. Open GitHub Copilot Chat
+2. Ask it to help with a complex problem or code issue
+3. Copilot should be able to provide step-by-step assistance and generate solutions
+
+# File System MCP Server Configuration
+
+This workspace is configured with a File System MCP server that provides file system capabilities for GitHub Copilot Chat.
+
+## File System Server Configuration
+
+The File System MCP server is configured in `.vscode/mcp.json` and will be automatically started by VS Code when using GitHub Copilot Chat.
+
+### File System Server Package
+
+- `@mcp/filesystem` - Executed via `npx` (no local installation needed)
+
+## File System Server Usage
+
+Once configured, the File System MCP server will:
+
+1. Automatically start when you use GitHub Copilot Chat
+2. Provide file system capabilities to Copilot Chat
+3. Allow Copilot to interact with the file system, such as reading and writing files
+
+## File System Server Functionality
+
+The File System MCP server provides file system tools:
+
+1. **File Reading**: Read files from the file system
+2. **File Writing**: Write files to the file system
+3. **Directory Listing**: List files and directories in a given path
+4. **File Searching**: Search for files matching specific criteria
+
+## File System Server Verification
+
+To verify the File System MCP server is working correctly:
+
+1. Open GitHub Copilot Chat
+2. Ask it to read, write, or search for files in your workspace
+3. Copilot should be able to perform file system operations as requested

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
     "recommendations": [
-        "codacy-app.codacy",
         "adrianwilczynski.user-secrets",
         "github.vscode-github-actions",
         "github.vscode-pull-request-github",

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,10 @@
+{
+  "servers": {
+    "memory": {
+      "command": "npx",
+      "args": [
+        "@modelcontextprotocol/server-memory"
+      ]
+    }
+  }
+}

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -5,6 +5,26 @@
       "args": [
         "@modelcontextprotocol/server-memory"
       ]
+    },
+    "fetch": {
+      "command": "uvx",
+      "args": [
+        "mcp-server-fetch"
+      ]
+    },
+    "sequential-thinking": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "@mcp/sequential-thinking"
+      ]
+    },
+    "file-system": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "@mcp/filesystem"
+      ]
     }
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,10 @@
 {
   // file settings
-  "files.autoSave": "off",
+  "files.autoSave": "afterDelay",
   "files.autoSaveDelay": 3000,
   "files.encoding": "utf8",
+  "chat.mcp.enabled": true,
+  "chat.mcp.discovery.enabled": true,
   // search settings, auto excludes files.exclude
   "search.exclude": {
     "**/_site/**": true,


### PR DESCRIPTION
This pull request introduces a comprehensive setup for integrating multiple MCP (Model Context Protocol) servers into the development environment. It includes changes to the dev container configuration, documentation, and VS Code settings to support these servers. The most important changes are grouped into configuration updates, new features, and documentation enhancements.

### Configuration Updates:
* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L46-R46): Updated `postCreateCommand` to execute a new startup script (`.devcontainer/startup.sh`) for initializing dependencies.
* [`.vscode/mcp.json`](diffhunk://#diff-756c99ad6a15758981c15d6ba32a2d83391908e8e021f0399e9d34339dc4eadaR1-R30): Added configuration for four MCP servers (`memory`, `fetch`, `sequential-thinking`, and `file-system`) to enable their integration with GitHub Copilot Chat.
* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L3-R7): Enabled MCP-related settings (`chat.mcp.enabled` and `chat.mcp.discovery.enabled`) and changed `files.autoSave` to `afterDelay` with a 3000ms delay.

### New Features:
* [`.devcontainer/startup.sh`](diffhunk://#diff-49205b36371a0a673e7a6d64ab5b7ae5f1bdb471c54299bf63ae060d7abfac1aR1-R46): Added a startup script to initialize the development environment, including verifying Node.js, installing the `uv` package manager, and restoring .NET packages.

### Documentation Enhancements:
* [`.github/instructions/mcp-servers.md`](diffhunk://#diff-a295d407a7764901db6944f7511a09f38986db265a10e194f5f06c3bce607236R1-R191): Added detailed documentation on the configuration, usage, and verification of the four MCP servers (`memory`, `fetch`, `sequential-thinking`, and `file-system`).

### Minor Changes:
* [`.vscode/extensions.json`](diffhunk://#diff-c16655a98a3ee89a7636a59c59a72b0e93649e3a1e947327cfc43a1336b4e912L3): Removed the `codacy-app.codacy` extension from the recommended list.