### PR TITLE
docs: Fixed the typo that said `INumerable` to `IEnumerable`

### DIFF
--- a/docs/pages/guide.md
+++ b/docs/pages/guide.md
@@ -192,7 +192,7 @@ public void MyClass(){
   IEnumerable<Quote> quotes = GetQuotesFromFeed("SPY");
 
   // compute indicator
-  INumerable<EmaResult> emaResults = quotes.GetEma(14);
+  IEnumerable<EmaResult> emaResults = quotes.GetEma(14);
 
   // convert to my Ema class list [using LINQ]
   List<MyEma> myEmaResults = emaResults


### PR DESCRIPTION
#### There was a typo in code syntax, it said  INumerable<EmaResult> emaResults = quotes.GetEma(14);

- [ ] Implement
- [ ] Fix: #
