### PR TITLE
ci: Exclude publishing tests results for Forks

### DIFF
--- a/.github/workflows/test-indicators.yml
+++ b/.github/workflows/test-indicators.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Post test results
         uses: dorny/test-reporter@v1.9.1
-        if: env.IS_PRIMARY == 'true' && always() && github.event.pull_request.head.repo.full_name == github.repository
+        if: env.IS_PRIMARY == 'true' && github.event.pull_request.head.repo.full_name == github.repository && always()
         with:
           name: Test results
           path: ./test-indicators/**/*.trx

--- a/.github/workflows/test-indicators.yml
+++ b/.github/workflows/test-indicators.yml
@@ -11,6 +11,7 @@ permissions:
   contents: read   # Required for checkout
   actions: read    # Required for workflow runs
   checks: write    # Required for test results
+  pull-requests: write  # Required for forked PRs
 
 jobs:
   test:
@@ -83,7 +84,7 @@ jobs:
 
       - name: Post test results
         uses: dorny/test-reporter@v1.9.1
-        if: env.IS_PRIMARY == 'true' && always()
+        if: env.IS_PRIMARY == 'true' && always() && github.event.pull_request.head.repo.full_name == github.repository
         with:
           name: Test results
           path: ./test-indicators/**/*.trx

--- a/.github/workflows/test-indicators.yml
+++ b/.github/workflows/test-indicators.yml
@@ -11,7 +11,6 @@ permissions:
   contents: read   # Required for checkout
   actions: read    # Required for workflow runs
   checks: write    # Required for test results
-  pull-requests: write  # Required for forked PRs
 
 jobs:
   test:


### PR DESCRIPTION
Contributors creating PRs from Forks won't get GitHub Secrets and elevated permissions, and therefore certain steps like publishing tests results to the Actions summary will fail.
