### PR TITLE
fix: Test workflow pub continue on error

### DIFF
--- a/.github/workflows/test-indicators.yml
+++ b/.github/workflows/test-indicators.yml
@@ -83,11 +83,12 @@ jobs:
 
       - name: Post test results
         uses: dorny/test-reporter@v1.9.1
-        if: env.IS_PRIMARY == 'true' && github.event.pull_request.head.repo.full_name == github.repository && always()
+        if: env.IS_PRIMARY == 'true' && always()
         with:
           name: Test results
           path: ./test-indicators/**/*.trx
           reporter: dotnet-trx
+        continue-on-error: true
 
       - name: Publish coverage to Codacy
         uses: codacy/codacy-coverage-reporter-action@v1
@@ -95,3 +96,5 @@ jobs:
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: ./test-indicators/**/coverage.cobertura.xml
+        continue-on-error: true
+


### PR DESCRIPTION
This pull request makes adjustments to the `.github/workflows/test-indicators.yml` file to improve workflow reliability by allowing certain steps to continue on error and simplifying conditional logic.

Changes to workflow reliability:

* `Post test results` step: Added `continue-on-error: true` to allow the workflow to proceed even if posting test results fails.
* `Publish coverage to Codacy` step: Added `continue-on-error: true` to ensure the workflow continues even if publishing coverage data fails.

Simplification of conditional logic:

* `Post test results` step: Simplified the `if` condition by removing the check for `github.event.pull_request.head.repo.full_name == github.repository`.