### PR TITLE
fix: Copilot setup continue on error

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -3,6 +3,9 @@ name: Copilot Environment Setup
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest
@@ -21,10 +24,12 @@ jobs:
         run: |
           dotnet tool install --global dotnet-format
           dotnet tool install --global dotnet-outdated-tool
+        continue-on-error: true
 
       - name: Build .NET Solution
         run: |
-          dotnet build --no-incremental
+          dotnet build
+        continue-on-error: true
 
       - name: Environment summary
         run: |
@@ -32,3 +37,4 @@ jobs:
           echo "- Repository: ${{ github.repository }}" >> $GITHUB_STEP_SUMMARY
           echo "- .NET SDKs: $(dotnet --list-sdks | wc -l) versions available" >> $GITHUB_STEP_SUMMARY
           echo "- .NET Tools: $(dotnet tool list --global | wc -l) available" >> $GITHUB_STEP_SUMMARY
+        continue-on-error: true


### PR DESCRIPTION
This pull request updates the `.github/workflows/copilot-setup-steps.yml` file to improve the Copilot environment setup workflow by adding permissions and making specific steps more resilient to errors. Below are the most important changes:

### Workflow Permissions:

* Added `permissions` block with `contents: read` to explicitly define the required permissions for the workflow.

### Error Handling Enhancements:

* Added `continue-on-error: true` to the following steps to allow the workflow to proceed even if these steps encounter errors:
  - Installing .NET tools (`dotnet-format` and `dotnet-outdated-tool`).
  - Building the .NET solution.
  - Generating the environment summary.

### Build Command Simplification:

* Removed the `--no-incremental` flag from the `dotnet build` command to simplify the build process.