### PR TITLE
ci: Upgrade PR title linter

### DIFF
--- a/.github/workflows/lint-pull-request.yml
+++ b/.github/workflows/lint-pull-request.yml
@@ -7,6 +7,11 @@ on:
       - edited
       - unlabeled
 
+concurrency:
+  group: >-
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: write
 
@@ -16,11 +21,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: amannn/action-semantic-pull-request@v5.5.3
+      - uses: amannn/action-semantic-pull-request@v6.1.1
         id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+            plan
           subjectPattern: ^([A-Z]).+$
           subjectPatternError: >
             The subject "**{subject}**" must start with an uppercase character.
@@ -30,7 +48,7 @@ jobs:
             dependencies
             automated
 
-      - uses: marocchino/sticky-pull-request-comment@v2.9.2
+      - uses: marocchino/sticky-pull-request-comment@v2.9.4
         if: always() && (steps.lint_pr_title.outputs.error_message != null)
         with:
           header: pr-title-lint-error
@@ -48,6 +66,7 @@ jobs:
 
             - `feat: Add API endpoint for market data`
             - `fix: Resolve WebSocket connection issues`
+            - `plan: Define technical implementation approach`
             - `chore: Update NuGet dependencies`
 
             <details>
@@ -56,6 +75,9 @@ jobs:
             #### Features & fixes
             - `feat: Add API endpoint for market data`
             - `fix: Resolve WebSocket connection issues`
+
+            #### Planning & architecture
+            - `plan: Define technical implementation approach`
 
             #### Code quality
             - `style: Format trading strategy classes`
@@ -74,12 +96,13 @@ jobs:
             #### Other
             - `revert: Remove faulty market data provider`
 
-            See [Conventional Commits](https://www.conventionalcommits.org) for more details.
+            See [Conventional Commits](https://www.conventionalcommits.org)
+            for more details.
             </details>
 
       # Delete a previous comment when the issue has been resolved
       - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
-        uses: marocchino/sticky-pull-request-comment@v2.9.2
+        uses: marocchino/sticky-pull-request-comment@v2.9.4
         with:
           header: pr-title-lint-error
           delete: true


### PR DESCRIPTION
This pull request updates the pull request title linting workflow in `.github/workflows/lint-pull-request.yml` to improve reliability, add support for new commit types, and enhance documentation. The main changes include updating action versions, introducing workflow concurrency control, and expanding the list of allowed commit types to include planning and architecture.

**Workflow improvements:**

* Added `concurrency` settings to ensure only one lint workflow runs per pull request, automatically cancelling any in-progress runs for the same PR.

**Action version upgrades:**

* Updated `amannn/action-semantic-pull-request` from v5.5.3 to v6.1.1 for improved linting and compatibility.
* Updated `marocchino/sticky-pull-request-comment` from v2.9.2 to v2.9.4 for better comment management. [[1]](diffhunk://#diff-c5b6848e526582281ad38f6c3a746c12470230d63ae6b3586bf9261741f5d5ceL33-R51) [[2]](diffhunk://#diff-c5b6848e526582281ad38f6c3a746c12470230d63ae6b3586bf9261741f5d5ceL77-R105)

**Commit type and documentation enhancements:**

* Added `plan` to the list of allowed commit types and expanded documentation with examples and a new "Planning & architecture" section. [[1]](diffhunk://#diff-c5b6848e526582281ad38f6c3a746c12470230d63ae6b3586bf9261741f5d5ceL19-R41) [[2]](diffhunk://#diff-c5b6848e526582281ad38f6c3a746c12470230d63ae6b3586bf9261741f5d5ceR69) [[3]](diffhunk://#diff-c5b6848e526582281ad38f6c3a746c12470230d63ae6b3586bf9261741f5d5ceR79-R81)