### PR TITLE
ci: Update PR title linter

### DIFF
--- a/.github/workflows/lint-pull-request.yml
+++ b/.github/workflows/lint-pull-request.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - edited
       - unlabeled
+      - ready_for_review
 
 concurrency:
   group: >-
@@ -19,6 +20,7 @@ jobs:
   main:
     name: lint PR title
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
 
     steps:
       - uses: amannn/action-semantic-pull-request@v6.1.1
@@ -89,7 +91,7 @@ jobs:
             - `test: Add unit tests for sign-in flow`
 
             #### Infrastructure
-            - `build: Update .NET SDK version to 8.0`
+            - `build: Update .NET SDK version to 9.0`
             - `ci: Add workflow for performance testing`
             - `chore: Update NuGet dependencies`
 


### PR DESCRIPTION
This pull request updates the lint workflow for pull requests in `.github/workflows/lint-pull-request.yml` to improve its accuracy and ensure it only runs when appropriate. The most important changes are grouped below.

Workflow trigger improvements:

* Added the `ready_for_review` event to the workflow triggers, so the lint check will run when a draft pull request is marked as ready for review.

Workflow execution logic:

* Added a conditional to the main job to prevent the workflow from running on draft pull requests, ensuring the lint check only runs on non-draft PRs.

Documentation update:

* Updated the example infrastructure PR title to reference `.NET SDK version 9.0` instead of `8.0` for consistency with current standards.