### PR TITLE
ci: Upgrade `setup-dotnet` action to v5

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -20,7 +20,7 @@ jobs:
           ruby-version: 3.3
 
       - name: Install .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "9.x"
           dotnet-quality: "ga"

--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -108,7 +108,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "9.x"
           dotnet-quality: "ga"
@@ -220,7 +220,7 @@ jobs:
 
     steps:
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "9.x"
           dotnet-quality: "ga"

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -2,15 +2,17 @@ name: Examples
 
 on:
   push:
-    branches: ["main"]
+    branches:
+      - main
+      - "v[0-9]*"
     paths:
       - docs/examples/**
-
   pull_request:
     branches: ["*"]
     paths:
       - docs/examples/**
       - ".github/workflows/test-examples.yml"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -25,7 +27,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "9.x"
           dotnet-quality: "ga"

--- a/.github/workflows/test-indicators-matrix.yml
+++ b/.github/workflows/test-indicators-matrix.yml
@@ -1,18 +1,17 @@
 name: Test Indicators (matrix)
 
 on:
+  push:
+    branches:
+      - "main"
+      - "v[0-9]*"
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Test Indicators"]
-    types:
-      - completed
 
 permissions:
-  contents: read   # Required for checkout
+  contents: read # Required for checkout
 
 jobs:
   test:
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     name: matrix validation
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test-indicators.yml
+++ b/.github/workflows/test-indicators.yml
@@ -2,7 +2,9 @@ name: Test Indicators
 
 on:
   push:
-    branches: ["main"]
+    branches:
+      - "main"
+      - "v[0-9]*"
   pull_request:
     branches: ["*"]
   workflow_dispatch:

--- a/.github/workflows/test-performance.yml
+++ b/.github/workflows/test-performance.yml
@@ -33,7 +33,7 @@ jobs:
           configFilePath: src/gitversion.yml
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "9.x"
           dotnet-quality: "ga"


### PR DESCRIPTION
Upgrade the setup-dotnet action from v4 to v5 across multiple workflows to ensure compatibility and take advantage of the latest features.