### PR TITLE
ci: Rename test Integration workflow

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -1,15 +1,14 @@
-name: Indicators
+name: Test Integration
 
 on:
   push:
-    branches: ["main"]
-
-  pull_request:
-    branches: ["*"]
+    branches:
+      - "main"
+      - "v[0-9]*"
+  workflow_dispatch:
 
 jobs:
   test:
-    name: integration tests
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
Rename the workflow from 'Indicators' to 'Test Integration' and streamline the branch triggers for better clarity and functionality.