### PR TITLE
ci: Remove fragile project management automation

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -5,8 +5,6 @@ on:
 
 permissions:
   contents: read
-  issues: read
-  repository-projects: write
 
 jobs:
   copilot-setup-steps:
@@ -103,80 +101,4 @@ jobs:
           echo "- \`/plan\` - Define implementation approach" >> $GITHUB_STEP_SUMMARY
           echo "- \`/tasks\` - Generate actionable task breakdown" >> $GITHUB_STEP_SUMMARY
           echo "- \`/implement\` - Execute planned implementation" >> $GITHUB_STEP_SUMMARY
-        continue-on-error: true
-
-      # Update project status for current branch if it has an associated PR
-      - name: Find associated PR
-        id: find-pr
-        run: |
-          # Get the current branch name
-          BRANCH_NAME="${{ github.ref_name }}"
-
-          # Check if there's an open PR for this branch
-          PR_NUMBER=$(gh pr list --head "$BRANCH_NAME" --state open --json number --jq '.[0].number // empty')
-
-          if [ -n "$PR_NUMBER" ]; then
-            echo "pr-number=$PR_NUMBER" >> $GITHUB_OUTPUT
-            echo "Found PR #$PR_NUMBER for branch $BRANCH_NAME"
-          else
-            echo "No open PR found for branch $BRANCH_NAME"
-          fi
-        env:
-          GH_TOKEN: ${{ github.token }}
-        continue-on-error: true
-
-      - name: Add PR to project
-        uses: actions/add-to-project@v1.0.2
-        if: ${{ steps.find-pr.outputs.pr-number }}
-        id: add-project
-        with:
-          project-url: https://github.com/users/DaveSkender/projects/1
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: true
-
-      - name: Check current project status
-        id: check-status
-        if: ${{ steps.find-pr.outputs.pr-number && steps.add-project.outputs.itemId }}
-        run: |
-          # Query the project item to get current status
-          ITEM_ID="${{ steps.add-project.outputs.itemId }}"
-
-          # Use GitHub CLI to get project item status
-          CURRENT_STATUS=$(gh project item-view $ITEM_ID --owner DaveSkender --format json | jq -r '.fields[] | select(.name == "Status") | .value // "null"')
-
-          echo "Current status: $CURRENT_STATUS"
-
-          # Define status progression: Icebox < Maybe < Do Next < In Progress < In Review < Done
-          # Only update if current status is one of: Icebox, Maybe, Do Next, or null/empty
-          case "$CURRENT_STATUS" in
-            "Icebox"|"Maybe"|"Do Next"|"null"|""|null)
-              echo "should-update=true" >> $GITHUB_OUTPUT
-              echo "Status '$CURRENT_STATUS' is before 'In Progress', will update"
-              ;;
-            *)
-              echo "should-update=false" >> $GITHUB_OUTPUT
-              echo "Status '$CURRENT_STATUS' is 'In Progress' or later, no update needed"
-              ;;
-          esac
-        env:
-          GH_TOKEN: ${{ github.token }}
-        continue-on-error: true
-
-      - name: Update project status to In Progress
-        if: ${{ steps.find-pr.outputs.pr-number && steps.add-project.outputs.itemId && steps.check-status.outputs.should-update == 'true' }}
-        run: |
-          # Try using the display name as option ID (GitHub CLI may accept this)
-          gh project item-edit \
-            --id "${{ steps.add-project.outputs.itemId }}" \
-            --field-id "1274949" \
-            --project-id "151306" \
-            --single-select-option-id "In Progress" || \
-          # Fallback: use text parameter if option ID fails
-          gh project item-edit \
-            --id "${{ steps.add-project.outputs.itemId }}" \
-            --field-id "1274949" \
-            --project-id "151306" \
-            --text "In Progress"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true

--- a/.github/workflows/lint-pull-request.yml
+++ b/.github/workflows/lint-pull-request.yml
@@ -15,8 +15,6 @@ concurrency:
 
 permissions:
   pull-requests: write
-  issues: read
-  repository-projects: write
 
 jobs:
   main:
@@ -110,59 +108,3 @@ jobs:
         with:
           header: pr-title-lint-error
           delete: true
-
-      # Add PR to project and update status to "In Progress" if not already there
-      - name: Add PR to project
-        uses: actions/add-to-project@v1.0.2
-        if: ${{ steps.lint_pr_title.outputs.error_message == null }}
-        id: add-project
-        with:
-          project-url: https://github.com/users/DaveSkender/projects/1
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check current project status
-        id: check-status
-        if: ${{ steps.lint_pr_title.outputs.error_message == null && steps.add-project.outputs.itemId }}
-        run: |
-          # Query the project item to get current status
-          ITEM_ID="${{ steps.add-project.outputs.itemId }}"
-
-          # Use GitHub CLI to get project item status
-          CURRENT_STATUS=$(gh project item-view $ITEM_ID --owner DaveSkender --format json | jq -r '.fields[] | select(.name == "Status") | .value // "null"')
-
-          echo "Current status: $CURRENT_STATUS"
-
-          # Define status progression: Icebox < Maybe < Do Next < In Progress < In Review < Done
-          # Only update if current status is one of: Icebox, Maybe, Do Next, or null/empty
-          case "$CURRENT_STATUS" in
-            "Icebox"|"Maybe"|"Do Next"|"null"|""|null)
-              echo "should-update=true" >> $GITHUB_OUTPUT
-              echo "Status '$CURRENT_STATUS' is before 'In Progress', will update"
-              ;;
-            *)
-              echo "should-update=false" >> $GITHUB_OUTPUT
-              echo "Status '$CURRENT_STATUS' is 'In Progress' or later, no update needed"
-              ;;
-          esac
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: true
-
-      - name: Update project status to In Progress
-        if: ${{ steps.lint_pr_title.outputs.error_message == null && steps.add-project.outputs.itemId && steps.check-status.outputs.should-update == 'true' }}
-        run: |
-          # Try using the display name as option ID (GitHub CLI may accept this)
-          gh project item-edit \
-            --id "${{ steps.add-project.outputs.itemId }}" \
-            --field-id "1274949" \
-            --project-id "151306" \
-            --single-select-option-id "In Progress" || \
-          # Fallback: use text parameter if option ID fails
-          gh project item-edit \
-            --id "${{ steps.add-project.outputs.itemId }}" \
-            --field-id "1274949" \
-            --project-id "151306" \
-            --text "In Progress"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: true


### PR DESCRIPTION
This pull request simplifies the GitHub Actions workflows by removing the steps that automatically add pull requests to a project board and update their project status. It also reduces the permissions required by these workflows, limiting their access to only what is necessary.

Workflow simplification:

* Removed all steps in `.github/workflows/copilot-setup-steps.yml` and `.github/workflows/lint-pull-request.yml` that added pull requests to the project board and updated their project status to "In Progress". This includes the use of the `actions/add-to-project` action and related status-checking and updating logic. [[1]](diffhunk://#diff-98dad98422cf59793a353f9b6bfe6a129977e92af3d5b4e38f98ae45bcb7560dL107-L182) [[2]](diffhunk://#diff-c5b6848e526582281ad38f6c3a746c12470230d63ae6b3586bf9261741f5d5ceL113-L168)

Permissions reduction:

* Reduced the permissions for both workflows by removing unnecessary `issues: read` and `repository-projects: write` permissions, keeping only the minimal required permissions. [[1]](diffhunk://#diff-98dad98422cf59793a353f9b6bfe6a129977e92af3d5b4e38f98ae45bcb7560dL8-L9) [[2]](diffhunk://#diff-c5b6848e526582281ad38f6c3a746c12470230d63ae6b3586bf9261741f5d5ceL18-L19)