### PR TITLE
test: Disable `request_changes_workflow` in CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,7 +11,7 @@ reviews:
   review_status: true
   commit_status: true
   fail_commit_status: false
-  request_changes_workflow: true
+  request_changes_workflow: false
   in_progress_fortune: false
 
   high_level_summary: false


### PR DESCRIPTION
This settings isn't doing what I expected and can be misleading for community contributors who aren't familiar with its workflow.