### PR TITLE
ci: Remove unneeded caching from .NET setup in deploy workflow

### DIFF
--- a/.github/workflows/deploy-package.yml
+++ b/.github/workflows/deploy-package.yml
@@ -251,8 +251,6 @@ jobs:
         with:
           dotnet-version: "9.x"
           dotnet-quality: "ga"
-          cache: true
-          cache-dependency-path: "**/packages.lock.json"
 
       - name: Download package
         uses: actions/download-artifact@v5


### PR DESCRIPTION
This pull request makes a minor adjustment to the deployment workflow by removing caching settings from the `.github/workflows/deploy-package.yml` file. This simplifies the workflow configuration and may affect build performance or dependency management.

* Removed the `cache` and `cache-dependency-path` options from the `dotnet-version` setup step in `.github/workflows/deploy-package.yml`.