### PR TITLE
refactor: Calc smoothed price once in HT Trendline

### DIFF
--- a/src/e-k/HtTrendline/HtTrendline.BufferList.cs
+++ b/src/e-k/HtTrendline/HtTrendline.BufferList.cs
@@ -174,7 +174,7 @@ public class HtlList : BufferList<HtlResult>, IIncrementFromChain
                 ? (((4 * it[i]) + (3 * it[i - 1]) + (2 * it[i - 2]) + it[i - 3]) / 10d).NaN2Null()
                 : pr[i].NaN2Null();
 
-            double? smoothPrice = (((4 * pr[i]) + (3 * pr[i - 1]) + (2 * pr[i - 2]) + pr[i - 3]) / 10d).NaN2Null();
+            double? smoothPrice = sp[i].NaN2Null();
 
             AddInternal(new HtlResult(
                 Timestamp: timestamp,

--- a/src/e-k/HtTrendline/HtTrendline.StaticSeries.cs
+++ b/src/e-k/HtTrendline/HtTrendline.StaticSeries.cs
@@ -119,7 +119,7 @@ public static partial class HtTrendline
                       ? (((4 * it[i]) + (3 * it[i - 1]) + (2 * it[i - 2]) + it[i - 3]) / 10d).NaN2Null()
                       : pr[i].NaN2Null(),
 
-                    SmoothPrice: (((4 * pr[i]) + (3 * pr[i - 1]) + (2 * pr[i - 2]) + pr[i - 3]) / 10d).NaN2Null()));
+                    SmoothPrice: sp[i].NaN2Null()));
             }
 
             // initialization period

--- a/src/e-k/HtTrendline/HtTrendline.StreamHub.cs
+++ b/src/e-k/HtTrendline/HtTrendline.StreamHub.cs
@@ -126,7 +126,7 @@ public class HtTrendlineHub
                   ? (((4 * it[i]) + (3 * it[i - 1]) + (2 * it[i - 2]) + it[i - 3]) / 10d).NaN2Null()
                   : pr[i].NaN2Null(),
 
-                SmoothPrice: (((4 * pr[i]) + (3 * pr[i - 1]) + (2 * pr[i - 2]) + pr[i - 3]) / 10d).NaN2Null());
+                SmoothPrice: sp[i].NaN2Null());
 
             return (result, i);
         }


### PR DESCRIPTION
We were calculating smoothed price a second time in HT Trendline.
This removes the duplicate calculation and just reuses the value from the first one.
It's the exact same output.

Found when assessing:
- #1752 