### PR TITLE
feat: Make StreamHub.Rebuild() virtual to support lookahead indicators

### DIFF
--- a/src/_common/StreamHub/StreamHub.Observer.cs
+++ b/src/_common/StreamHub/StreamHub.Observer.cs
@@ -35,7 +35,7 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamObserver<TIn>
     }
 
     /// <inheritdoc/>
-    public void OnRebuild(DateTime fromTimestamp)
+    public virtual void OnRebuild(DateTime fromTimestamp)
         => Rebuild(fromTimestamp);
 
     /// <inheritdoc/>

--- a/src/_common/StreamHub/StreamHub.cs
+++ b/src/_common/StreamHub/StreamHub.cs
@@ -359,7 +359,7 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamHub<TIn, TOut>
     /// Rebuilds the cache from a specific timestamp.
     /// </summary>
     /// <inheritdoc/>
-    public void Rebuild(DateTime fromTimestamp)
+    public virtual void Rebuild(DateTime fromTimestamp)
     {
         // clear cache
         RemoveRange(fromTimestamp, notify: false);

--- a/src/a-d/Dpo/Dpo.StreamHub.cs
+++ b/src/a-d/Dpo/Dpo.StreamHub.cs
@@ -187,6 +187,35 @@ public class DpoHub
 
         // No internal state to restore for DPO (stateless indicator)
     }
+
+    /// <summary>
+    /// Rebuilds the cache from a specific timestamp with offset adjustment for downstream observers.
+    /// </summary>
+    /// <param name="fromTimestamp">Point in time to rebuild from.</param>
+    /// <remarks>
+    /// DPO has a backward offset dependency. When provider history is mutated at position p,
+    /// DPO positions from (p - offset) are affected. This override adjusts the rebuild timestamp
+    /// backward to notify downstream observers of the actual affected position, ensuring chained
+    /// observers (e.g., SmaHub) recalculate from the correct starting point.
+    /// </remarks>
+    public override void Rebuild(DateTime fromTimestamp)
+    {
+        // Adjust timestamp backward by offset to notify downstream of actual affected position
+        DateTime adjustedTimestamp = fromTimestamp;
+        if (ProviderCache.Count > 0)
+        {
+            int mutationIndex = ProviderCache.IndexGte(fromTimestamp);
+            if (mutationIndex >= 0)
+            {
+                int adjustedIndex = Math.Max(0, mutationIndex - Offset);
+                adjustedTimestamp = ProviderCache[adjustedIndex].Timestamp;
+            }
+        }
+
+        // Call base rebuild with adjusted timestamp
+        // This will notify downstream observers from the adjusted position
+        base.Rebuild(adjustedTimestamp);
+    }
 }
 
 /// <summary>

--- a/tests/indicators/_common/QuotePart/QuotePart.StreamHub.Tests.cs
+++ b/tests/indicators/_common/QuotePart/QuotePart.StreamHub.Tests.cs
@@ -45,17 +45,8 @@ public class QuotePartHubTests : StreamHubTestBase, ITestQuoteObserver, ITestCha
         IReadOnlyList<QuotePart> expectedRevised = RevisedQuotes.Use(candlePart);
 
         // assert, should equal series
-        for (int i = 0; i < quotesCount - 1; i++)
-        {
-            Quote q = RevisedQuotes[i];
-            QuotePart s = expectedRevised[i];
-            QuotePart r = sut[i];
-
-            r.Timestamp.Should().Be(q.Timestamp);
-            r.Timestamp.Should().Be(s.Timestamp);
-            r.Value.Should().Be(s.Value);
-            r.Should().Be(s);
-        }
+        sut.Should().HaveCount(quotesCount - 1);
+        sut.IsExactly(expectedRevised);
 
         observer.Unsubscribe();
         quoteHub.EndTransmission();
@@ -98,17 +89,8 @@ public class QuotePartHubTests : StreamHubTestBase, ITestQuoteObserver, ITestCha
             .ToSma(smaPeriods);
 
         // assert, should equal series
-        for (int i = 0; i < quotesCount - 1; i++)
-        {
-            Quote q = RevisedQuotes[i];
-            SmaResult s = expected[i];
-            SmaResult r = sut[i];
-
-            r.Timestamp.Should().Be(q.Timestamp);
-            r.Timestamp.Should().Be(s.Timestamp);
-            r.Sma.Should().Be(s.Sma);
-            r.Should().Be(s);
-        }
+        sut.Should().HaveCount(quotesCount - 1);
+        sut.IsExactly(expected);
 
         observer.Unsubscribe();
         quoteHub.EndTransmission();


### PR DESCRIPTION
## Merged into PR #1789

This PR has been successfully merged into #1789 (StreamHub audit and test standardization).

The DPO Rebuild() framework fix is now part of the broader StreamHub testing infrastructure PR.

See: https://github.com/DaveSkender/Stock.Indicators/pull/1789

---

## Summary

Makes `Rebuild()` and `OnRebuild()` virtual in StreamHub framework to enable indicators with lookahead dependencies (like DPO) to properly notify downstream chained observers when provider history is mutated.

## Problem

DPO (Detrended Price Oscillator) requires lookahead data for its calculation:
```csharp
DPO[i] = Value[i] - SMA[i + offset]
```

When a provider's history is mutated (Insert/Remove), the framework rebuilds from the mutation point. However, DPO positions *before* the mutation are also affected due to the backward offset dependency. Without the ability to override `Rebuild()`, DPO cannot notify downstream observers (e.g., chained SmaHub) of the actual affected range, causing incomplete recalculation.

## Solution

1. **Framework Changes:**
   - Made `StreamHub.Rebuild()` virtual
   - Made `StreamHub.OnRebuild()` virtual
   
2. **DPO Implementation:**
   - Override `Rebuild()` to adjust the timestamp backward by `Offset`
   - This ensures downstream observers are notified from the actual affected position
   
3. **Test Updates:**
   - Removed `[Ignore]` attribute from DPO ChainProvider test
   - Test now validates correct behavior with chained observers

## Notes

- Consolidated duplicate fix from PR #1800 with cleaner implementation
- Co-authored with @copilot-swe-agent contributions
- Enables future lookahead indicators to properly handle chained observers