### PR TITLE
refactor: Rename `StreamHub` base classes

### DIFF
--- a/.github/skills/indicator-stream/SKILL.md
+++ b/.github/skills/indicator-stream/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: indicator-stream
-description: Implement StreamHub real-time indicators with O(1) performance. Use for ChainProvider or QuoteProvider implementations. Covers provider selection, RollbackState patterns, performance anti-patterns, and comprehensive testing with StreamHubTestBase.
+description: Implement StreamHub real-time indicators with O(1) performance. Use for ChainHub or QuoteProvider implementations. Covers provider selection, RollbackState patterns, performance anti-patterns, and comprehensive testing with StreamHubTestBase.
 ---
 
 # StreamHub indicator development
@@ -9,8 +9,8 @@ description: Implement StreamHub real-time indicators with O(1) performance. Use
 
 | Provider Base | Input | Output | Use Case |
 | ------------- | ----- | ------ | -------- |
-| `ChainProvider<IReusable, TResult>` | Single value | IReusable | Chainable indicators |
-| `ChainProvider<IQuote, TResult>` | OHLCV | IReusable | Quote-driven, chainable output |
+| `ChainHub<IReusable, TResult>` | Single value | IReusable | Chainable indicators |
+| `ChainHub<IQuote, TResult>` | OHLCV | IReusable | Quote-driven, chainable output |
 | `QuoteProvider<IQuote, TResult>` | OHLCV | IQuote | Quote-to-quote transformation |
 
 ## Performance requirements
@@ -69,7 +69,7 @@ protected override void RollbackState(DateTime timestamp)
 ## Required implementation
 
 - [ ] Source code: `src/**/{IndicatorName}.StreamHub.cs` file exists
-  - [ ] Uses appropriate provider base (`ChainProvider` or `QuoteProvider`)
+  - [ ] Uses appropriate provider base (`ChainHub` or `QuoteProvider`)
   - [ ] Validates parameters in constructor; calls `Reinitialize()` as needed
   - [ ] Implements O(1) state updates; avoids O(n²) recalculation
   - [ ] Overrides `RollbackState()` when maintaining stateful fields

--- a/.github/skills/indicator-stream/references/provider-selection.md
+++ b/.github/skills/indicator-stream/references/provider-selection.md
@@ -4,18 +4,18 @@
 
 | Provider Base | Input | Output | Use Case | Examples |
 | ------------- | ----- | ------ | -------- | -------- |
-| `ChainProvider<IReusable, TResult>` | Single value | `IReusable` | Chainable indicators | EMA, SMA, RSI, MACD |
-| `ChainProvider<IQuote, TResult>` | OHLCV | `IReusable` | Quote-driven, chainable output | ADX, ATR, CCI, OBV |
+| `ChainHub<IReusable, TResult>` | Single value | `IReusable` | Chainable indicators | EMA, SMA, RSI, MACD |
+| `ChainHub<IQuote, TResult>` | OHLCV | `IReusable` | Quote-driven, chainable output | ADX, ATR, CCI, OBV |
 | `QuoteProvider<IQuote, TResult>` | OHLCV | `IResult` | Quote transformation | HeikinAshi, Renko |
 
-## ChainProvider<IReusable, TResult>
+## ChainHub<IReusable, TResult>
 
 **Most common pattern** (~45 indicators): Chainable input and output, supports EMA → RSI → SMA chains
 
 **Examples**: EMA, SMA, RSI, MACD, Trix, TSI, TEMA, DEMA
 
 ```csharp
-public class EmaHub : ChainProvider<IReusable, EmaResult>, IEma
+public class EmaHub : ChainHub<IReusable, EmaResult>, IEma
 {
     internal EmaHub(IChainProvider<IReusable> provider, int lookbackPeriods)
         : base(provider)
@@ -27,14 +27,14 @@ public class EmaHub : ChainProvider<IReusable, EmaResult>, IEma
 }
 ```
 
-## ChainProvider<IQuote, TResult>
+## ChainHub<IQuote, TResult>
 
 **Quote-driven input, chainable output** (~15 indicators): Requires OHLCV data, produces single chainable `IReusable` output
 
 **Examples**: ADX, ATR, Aroon, CCI, CMF, OBV
 
 ```csharp
-public class AdxHub : ChainProvider<IQuote, AdxResult>, IAdx
+public class AdxHub : ChainHub<IQuote, AdxResult>, IAdx
 {
     // Requires quote data, produces chainable AdxResult
 }
@@ -57,8 +57,8 @@ public class HeikinAshiHub : QuoteProvider<IQuote, HeikinAshiResult>
 
 | Provider Base | Observer Interface | Provider Interface |
 | ------------- | ------------------ | ------------------ |
-| `ChainProvider<IReusable, T>` | `ITestChainObserver` | `ITestChainProvider` |
-| `ChainProvider<IQuote, T>` | `ITestChainObserver` | `ITestChainProvider` |
+| `ChainHub<IReusable, T>` | `ITestChainObserver` | `ITestChainProvider` |
+| `ChainHub<IQuote, T>` | `ITestChainObserver` | `ITestChainProvider` |
 | `QuoteProvider<IQuote, T>` | `ITestQuoteObserver` | `ITestChainProvider` |
 
 ---

--- a/docs/plans/file-reorg.plan.md
+++ b/docs/plans/file-reorg.plan.md
@@ -124,7 +124,7 @@ Follow these conventions for all file naming:
 ### 8. PascalCase for file names
 
 - **Rule**: All file names use PascalCase (UpperCamelCase)
-- **Example**: `ChainProvider.cs`, `RollingWindowMax.cs`, `StringOutExtensions.cs`
+- **Example**: `ChainHub.cs`, `RollingWindowMax.cs`, `StringOutExtensions.cs`
 
 ### 9. Avoid generic terms
 

--- a/docs/plans/streaming-indicators.plan.md
+++ b/docs/plans/streaming-indicators.plan.md
@@ -103,7 +103,7 @@ DPO (Detrended Price Oscillator) required a framework enhancement to support cha
   - ✅ Implemented with lookahead offset pattern
   - ✅ Framework fix: Made `StreamHub.Rebuild()` and `OnRebuild()` virtual (PR #1802/#1800)
   - ✅ DPO override adjusts rebuild timestamp backward by offset for chained observers
-  - ✅ ChainProvider test now passes (removed `[Ignore]` attribute)
+  - ✅ ChainHub test now passes (removed `[Ignore]` attribute)
   - Has both BufferList and StreamHub
 
 - [x] **T145** - Slope StreamHub in `src/s-z/Slope/Slope.StreamHub.cs`
@@ -176,7 +176,7 @@ The following were evaluated and intentionally excluded from streaming implement
 - [x] **T175-T179** - StreamHub test interface compliance audits (5 tasks)
   - ✅ Audit script validates all tests implement correct interfaces
   - ✅ Confirmed: ITestQuoteObserver, ITestChainObserver properly used
-  - ✅ All required test methods present (QuoteObserver, ChainObserver, ChainProvider)
+  - ✅ All required test methods present (QuoteObserver, ChainObserver, ChainHub)
   - ✅ No interface compliance issues found
   - **Status**: COMPLETE
 
@@ -345,7 +345,7 @@ These algorithmic improvements apply to Series (batch) implementations. See [Iss
   - [x] Test interface compliance ✅ (T175-T179 - all tests validated)
   - [x] Test base class review ✅ (T184-T185 - validated, no updates needed)
   - [x] Provider history testing ✅ (T180-T183 - 40/42 applicable complete, 2 excluded)
-  - [x] DPO ChainProvider testing ✅ (now unblocked and passing)
+  - [x] DPO ChainHub testing ✅ (now unblocked and passing)
   - [x] Performance benchmarks ✅ (December 2025 baseline run)
   - [x] Memory validation ✅ (infrastructure ready)
 - **Low** (Polish + enhancements): 2-4 hours

--- a/src/_common/QuotePart/QuotePart.StreamHub.cs
+++ b/src/_common/QuotePart/QuotePart.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Streaming hub for managing quote parts.
 /// </summary>
 public class QuotePartHub
-    : ChainProvider<IQuote, QuotePart>, IQuotePart
+    : ChainHub<IQuote, QuotePart>, IQuotePart
 {
     internal QuotePartHub(
         IQuoteProvider<IQuote> provider,

--- a/src/_common/StreamHub/Providers/ChainHub.cs
+++ b/src/_common/StreamHub/Providers/ChainHub.cs
@@ -1,7 +1,7 @@
 namespace Skender.Stock.Indicators;
 
 /// <inheritdoc cref="IStreamHub{TIn, TOut}"/>
-public abstract class ChainProvider<TIn, TOut>(
+public abstract class ChainHub<TIn, TOut>(
     IStreamObservable<TIn> provider
 ) : StreamHub<TIn, TOut>(provider), IChainProvider<TOut>  // likely has to be concrete type
      where TIn : IReusable

--- a/src/a-d/Adl/Adl.StreamHub.cs
+++ b/src/a-d/Adl/Adl.StreamHub.cs
@@ -3,7 +3,7 @@ namespace Skender.Stock.Indicators;
 /// <summary>
 /// Streaming hub for Accumulation/Distribution Line (ADL).
 /// </summary>
-public class AdlHub : ChainProvider<IQuote, AdlResult>
+public class AdlHub : ChainHub<IQuote, AdlResult>
 {
     internal AdlHub(IQuoteProvider<IQuote> provider)
         : base(provider)

--- a/src/a-d/Adx/Adx.StreamHub.cs
+++ b/src/a-d/Adx/Adx.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Streaming hub for Average Directional Index (ADX).
 /// </summary>
 public class AdxHub
-    : ChainProvider<IQuote, AdxResult>, IAdx
+    : ChainHub<IQuote, AdxResult>, IAdx
 {
     internal AdxHub(
         IQuoteProvider<IQuote> quoteProvider,

--- a/src/a-d/Alma/Alma.StreamHub.cs
+++ b/src/a-d/Alma/Alma.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Streaming hub for Arnaud Legoux Moving Average (ALMA).
 /// </summary>
 public class AlmaHub
-    : ChainProvider<IReusable, AlmaResult>, IAlma
+    : ChainHub<IReusable, AlmaResult>, IAlma
 {
     private readonly double[] weights;
     private readonly double normalizationFactor;

--- a/src/a-d/Aroon/Aroon.StreamHub.cs
+++ b/src/a-d/Aroon/Aroon.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Represents a hub for Aroon Oscillator calculations.
 /// </summary>
 public class AroonHub
-    : ChainProvider<IQuote, AroonResult>, IAroon
+    : ChainHub<IQuote, AroonResult>, IAroon
 {
     internal AroonHub(
         IQuoteProvider<IQuote> provider,

--- a/src/a-d/Atr/Atr.StreamHub.cs
+++ b/src/a-d/Atr/Atr.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Provides functionality to calculate the Average True Range (ATR) for a series of quotes.
 /// </summary>
 public class AtrHub
-    : ChainProvider<IQuote, AtrResult>, IAtr
+    : ChainHub<IQuote, AtrResult>, IAtr
 {
     internal AtrHub(IQuoteProvider<IQuote> provider,
         int lookbackPeriods)

--- a/src/a-d/Awesome/Awesome.StreamHub.cs
+++ b/src/a-d/Awesome/Awesome.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Streaming hub for Awesome Oscillator.
 /// </summary>
 public class AwesomeHub
-    : ChainProvider<IReusable, AwesomeResult>, IAwesome
+    : ChainHub<IReusable, AwesomeResult>, IAwesome
 {
     internal AwesomeHub(
         IChainProvider<IReusable> provider,

--- a/src/a-d/BollingerBands/BollingerBands.StreamHub.cs
+++ b/src/a-d/BollingerBands/BollingerBands.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Provides methods for creating Bollinger Bands hubs.
 /// </summary>
 public class BollingerBandsHub
-    : ChainProvider<IReusable, BollingerBandsResult>, IBollingerBands
+    : ChainHub<IReusable, BollingerBandsResult>, IBollingerBands
 {
     internal BollingerBandsHub(
         IChainProvider<IReusable> provider,

--- a/src/a-d/Bop/Bop.StreamHub.cs
+++ b/src/a-d/Bop/Bop.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Streaming hub for Balance of Power (BOP).
 /// </summary>
 public class BopHub
-    : ChainProvider<IQuote, BopResult>, IBop
+    : ChainHub<IQuote, BopResult>, IBop
 {
     internal BopHub(
         IQuoteProvider<IQuote> provider,

--- a/src/a-d/Cci/Cci.StreamHub.cs
+++ b/src/a-d/Cci/Cci.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Streaming hub for Commodity Channel Index (CCI) calculations.
 /// </summary>
 public class CciHub
-    : ChainProvider<IQuote, CciResult>, ICci
+    : ChainHub<IQuote, CciResult>, ICci
 {
     private readonly CciList _cciList;
 

--- a/src/a-d/ChaikinOsc/ChaikinOsc.StreamHub.cs
+++ b/src/a-d/ChaikinOsc/ChaikinOsc.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Streaming hub for Chaikin Oscillator.
 /// </summary>
 public class ChaikinOscHub
-    : ChainProvider<IQuote, ChaikinOscResult>, IChaikinOsc
+    : ChainHub<IQuote, ChaikinOscResult>, IChaikinOsc
 {
     internal ChaikinOscHub(
         IQuoteProvider<IQuote> provider,

--- a/src/a-d/Chop/Chop.StreamHub.cs
+++ b/src/a-d/Chop/Chop.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Streaming hub for Choppiness Index (CHOP) on a series of quotes.
 /// </summary>
 public class ChopHub
-    : ChainProvider<IQuote, ChopResult>, IChop
+    : ChainHub<IQuote, ChopResult>, IChop
 {
     private readonly RollingWindowMax<double> _trueHighWindow;
     private readonly RollingWindowMin<double> _trueLowWindow;

--- a/src/a-d/Cmf/Cmf.StreamHub.cs
+++ b/src/a-d/Cmf/Cmf.StreamHub.cs
@@ -3,7 +3,7 @@ namespace Skender.Stock.Indicators;
 /// <summary>
 /// Provides methods for creating CMF stream hubs.
 /// </summary>
-public class CmfHub : ChainProvider<IQuote, CmfResult>, ICmf
+public class CmfHub : ChainHub<IQuote, CmfResult>, ICmf
 {
     internal CmfHub(
         IQuoteProvider<IQuote> provider,

--- a/src/a-d/Cmo/Cmo.StreamHub.cs
+++ b/src/a-d/Cmo/Cmo.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Streaming hub for Chande Momentum Oscillator (CMO) calculations.
 /// </summary>
 public class CmoHub
-    : ChainProvider<IReusable, CmoResult>, ICmo
+    : ChainHub<IReusable, CmoResult>, ICmo
 {
     private readonly Queue<(bool? isUp, double value)> _tickBuffer;
 

--- a/src/a-d/ConnorsRsi/ConnorsRsi.StreamHub.cs
+++ b/src/a-d/ConnorsRsi/ConnorsRsi.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Streaming hub for Connors RSI indicator in a streaming context.
 /// </summary>
 public class ConnorsRsiHub
-    : ChainProvider<IReusable, ConnorsRsiResult>, IConnorsRsi
+    : ChainHub<IReusable, ConnorsRsiResult>, IConnorsRsi
 {
     private readonly RsiHub rsiHub;
     private readonly List<double> streakBuffer;

--- a/src/a-d/Dema/Dema.StreamHub.cs
+++ b/src/a-d/Dema/Dema.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Streaming hub for Double Exponential Moving Average (DEMA).
 /// </summary>
 public class DemaHub
-    : ChainProvider<IReusable, DemaResult>, IDema
+    : ChainHub<IReusable, DemaResult>, IDema
 {
     private double lastEma1 = double.NaN;
     private double lastEma2 = double.NaN;

--- a/src/a-d/Dpo/Dpo.StreamHub.cs
+++ b/src/a-d/Dpo/Dpo.StreamHub.cs
@@ -11,7 +11,7 @@ namespace Skender.Stock.Indicators;
 /// Results maintain 1:1 correspondence with inputs.
 /// </remarks>
 public class DpoHub
-    : ChainProvider<IReusable, DpoResult>, IDpo
+    : ChainHub<IReusable, DpoResult>, IDpo
 {
     internal DpoHub(
         IChainProvider<IReusable> provider,

--- a/src/a-d/Dynamic/Dynamic.StreamHub.cs
+++ b/src/a-d/Dynamic/Dynamic.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Streaming hub for McGinley Dynamic.
 /// </summary>
 public class DynamicHub
-    : ChainProvider<IReusable, DynamicResult>, IDynamic
+    : ChainHub<IReusable, DynamicResult>, IDynamic
 {
     internal DynamicHub(
         IChainProvider<IReusable> provider,

--- a/src/e-k/Ema/Ema.StreamHub.cs
+++ b/src/e-k/Ema/Ema.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Streaming hub for Exponential Moving Average (EMA).
 /// </summary>
 public class EmaHub
-    : ChainProvider<IReusable, EmaResult>, IEma
+    : ChainHub<IReusable, EmaResult>, IEma
 {
     internal EmaHub(
         IChainProvider<IReusable> provider,

--- a/src/e-k/Epma/Epma.StreamHub.cs
+++ b/src/e-k/Epma/Epma.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Streaming hub for Endpoint Moving Average (EPMA)
 /// </summary>
 public class EpmaHub
-    : ChainProvider<IReusable, EpmaResult>, IEpma
+    : ChainHub<IReusable, EpmaResult>, IEpma
 {
     internal EpmaHub(
         IChainProvider<IReusable> provider,

--- a/src/e-k/FisherTransform/FisherTransform.StreamHub.cs
+++ b/src/e-k/FisherTransform/FisherTransform.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Streaming hub for Fisher Transform indicator using a stream hub.
 /// </summary>
 public class FisherTransformHub
-    : ChainProvider<IReusable, FisherTransformResult>, IFisherTransform
+    : ChainHub<IReusable, FisherTransformResult>, IFisherTransform
 {
 
     /// <summary>

--- a/src/e-k/ForceIndex/ForceIndex.StreamHub.cs
+++ b/src/e-k/ForceIndex/ForceIndex.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Provides streaming hub for Force Index calculations.
 /// </summary>
 public class ForceIndexHub
-    : ChainProvider<IReusable, ForceIndexResult>, IForceIndex
+    : ChainHub<IReusable, ForceIndexResult>, IForceIndex
 {
     private readonly double _k;
 

--- a/src/e-k/Hma/Hma.StreamHub.cs
+++ b/src/e-k/Hma/Hma.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Streaming hub for Hull Moving Average (HMA).
 /// </summary>
 public class HmaHub
-    : ChainProvider<IReusable, HmaResult>, IHma
+    : ChainHub<IReusable, HmaResult>, IHma
 {
     private readonly int wmaN1Periods;
     private readonly int wmaN2Periods;

--- a/src/e-k/HtTrendline/HtTrendline.StreamHub.cs
+++ b/src/e-k/HtTrendline/HtTrendline.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Provides methods for calculating the Hilbert Transform Instantaneous Trendline (HTL) indicator.
 /// </summary>
 public class HtTrendlineHub
-    : ChainProvider<IReusable, HtlResult>, IHtTrendline
+    : ChainHub<IReusable, HtlResult>, IHtTrendline
 {
 
     private readonly List<double> pr = [];   // price

--- a/src/e-k/Hurst/Hurst.StreamHub.cs
+++ b/src/e-k/Hurst/Hurst.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Provides streaming calculation of the Hurst Exponent indicator.
 /// </summary>
 public class HurstHub
-    : ChainProvider<IReusable, HurstResult>, IHurst
+    : ChainHub<IReusable, HurstResult>, IHurst
 {
     private readonly Queue<double> _buffer;
 

--- a/src/e-k/Kama/Kama.StreamHub.cs
+++ b/src/e-k/Kama/Kama.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Streaming hub for Kaufman's Adaptive Moving Average (KAMA).
 /// </summary>
 public class KamaHub
-    : ChainProvider<IReusable, KamaResult>, IKama
+    : ChainHub<IReusable, KamaResult>, IKama
 {
     private readonly double _scFast;
     private readonly double _scSlow;

--- a/src/e-k/Kvo/Kvo.StreamHub.cs
+++ b/src/e-k/Kvo/Kvo.StreamHub.cs
@@ -27,7 +27,7 @@ public static partial class Kvo
 /// Streaming hub for Klinger Volume Oscillator (KVO) calculations.
 /// </summary>
 public class KvoHub
-    : ChainProvider<IQuote, KvoResult>, IKvo
+    : ChainHub<IQuote, KvoResult>, IKvo
 {
     private readonly int _fastPeriods;
     private readonly int _slowPeriods;

--- a/src/m-r/Macd/Macd.StreamHub.cs
+++ b/src/m-r/Macd/Macd.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Streaming hub for MACD (Moving Average Convergence Divergence).
 /// </summary>
 public class MacdHub
-    : ChainProvider<IReusable, MacdResult>, IMacd
+    : ChainHub<IReusable, MacdResult>, IMacd
 {
     internal MacdHub(
         IChainProvider<IReusable> provider,

--- a/src/m-r/Mama/Mama.StreamHub.cs
+++ b/src/m-r/Mama/Mama.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Streaming hub for MAMA.
 /// </summary>
 public class MamaHub
-    : ChainProvider<IReusable, MamaResult>, IMama
+    : ChainHub<IReusable, MamaResult>, IMama
 {
 
     // State arrays for MESA algorithm

--- a/src/m-r/Mfi/Mfi.StreamHub.cs
+++ b/src/m-r/Mfi/Mfi.StreamHub.cs
@@ -3,7 +3,7 @@ namespace Skender.Stock.Indicators;
 /// <summary>
 /// Streaming hub for Money Flow Index (MFI).
 /// </summary>
-public class MfiHub : ChainProvider<IQuote, MfiResult>, IMfi
+public class MfiHub : ChainHub<IQuote, MfiResult>, IMfi
 {
     private readonly Queue<(double TruePrice, double MoneyFlow, int Direction)> _buffer;
     private double? _prevTruePrice;

--- a/src/m-r/Obv/Obv.StreamHub.cs
+++ b/src/m-r/Obv/Obv.StreamHub.cs
@@ -3,7 +3,7 @@ namespace Skender.Stock.Indicators;
 /// <summary>
 /// Provides methods for creating OBV hubs.
 /// </summary>
-public class ObvHub : ChainProvider<IQuote, ObvResult>
+public class ObvHub : ChainHub<IQuote, ObvResult>
 {
     internal ObvHub(
         IQuoteProvider<IQuote> provider) : base(provider)

--- a/src/m-r/ParabolicSar/ParabolicSar.StreamHub.cs
+++ b/src/m-r/ParabolicSar/ParabolicSar.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Streaming hub for Parabolic SAR.
 /// </summary>
 public class ParabolicSarHub
-    : ChainProvider<IQuote, ParabolicSarResult>, IParabolicSar
+    : ChainHub<IQuote, ParabolicSarResult>, IParabolicSar
 {
     private readonly Queue<(double High, double Low)> _buffer;
 

--- a/src/m-r/Pmo/Pmo.StreamHub.cs
+++ b/src/m-r/Pmo/Pmo.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Streaming hub for Price Momentum Oscillator (PMO).
 /// </summary>
 public class PmoHub
-    : ChainProvider<IReusable, PmoResult>, IPmo
+    : ChainHub<IReusable, PmoResult>, IPmo
 {
     private readonly double smoothingConstant1;
     private readonly double smoothingConstant2;

--- a/src/m-r/Pvo/Pvo.StreamHub.cs
+++ b/src/m-r/Pvo/Pvo.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Streaming hub for PVO (Percentage Volume Oscillator).
 /// </summary>
 public class PvoHub
-    : ChainProvider<IReusable, PvoResult>, IPvo
+    : ChainHub<IReusable, PvoResult>, IPvo
 {
     private double _prevFastEma = double.NaN;
     private double _prevSlowEma = double.NaN;

--- a/src/m-r/Roc/Roc.StreamHub.cs
+++ b/src/m-r/Roc/Roc.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Streaming hub for Rate of Change (ROC).
 /// </summary>
 public class RocHub
-    : ChainProvider<IReusable, RocResult>, IRoc
+    : ChainHub<IReusable, RocResult>, IRoc
 {
     internal RocHub(
         IChainProvider<IReusable> provider,

--- a/src/m-r/RocWb/RocWb.StreamHub.cs
+++ b/src/m-r/RocWb/RocWb.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Streaming hub for Rate of Change with Bands (RocWb).
 /// </summary>
 public class RocWbHub
-    : ChainProvider<IReusable, RocWbResult>, IRocWb
+    : ChainHub<IReusable, RocWbResult>, IRocWb
 {
     private readonly double k;
     private double prevEma = double.NaN;

--- a/src/m-r/Rsi/Rsi.StreamHub.cs
+++ b/src/m-r/Rsi/Rsi.StreamHub.cs
@@ -9,7 +9,7 @@ namespace Skender.Stock.Indicators;
 /// for normal streaming while allowing O(n) rebuild when needed.
 /// </remarks>
 public class RsiHub
-    : ChainProvider<IReusable, RsiResult>, IRsi
+    : ChainHub<IReusable, RsiResult>, IRsi
 {
     private double _avgGain = double.NaN;
     private double _avgLoss = double.NaN;

--- a/src/s-z/Slope/Slope.StreamHub.cs
+++ b/src/s-z/Slope/Slope.StreamHub.cs
@@ -9,7 +9,7 @@ namespace Skender.Stock.Indicators;
 /// This matches the Series implementation's behavior.
 /// </remarks>
 public class SlopeHub
-    : ChainProvider<IReusable, SlopeResult>, ISlope
+    : ChainHub<IReusable, SlopeResult>, ISlope
 {
     private readonly Queue<double> buffer;
 

--- a/src/s-z/Sma/Sma.StreamHub.cs
+++ b/src/s-z/Sma/Sma.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Streaming hub for Simple Moving Average (SMA).
 /// </summary>
 public class SmaHub
-    : ChainProvider<IReusable, SmaResult>, ISma
+    : ChainHub<IReusable, SmaResult>, ISma
 {
 
     internal SmaHub(

--- a/src/s-z/SmaAnalysis/SmaAnalysis.StreamHub.cs
+++ b/src/s-z/SmaAnalysis/SmaAnalysis.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Represents a Simple Moving Average (SMA) Analysis stream hub.
 /// </summary>
 public class SmaAnalysisHub
-    : ChainProvider<IReusable, SmaAnalysisResult>, ISma
+    : ChainHub<IReusable, SmaAnalysisResult>, ISma
 {
     internal SmaAnalysisHub(
         IChainProvider<IReusable> provider,

--- a/src/s-z/Smi/Smi.StreamHub.cs
+++ b/src/s-z/Smi/Smi.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Represents a Stochastic Momentum Index (SMI) stream hub that calculates SMI with signal line.
 /// </summary>
 public sealed class SmiHub
-    : ChainProvider<IQuote, SmiResult>, ISmi
+    : ChainHub<IQuote, SmiResult>, ISmi
 {
 
     // Rolling windows for O(1) high/low tracking

--- a/src/s-z/Smma/Smma.StreamHub.cs
+++ b/src/s-z/Smma/Smma.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Provides methods for calculating the Smoothed Moving Average (SMMA) indicator.
 /// </summary>
 public class SmmaHub
-    : ChainProvider<IReusable, SmmaResult>, ISmma
+    : ChainHub<IReusable, SmmaResult>, ISmma
 {
     internal SmmaHub(
         IChainProvider<IReusable> provider,

--- a/src/s-z/Stc/Stc.StreamHub.cs
+++ b/src/s-z/Stc/Stc.StreamHub.cs
@@ -12,7 +12,7 @@ internal record StcMacdState(double FastEma, double SlowEma, double Macd);
 /// Provides methods for creating Schaff Trend Cycle (STC) streaming hubs.
 /// </summary>
 public class StcHub
-    : ChainProvider<IReusable, StcResult>, IStc
+    : ChainHub<IReusable, StcResult>, IStc
 {
 
     private readonly RollingWindowMax<double> _macdHighWindow;

--- a/src/s-z/StdDev/StdDev.StreamHub.cs
+++ b/src/s-z/StdDev/StdDev.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Represents a Standard Deviation stream hub.
 /// </summary>
 public class StdDevHub
-    : ChainProvider<IReusable, StdDevResult>, IStdDev
+    : ChainHub<IReusable, StdDevResult>, IStdDev
 {
     internal StdDevHub(
         IChainProvider<IReusable> provider,

--- a/src/s-z/StochRsi/StochRsi.StreamHub.cs
+++ b/src/s-z/StochRsi/StochRsi.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Represents a Stochastic RSI stream hub that calculates Stochastic oscillator on RSI values.
 /// </summary>
 public sealed class StochRsiHub
-    : ChainProvider<IReusable, StochRsiResult>
+    : ChainHub<IReusable, StochRsiResult>
 {
     /// <summary>
     /// Internal RSI hub for incremental RSI calculation

--- a/src/s-z/T3/T3.StreamHub.cs
+++ b/src/s-z/T3/T3.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Provides methods for calculating the T3 Moving Average indicator.
 /// </summary>
 public class T3Hub
-    : ChainProvider<IReusable, T3Result>, IT3
+    : ChainHub<IReusable, T3Result>, IT3
 {
     private double lastEma1 = double.NaN;
     private double lastEma2 = double.NaN;

--- a/src/s-z/Tema/Tema.StreamHub.cs
+++ b/src/s-z/Tema/Tema.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Provides methods for calculating the Triple Exponential Moving Average (TEMA) indicator.
 /// </summary>
 public class TemaHub
-    : ChainProvider<IReusable, TemaResult>, ITema
+    : ChainHub<IReusable, TemaResult>, ITema
 {
     private double lastEma1 = double.NaN;
     private double lastEma2 = double.NaN;

--- a/src/s-z/Tr/Tr.StreamHub.cs
+++ b/src/s-z/Tr/Tr.StreamHub.cs
@@ -2,7 +2,7 @@ namespace Skender.Stock.Indicators;
 
 /// <inheritdoc />
 public class TrHub
-    : ChainProvider<IQuote, TrResult>
+    : ChainHub<IQuote, TrResult>
 {
     internal TrHub(IQuoteProvider<IQuote> provider)
         : base(provider)

--- a/src/s-z/Trix/Trix.StreamHub.cs
+++ b/src/s-z/Trix/Trix.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Streaming hub for Triple Exponential Moving Average Oscillator (TRIX) calculations.
 /// </summary>
 public class TrixHub
-    : ChainProvider<IReusable, TrixResult>, ITrix
+    : ChainHub<IReusable, TrixResult>, ITrix
 {
     private double lastEma1 = double.NaN;
     private double lastEma2 = double.NaN;

--- a/src/s-z/Tsi/Tsi.StreamHub.cs
+++ b/src/s-z/Tsi/Tsi.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Provides methods for calculating the True Strength Index (TSI) indicator.
 /// </summary>
 public class TsiHub
-    : ChainProvider<IReusable, TsiResult>, ITsi
+    : ChainHub<IReusable, TsiResult>, ITsi
 {
     private readonly double mult1;  // smoothing constant for first EMA (lookbackPeriods)
     private readonly double mult2;  // smoothing constant for second EMA (smoothPeriods)

--- a/src/s-z/UlcerIndex/UlcerIndex.StreamHub.cs
+++ b/src/s-z/UlcerIndex/UlcerIndex.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Provides streaming hub for calculating the Ulcer Index indicator.
 /// </summary>
 public class UlcerIndexHub
-    : ChainProvider<IReusable, UlcerIndexResult>, IUlcerIndex
+    : ChainHub<IReusable, UlcerIndexResult>, IUlcerIndex
 {
     internal UlcerIndexHub(
         IChainProvider<IReusable> provider,

--- a/src/s-z/Ultimate/Ultimate.StreamHub.cs
+++ b/src/s-z/Ultimate/Ultimate.StreamHub.cs
@@ -2,7 +2,7 @@ namespace Skender.Stock.Indicators;
 
 /// <inheritdoc />
 public class UltimateHub
-    : ChainProvider<IReusable, UltimateResult>, IUltimate
+    : ChainHub<IReusable, UltimateResult>, IUltimate
 {
     internal UltimateHub(
         IQuoteProvider<IQuote> provider,

--- a/src/s-z/Vwap/Vwap.StreamHub.cs
+++ b/src/s-z/Vwap/Vwap.StreamHub.cs
@@ -3,7 +3,7 @@ namespace Skender.Stock.Indicators;
 /// <summary>
 /// Streaming hub for Volume Weighted Average Price (VWAP).
 /// </summary>
-public class VwapHub : ChainProvider<IQuote, VwapResult>
+public class VwapHub : ChainHub<IQuote, VwapResult>
 {
     private readonly bool _autoAnchor;
     private double _cumVolume;

--- a/src/s-z/Vwma/Vwma.StreamHub.cs
+++ b/src/s-z/Vwma/Vwma.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Provides methods for creating VWMA hubs.
 /// </summary>
 public class VwmaHub
-    : ChainProvider<IReusable, VwmaResult>, IVwma
+    : ChainHub<IReusable, VwmaResult>, IVwma
 {
     internal VwmaHub(
         IQuoteProvider<IQuote> provider,

--- a/src/s-z/Wma/Wma.StreamHub.cs
+++ b/src/s-z/Wma/Wma.StreamHub.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Provides methods for creating WMA hubs.
 /// </summary>
 public class WmaHub
-    : ChainProvider<IReusable, WmaResult>, IWma
+    : ChainHub<IReusable, WmaResult>, IWma
 {
     internal WmaHub(
         IChainProvider<IReusable> provider,

--- a/tests/indicators/m-r/MaEnvelopes/MaEnvelopes.StreamHub.Tests.cs
+++ b/tests/indicators/m-r/MaEnvelopes/MaEnvelopes.StreamHub.Tests.cs
@@ -90,39 +90,6 @@ public class MaEnvelopesHubTests : StreamHubTestBase, ITestChainObserver
     }
 
     [TestMethod]
-    public void ChainProvider()
-    {
-        const int maPeriods = 20;
-        int length = Quotes.Count;
-
-        // setup quote provider hub
-        QuoteHub quoteHub = new();
-
-        // setup observer
-        MaEnvelopesHub maEnvHub = quoteHub.ToMaEnvelopesHub(maPeriods, percentOffset);
-
-        // MaEnvelopeResult doesn't implement IReusable, so it cannot be used as a provider for other indicators
-        // This test verifies the hub works correctly but doesn't chain to another indicator
-
-        // emulate quote stream
-        for (int i = 0; i < length; i++) { quoteHub.Add(Quotes[i]); }
-
-        // final results
-        IReadOnlyList<MaEnvelopeResult> actuals = maEnvHub.Results;
-
-        // time-series, for comparison
-        IReadOnlyList<MaEnvelopeResult> expected = Quotes.ToMaEnvelopes(maPeriods, percentOffset);
-
-        // assert, should equal series
-        actuals.Should().HaveCount(length);
-        actuals.IsExactly(expected);
-
-        // cleanup
-        maEnvHub.Unsubscribe();
-        quoteHub.EndTransmission();
-    }
-
-    [TestMethod]
     public void WithDemaType()
     {
         int length = Quotes.Count;

--- a/tools/scripts/audit-streamhub.sh
+++ b/tools/scripts/audit-streamhub.sh
@@ -132,7 +132,7 @@ for test_file in "${test_files[@]}"; do
 
         if [[ $has_chain_provider -eq 1 ]]; then
             if ! grep -q "ChainProvider_MatchesSeriesExactly" "$test_file"; then
-                test_method_issues_list+=("$indicator_name: Missing ChainProvider test method")
+                test_method_issues_list+=("$indicator_name: Missing ChainHub test method")
                 test_method_issues=$((test_method_issues + 1))
             fi
         fi
@@ -182,7 +182,7 @@ for test_file in "${test_files[@]}"; do
             fi
         fi
 
-        # Check ChainProvider method for provider history testing
+        # Check ChainHub method for provider history testing
         has_chain_provider_method=$(grep -c "ChainProvider_MatchesSeriesExactly" "$test_file" || true)
 
         if [[ $has_chain_provider_method -gt 0 ]]; then
@@ -190,7 +190,7 @@ for test_file in "${test_files[@]}"; do
             has_remove=$(grep -A 50 "ChainProvider_MatchesSeriesExactly" "$test_file" | grep -c "\.Remove(" || true)
 
             if [[ $has_insert -eq 0 ]] || [[ $has_remove -eq 0 ]]; then
-                provider_history_issues+=("$indicator_name: ChainProvider test missing Insert/Remove operations")
+                provider_history_issues+=("$indicator_name: ChainHub test missing Insert/Remove operations")
                 provider_history_missing=$((provider_history_missing + 1))
             fi
         fi


### PR DESCRIPTION
Renaming `ChainProvider` to `ChainHub` and other related clarifying items.