### PR TITLE
feat: Add Trader's Dynamic Index (Goldminds)

### DIFF
--- a/src/_common/Catalog/Catalog.Listings.cs
+++ b/src/_common/Catalog/Catalog.Listings.cs
@@ -412,6 +412,11 @@ public static partial class Catalog
         _listings.Add(Tema.SeriesListing);
         _listings.Add(Tema.StreamListing);
 
+        // TDI GM (Traders Dynamic Index Goldminds)
+        _listings.Add(TdiGm.BufferListing);
+        _listings.Add(TdiGm.SeriesListing);
+        _listings.Add(TdiGm.StreamListing);
+
         // TR (True Range)
         _listings.Add(Tr.BufferListing);
         _listings.Add(Tr.SeriesListing);

--- a/src/s-z/TdiGm/ITdiGm.cs
+++ b/src/s-z/TdiGm/ITdiGm.cs
@@ -1,0 +1,12 @@
+namespace Skender.Stock.Indicators;
+
+/// <summary>
+/// Interface for TdiGm configuration parameters
+/// </summary>
+public interface ITdiGm
+{
+    int RsiPeriod { get; }
+    int BandLength { get; }
+    int FastLength { get; }
+    int SlowLength { get; }
+}

--- a/src/s-z/TdiGm/TdiGm.BufferList.cs
+++ b/src/s-z/TdiGm/TdiGm.BufferList.cs
@@ -19,7 +19,7 @@ public class TdiGmList : BufferList<TdiGmResult>, IIncrementFromChain, ITdiGm
     /// <param name="fastLength">The fast length.</param>
     /// <param name="slowLength">The slow length.</param>
     public TdiGmList(
-         int rsiPeriod = 21,
+        int rsiPeriod = 21,
         int bandLength = 34,
         int fastLength = 2,
         int slowLength = 7
@@ -111,7 +111,7 @@ public class TdiGmList : BufferList<TdiGmResult>, IIncrementFromChain, ITdiGm
 
             upper = ma + offset;
             lower = ma - offset;
-            middle = (upper + lower) / 2;
+            middle = ma;
         }
 
         // Create and add the result

--- a/src/s-z/TdiGm/TdiGm.BufferList.cs
+++ b/src/s-z/TdiGm/TdiGm.BufferList.cs
@@ -1,0 +1,102 @@
+namespace Skender.Stock.Indicators;
+
+/// <summary>
+/// TDI-GM from incremental reusable values.
+/// </summary>
+public class TdiGmList : BufferList<TdiGmResult>, IIncrementFromChain, ITdiGm
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TdiGmList"/> class.
+    /// </summary>
+    /// <param name="rsiPeriod">The RSI period.</param>
+    /// <param name="bandLength">The band length.</param>
+    /// <param name="fastLength">The fast length.</param>
+    /// <param name="slowLength">The slow length.</param>
+    public TdiGmList(
+         int rsiPeriod = 21,
+        int bandLength = 34,
+        int fastLength = 2,
+        int slowLength = 7
+    )
+    {
+        TdiGm.Validate(rsiPeriod, bandLength, fastLength, slowLength);
+        RsiPeriod = rsiPeriod;
+        BandLength = bandLength;
+        FastLength = fastLength;
+        SlowLength = slowLength;
+
+        Name = $"TdiGm({21}, {34}, {2}, {7})";
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TdiGmList"/> class with initial reusable values.
+    /// </summary>
+    /// <param name="rsiPeriod">The RSI period.</param>
+    /// <param name="bandLength">The band length.</param>
+    /// <param name="fastLength">The fast length.</param>
+    /// <param name="slowLength">The slow length.</param>
+    /// <param name="values">Initial reusable values to populate the list.</param>
+    public TdiGmList(
+        int rsiPeriod,
+        int bandLength,
+        int fastLength,
+        int slowLength,
+        IReadOnlyList<IReusable> values
+    )
+        : this(rsiPeriod, bandLength, fastLength, slowLength) => Add(values);
+
+    public int RsiPeriod { get; init; }
+    public int BandLength { get; init; }
+    public int FastLength { get; init; }
+    public int SlowLength { get; init; }
+
+    /// <inheritdoc />
+    public void Add(DateTime timestamp, double value)
+    {
+
+    }
+
+    /// <inheritdoc />
+    public void Add(IReusable value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        Add(value.Timestamp, value.Value);
+    }
+
+    /// <inheritdoc />
+    public void Add(IReadOnlyList<IReusable> values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+
+        for (int i = 0; i < values.Count; i++)
+        {
+            Add(values[i].Timestamp, values[i].Value);
+        }
+    }
+
+    /// <inheritdoc />
+    public override void Clear()
+    {
+        base.Clear();
+    }
+}
+
+public static partial class TdiGm
+{
+    /// <summary>
+    /// Creates a buffer list for TDI-GM calculations.
+    /// </summary>
+    /// <param name="source">The source list of reusable values.</param>
+    /// <param name="rsiPeriod">The RSI period.</param>
+    /// <param name="bandLength">The band length.</param>
+    /// <param name="fastLength">The fast length.</param>
+    /// <param name="slowLength">The slow length.</param>
+    /// <returns>A buffer list for TDI-GM calculations.</returns>
+    public static TdiGmList ToTdiGmList(
+        this IReadOnlyList<IReusable> source,
+        int rsiPeriod = 21,
+        int bandLength = 34,
+        int fastLength = 2,
+        int slowLength = 7)
+        => new(rsiPeriod, bandLength, fastLength, slowLength) { source };
+}

--- a/src/s-z/TdiGm/TdiGm.Catalog.cs
+++ b/src/s-z/TdiGm/TdiGm.Catalog.cs
@@ -1,0 +1,50 @@
+namespace Skender.Stock.Indicators;
+
+public static partial class TdiGm
+{
+    /// <summary>
+    /// TDI-GM Common Base Listing
+    /// </summary>
+    internal static readonly IndicatorListing CommonListing =
+        new CatalogListingBuilder()
+            .WithName("Traders Dynamic Index (Goldminds)")
+            .WithId("TDIGM")
+            .WithCategory(Category.Oscillator)
+            .AddParameter<int>("rsiPeriod", "RSI Period", description: "Number of periods for the RSI calculation", isRequired: false, defaultValue: 21, minimum: 1, maximum: 250)
+            .AddParameter<int>("bandLength", "Band Length", description: "Number of periods for band calculations", isRequired: false, defaultValue: 34, minimum: 1, maximum: 250)
+            .AddParameter<int>("fastLength", "Fast Length", description: "Number of periods for fast moving average", isRequired: false, defaultValue: 2, minimum: 1, maximum: 250)
+            .AddParameter<int>("slowLength", "Slow Length", description: "Number of periods for slow moving average", isRequired: false, defaultValue: 7, minimum: 1, maximum: 250)
+            .AddResult("Upper", "Upper Band", ResultType.Default)
+            .AddResult("Lower", "Lower Band", ResultType.Default)
+            .AddResult("Middle", "Middle Band", ResultType.Default)
+            .AddResult("Fast", "Fast MA", ResultType.Default, isReusable: true)
+            .AddResult("Slow", "Slow MA", ResultType.Default)
+            .Build();
+
+    /// <summary>
+    /// TDI-GM Series Listing
+    /// </summary>
+    internal static readonly IndicatorListing SeriesListing =
+        new CatalogListingBuilder(CommonListing)
+            .WithStyle(Style.Series)
+            .WithMethodName("ToTdiGm")
+            .Build();
+
+    /// <summary>
+    /// TDI-GM Stream Listing
+    /// </summary>
+    internal static readonly IndicatorListing StreamListing =
+        new CatalogListingBuilder(CommonListing)
+            .WithStyle(Style.Stream)
+            .WithMethodName("ToTdiGmHub")
+            .Build();
+
+    /// <summary>
+    /// TDI-GM Buffer Listing
+    /// </summary>
+    internal static readonly IndicatorListing BufferListing =
+        new CatalogListingBuilder(CommonListing)
+            .WithStyle(Style.Buffer)
+            .WithMethodName("ToTdiGmList")
+            .Build();
+}

--- a/src/s-z/TdiGm/TdiGm.Models.cs
+++ b/src/s-z/TdiGm/TdiGm.Models.cs
@@ -1,0 +1,20 @@
+namespace Skender.Stock.Indicators;
+
+/// <summary>
+/// TDIGM result containing all indicator series.
+/// Value points to the fast MA (most relevant for trading signals).
+/// Implements IReusable to enable chaining in Skender v3.
+/// </summary>
+[Serializable]
+public record TdiGmResult() : IReusable
+{
+    public required DateTime Timestamp { get; init; }
+    public double? Upper { get; init; }
+    public double? Lower { get; init; }
+    public double? Middle { get; init; }
+    public double? Slow { get; init; }
+    public double? Fast { get; init; }
+
+    [JsonIgnore]
+    public double Value => Fast.Null2NaN();
+}

--- a/src/s-z/TdiGm/TdiGm.StaticSeries.cs
+++ b/src/s-z/TdiGm/TdiGm.StaticSeries.cs
@@ -54,7 +54,7 @@ public static partial class TdiGm
                 double offset = 1.6185 * stdDev.Value;
                 upper = middleBand.Value + offset;
                 lower = middleBand.Value - offset;
-                middle = (upper + lower) / 2;
+                middle = middleBand.Value;
             }
 
             results.Add(

--- a/src/s-z/TdiGm/TdiGm.StaticSeries.cs
+++ b/src/s-z/TdiGm/TdiGm.StaticSeries.cs
@@ -1,0 +1,35 @@
+namespace Skender.Stock.Indicators;
+
+/// <summary>
+/// TDI-GM indicator.
+/// </summary>
+public static partial class TdiGm
+{
+    /// <summary>
+    /// Calculates the TDI-GM for a series of data.
+    /// </summary>
+    /// <param name="source">The source list of data.</param>
+    /// <param name="rsiPeriod">The RSI period.</param>
+    /// <param name="bandLength">The band length.</param>
+    /// <param name="fastLength">The fast length.</param>
+    /// <param name="slowLength">The slow length.</param>
+    /// <returns>A list of TdiGmResult containing the TDI-GM values.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> is null.</exception>
+    public static IReadOnlyList<TdiGmResult> ToTdiGm(
+        this IReadOnlyList<IReusable> source,
+        int rsiPeriod = 21,
+        int bandLength = 34,
+        int fastLength = 2,
+        int slowLength = 7)
+    {
+        // check parameter arguments
+        ArgumentNullException.ThrowIfNull(source);
+        Validate(rsiPeriod, bandLength, fastLength, slowLength);
+
+        // initialize
+        int length = source.Count;
+        List<TdiGmResult> results = new(length);
+
+        return results;
+    }
+}

--- a/src/s-z/TdiGm/TdiGm.StreamHub.cs
+++ b/src/s-z/TdiGm/TdiGm.StreamHub.cs
@@ -1,0 +1,167 @@
+namespace Skender.Stock.Indicators;
+
+/// <summary>
+/// TDIGM (Traders Dynamic Index [Goldminds]) streaming hub implementation.
+/// Derives from ChainHub to enable streaming computation and chaining following Skender v3 pattern.
+/// 
+/// Computation pipeline using chained hubs:
+/// 1. RsiHub(rsiPeriod) on input quotes → RSI values
+/// 2. SmaHub(bandLength) on RSI values → middle band
+/// 3. StdDevHub(bandLength) on RSI values → used to calculate upper/lower bands with 1.6185 multiplier
+/// 4. SmaHub(fastLength) on RSI values → fast MA
+/// 5. SmaHub(slowLength) on RSI values → slow MA
+/// </summary>
+public sealed class TdiGmHub
+    : ChainHub<IReusable, TdiGmResult>, ITdiGm
+{
+    public int RsiPeriod { get; private set; }
+    public int BandLength { get; private set; }
+    public int FastLength { get; private set; }
+    public int SlowLength { get; private set; }
+
+    // Chained hubs for efficient computation
+    private readonly RsiHub _rsiHub;
+    private readonly SmaHub _middleBandHub;  // SMA of RSI values
+    private readonly StdDevHub _stdDevHub;   // StdDev of RSI values
+    private readonly SmaHub _fastMaHub;      // Fast SMA of RSI values
+    private readonly SmaHub _slowMaHub;      // Slow SMA of RSI values
+
+    /// <summary>
+    /// Creates a new TdiGmHub instance. Internal constructor - use ToTdiGmHub() extension method.
+    /// </summary>
+    /// <param name="provider">The chain provider to subscribe to</param>
+    /// <param name="rsiPeriod">RSI period for the base oscillator (default: 21)</param>
+    /// <param name="bandLength">Band length for middle band and standard deviation (default: 34)</param>
+    /// <param name="fastLength">Fast moving average period on RSI (default: 2)</param>
+    /// <param name="slowLength">Slow moving average period on RSI (default: 7)</param>
+    internal TdiGmHub(
+        IChainProvider<IReusable> provider,
+        int rsiPeriod,
+        int bandLength,
+        int fastLength,
+        int slowLength)
+        : base(provider)
+    {
+        RsiPeriod = rsiPeriod;
+        BandLength = bandLength;
+        FastLength = fastLength;
+        SlowLength = slowLength;
+
+        // Create the hub chain:
+        // provider (Candle) → RsiHub → [SmaHub(band), StdDevHub(band), SmaHub(fast), SmaHub(slow)]
+        _rsiHub = provider.ToRsiHub(rsiPeriod);
+        _middleBandHub = _rsiHub.ToSmaHub(bandLength);
+        _stdDevHub = _rsiHub.ToStdDevHub(bandLength);
+        _fastMaHub = _rsiHub.ToSmaHub(fastLength);
+        _slowMaHub = _rsiHub.ToSmaHub(slowLength);
+
+        Reinitialize();
+    }
+
+    /// <summary>
+    /// Converts an input item to a TdiGmResult indicator value.
+    /// Called by StreamHub base class for each item in ProviderCache.
+    /// Uses chained hubs - gets current values from each hub's cache.
+    /// </summary>
+    /// <param name="item">Input item (Candle)</param>
+    /// <param name="indexHint">Index hint for optimization</param>
+    /// <returns>Tuple of (indicator result, index)</returns>
+    protected override (TdiGmResult, int) ToIndicator(IReusable item, int? indexHint)
+    {
+        int index = indexHint ?? ProviderCache.Count - 1;
+        DateTime timestamp = item.Timestamp;
+
+        // Get the latest results from each chained hub
+        // Each hub has already computed its value for this index
+        var middleBandResult = _middleBandHub.Results.LastOrDefault();
+        var stdDevResult = _stdDevHub.Results.LastOrDefault();
+        var fastMaResult = _fastMaHub.Results.LastOrDefault();
+        var slowMaResult = _slowMaHub.Results.LastOrDefault();
+
+        // Calculate TDIGM bands using the hub results
+        double? upper = null;
+        double? lower = null;
+        double? middle = null;
+
+        if (middleBandResult?.Sma != null && stdDevResult?.StdDev != null)
+        {
+            var ma = middleBandResult.Sma.Value;
+            var stdDev = stdDevResult.StdDev.Value;
+            var offset = 1.6185 * stdDev;
+
+            upper = ma + offset;
+            lower = ma - offset;
+            middle = (upper + lower) / 2;
+        }
+
+        // Create the result
+        var result = new TdiGmResult() {
+            Timestamp = timestamp,
+            Upper = upper,
+            Lower = lower,
+            Middle = middle,
+            Fast = fastMaResult?.Sma != null ? fastMaResult.Sma.Value : null,
+            Slow = slowMaResult?.Sma != null ? slowMaResult.Sma.Value : null
+        };
+
+        return (result, index);
+    }
+
+    /// <summary>
+    /// Binary settings for hub behavior configuration.
+    /// </summary>
+    public override BinarySettings Properties
+    {
+        get => base.Properties;
+        init => base.Properties = value;
+    }
+
+    /// <summary>
+    /// Rolls back the hub state to a specific timestamp by rebuilding from that point.
+    /// Used to restore indicator state when replaying historical data.
+    /// The base implementation and chained hubs handle their own rollback.
+    /// </summary>
+    /// <param name="timestamp">The timestamp to roll back to</param>
+    protected override void RollbackState(DateTime timestamp)
+    {
+        // Base implementation handles rolling back through ProviderCache
+        // Chained hubs will rollback automatically through their own providers
+        base.RollbackState(timestamp);
+    }
+
+    /// <summary>
+    /// Returns a string representation of this hub.
+    /// </summary>
+    public override string ToString()
+    {
+        return $"TdiGmHub(RSI={RsiPeriod}, Band={BandLength}, Fast={FastLength}, Slow={SlowLength})";
+    }
+}
+
+/// <summary>
+/// Extension methods for creating TdiGmHub instances.
+/// Following Skender v3 pattern where factory method is in the same file as the hub.
+/// </summary>
+public static class TdiGmHubExtensions
+{
+    /// <summary>
+    /// Creates a TdiGmHub from any IChainProvider source.
+    /// Factory method following Skender v3 pattern (e.g., ToRsi, ToSma, etc.)
+    /// </summary>
+    /// <param name="source">The source chain provider (e.g., QuoteHub)</param>
+    /// <param name="rsiPeriod">RSI period for the base oscillator (default: 21)</param>
+    /// <param name="bandLength">Band length for middle band and standard deviation (default: 34)</param>
+    /// <param name="fastLength">Fast moving average period on RSI (default: 2)</param>
+    /// <param name="slowLength">Slow moving average period on RSI (default: 7)</param>
+    /// <returns>A new TdiGmHub instance chained to the source</returns>
+    public static TdiGmHub ToTdiGmHub(
+        this IChainProvider<IReusable> source,
+        int rsiPeriod = 21,
+        int bandLength = 34,
+        int fastLength = 2,
+        int slowLength = 7)
+    {
+        // Create the hub by passing the provider and parameters
+        return new TdiGmHub(source, rsiPeriod, bandLength, fastLength, slowLength);
+    }
+}

--- a/src/s-z/TdiGm/TdiGm.StreamHub.cs
+++ b/src/s-z/TdiGm/TdiGm.StreamHub.cs
@@ -14,10 +14,10 @@ namespace Skender.Stock.Indicators;
 public sealed class TdiGmHub
     : ChainHub<IReusable, TdiGmResult>, ITdiGm
 {
-    public int RsiPeriod { get; private set; }
-    public int BandLength { get; private set; }
-    public int FastLength { get; private set; }
-    public int SlowLength { get; private set; }
+    public int RsiPeriod { get; init; }
+    public int BandLength { get; init; }
+    public int FastLength { get; init; }
+    public int SlowLength { get; init; }
 
     // Chained hubs for efficient computation
     private readonly RsiHub _rsiHub;
@@ -42,6 +42,7 @@ public sealed class TdiGmHub
         int slowLength)
         : base(provider)
     {
+        TdiGm.Validate(rsiPeriod, bandLength, fastLength, slowLength);
         RsiPeriod = rsiPeriod;
         BandLength = bandLength;
         FastLength = fastLength;
@@ -91,7 +92,7 @@ public sealed class TdiGmHub
 
             upper = ma + offset;
             lower = ma - offset;
-            middle = (upper + lower) / 2;
+            middle = ma;
         }
 
         // Create the result

--- a/src/s-z/TdiGm/TdiGm.StreamHub.cs
+++ b/src/s-z/TdiGm/TdiGm.StreamHub.cs
@@ -73,10 +73,10 @@ public sealed class TdiGmHub
 
         // Get the latest results from each chained hub
         // Each hub has already computed its value for this index
-        var middleBandResult = _middleBandHub.Results.LastOrDefault();
-        var stdDevResult = _stdDevHub.Results.LastOrDefault();
-        var fastMaResult = _fastMaHub.Results.LastOrDefault();
-        var slowMaResult = _slowMaHub.Results.LastOrDefault();
+        var middleBandResult = _middleBandHub.Results[^1];
+        var stdDevResult = _stdDevHub.Results[^1];
+        var fastMaResult = _fastMaHub.Results[^1];
+        var slowMaResult = _slowMaHub.Results[^1];
 
         // Calculate TDIGM bands using the hub results
         double? upper = null;

--- a/src/s-z/TdiGm/TdiGm.Utilities.cs
+++ b/src/s-z/TdiGm/TdiGm.Utilities.cs
@@ -22,10 +22,22 @@ public static partial class TdiGm
                 "RSI period must be greater than 0.");
         }
 
+        if (rsiPeriod > 250)
+        {
+            throw new ArgumentOutOfRangeException(nameof(rsiPeriod), rsiPeriod,
+                "RSI period must not exceed 250.");
+        }
+        
         if (bandLength <= 0)
         {
             throw new ArgumentOutOfRangeException(nameof(bandLength), bandLength,
                 "Band length must be greater than 0.");
+        }
+
+        if (bandLength > 250)
+        {
+            throw new ArgumentOutOfRangeException(nameof(bandLength), bandLength,
+                "Band length must not exceed 250.");
         }
 
         if (fastLength <= 0)
@@ -34,10 +46,22 @@ public static partial class TdiGm
                 "Fast length must be greater than 0.");
         }
 
+        if (fastLength > 250)
+        {
+            throw new ArgumentOutOfRangeException(nameof(fastLength), fastLength,
+                "Fast length must not exceed 250.");
+        }
+
         if (slowLength <= 0)
         {
             throw new ArgumentOutOfRangeException(nameof(slowLength), slowLength,
                 "Slow length must be greater than 0.");
+        }
+
+        if (slowLength > 250)
+        {
+            throw new ArgumentOutOfRangeException(nameof(slowLength), slowLength,
+                "Slow length must not exceed 250.");
         }
     }
 }

--- a/src/s-z/TdiGm/TdiGm.Utilities.cs
+++ b/src/s-z/TdiGm/TdiGm.Utilities.cs
@@ -1,0 +1,20 @@
+namespace Skender.Stock.Indicators;
+
+/// <summary>
+/// Provides utility methods for the TDI-GM indicator.
+/// </summary>
+public static partial class TdiGm
+{
+    /// <summary>
+    /// Validates the parameters for the TDI-GM calculation.
+    /// </summary>
+    internal static void Validate(
+        int rsiPeriod,
+        int bandLength,
+        int fastLength,
+        int slowLength
+        )
+    {
+        // check parameter arguments
+    }
+}

--- a/src/s-z/TdiGm/TdiGm.Utilities.cs
+++ b/src/s-z/TdiGm/TdiGm.Utilities.cs
@@ -16,5 +16,28 @@ public static partial class TdiGm
         )
     {
         // check parameter arguments
+        if (rsiPeriod <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(rsiPeriod), rsiPeriod,
+                "RSI period must be greater than 0.");
+        }
+
+        if (bandLength <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(bandLength), bandLength,
+                "Band length must be greater than 0.");
+        }
+
+        if (fastLength <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(fastLength), fastLength,
+                "Fast length must be greater than 0.");
+        }
+
+        if (slowLength <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(slowLength), slowLength,
+                "Slow length must be greater than 0.");
+        }
     }
 }


### PR DESCRIPTION
A posh RSI indicator with stddev bands and fast/slow ma's to track momentum.
The fast ma represents current aggression (takers).
The bands represent typical patience (makers).
You're looking for "sharkfins" = fast ma exceeds the volatility bands violently, lingers outside for a few bars, then reverses.

Notice that the fast ma's position within the bands tends to correlate with the stochastic rsi.
When the fast ma touches the lower band, stochastic will be toward 0.
When the fast ma touches the upper band, stochastic will be toward 100.
Fast ma reverts to the slow ma.
Slow ma reverts to the middle of the bands.
All three revert towards 50%.

The streamhub variant offloads most of the implementation onto your hubs! Very cool.