### PR TITLE
feat: Extend `Use()` adapter

### DIFF
--- a/src/_common/Candles/Candles.Utilities.cs
+++ b/src/_common/Candles/Candles.Utilities.cs
@@ -6,6 +6,28 @@ namespace Skender.Stock.Indicators;
 public static class Candlesticks
 {
     /// <summary>
+    /// Converts Candle results to a chainable list using the Price field.
+    /// </summary>
+    /// <param name="results">The list of Candle results.</param>
+    /// <returns>A list of chainable values.</returns>
+    public static IReadOnlyList<QuotePart> Use(
+        this IReadOnlyList<CandleResult> results)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+        int length = results.Count;
+        List<QuotePart> list = new(length);
+
+        for (int i = 0; i < length; i++)
+        {
+            CandleResult r = results[i];
+            double value = (double?)r.Price ?? double.NaN;
+            list.Add(new QuotePart(r.Timestamp, value));
+        }
+
+        return list;
+    }
+
+    /// <summary>
     /// Condenses the list of candle results by filtering out those with no match.
     /// </summary>
     /// <param name="candleResults">The list of candle results to condense.</param>

--- a/src/_common/QuotePart/QuotePart.StaticSeries.cs
+++ b/src/_common/QuotePart/QuotePart.StaticSeries.cs
@@ -30,14 +30,4 @@ public static partial class QuoteParts
 
         return result;
     }
-
-    /// <inheritdoc cref="ToQuotePart(IReadOnlyList{IQuote}, CandlePart)"/>
-    /// <remarks>This is an alias of <see cref="ToQuotePartList(IReadOnlyList{IQuote}, CandlePart)"/></remarks>
-    public static IReadOnlyList<QuotePart> Use(
-        this IReadOnlyList<IQuote> quotes,
-        CandlePart candlePart)
-        => quotes.ToQuotePart(candlePart);
-
-    // TODO: should we deprecate Use in favor of "ToQuotePart"?
-    // Probably not, this is a fairly simple alias.
 }

--- a/src/_common/QuotePart/UseExtensions.cs
+++ b/src/_common/QuotePart/UseExtensions.cs
@@ -4,7 +4,7 @@ public static class UseExtensions
 {
     /// <inheritdoc cref="ToQuotePart(IReadOnlyList{IQuote}, CandlePart)"/>
     /// <remarks>This is an alias of <see cref="ToQuotePartList(IReadOnlyList{IQuote}, CandlePart)"/></remarks>
-    public static IReadOnlyList<QuotePart> Use(
+    public static IReadOnlyList<ISeries> Use(
         this IReadOnlyList<IQuote> quotes,
         CandlePart candlePart)
         => quotes.ToQuotePart(candlePart);

--- a/src/_common/QuotePart/UseExtensions.cs
+++ b/src/_common/QuotePart/UseExtensions.cs
@@ -1,0 +1,6 @@
+namespace Skender.Stock.Indicators;
+
+public static class UseExtensions
+{
+  // move QuotePart o
+}

--- a/src/_common/QuotePart/UseExtensions.cs
+++ b/src/_common/QuotePart/UseExtensions.cs
@@ -2,5 +2,10 @@ namespace Skender.Stock.Indicators;
 
 public static class UseExtensions
 {
-  // move QuotePart o
+    /// <inheritdoc cref="ToQuotePart(IReadOnlyList{IQuote}, CandlePart)"/>
+    /// <remarks>This is an alias of <see cref="ToQuotePartList(IReadOnlyList{IQuote}, CandlePart)"/></remarks>
+    public static IReadOnlyList<QuotePart> Use(
+        this IReadOnlyList<IQuote> quotes,
+        CandlePart candlePart)
+        => quotes.ToQuotePart(candlePart);
 }

--- a/src/_common/QuotePart/UseExtensions.cs
+++ b/src/_common/QuotePart/UseExtensions.cs
@@ -4,7 +4,7 @@ public static class UseExtensions
 {
     /// <inheritdoc cref="ToQuotePart(IReadOnlyList{IQuote}, CandlePart)"/>
     /// <remarks>This is an alias of <see cref="ToQuotePartList(IReadOnlyList{IQuote}, CandlePart)"/></remarks>
-    public static IReadOnlyList<ISeries> Use(
+    public static IReadOnlyList<IReusable> Use(
         this IReadOnlyList<IQuote> quotes,
         CandlePart candlePart)
         => quotes.ToQuotePart(candlePart);

--- a/src/a-d/Alligator/Alligator.Enums.cs
+++ b/src/a-d/Alligator/Alligator.Enums.cs
@@ -1,0 +1,22 @@
+namespace Skender.Stock.Indicators;
+
+/// <summary>
+/// Field selection for Alligator indicator.
+/// </summary>
+public enum AlligatorLine
+{
+    /// <summary>
+    /// Jaw line (blue line, 13-period SMMA shifted 8 periods forward).
+    /// </summary>
+    Jaw = 0,
+
+    /// <summary>
+    /// Teeth line (red line, 8-period SMMA shifted 5 periods forward).
+    /// </summary>
+    Teeth = 1,
+
+    /// <summary>
+    /// Lips line (green line, 5-period SMMA shifted 3 periods forward).
+    /// </summary>
+    Lips = 2
+}

--- a/src/a-d/Alligator/Alligator.Utilities.cs
+++ b/src/a-d/Alligator/Alligator.Utilities.cs
@@ -6,6 +6,37 @@ namespace Skender.Stock.Indicators;
 public static partial class Alligator
 {
     /// <summary>
+    /// Converts Alligator results to a chainable list using the specified line.
+    /// </summary>
+    /// <param name="results">The list of Alligator results.</param>
+    /// <param name="line">The Alligator line to use for chaining.</param>
+    /// <returns>A list of chainable values.</returns>
+    public static IReadOnlyList<QuotePart> Use(
+        this IReadOnlyList<AlligatorResult> results,
+        AlligatorLine line = AlligatorLine.Jaw)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+        int length = results.Count;
+        List<QuotePart> list = new(length);
+
+        for (int i = 0; i < length; i++)
+        {
+            AlligatorResult r = results[i];
+
+            double value = line switch {
+                AlligatorLine.Jaw => r.Jaw.Null2NaN(),
+                AlligatorLine.Teeth => r.Teeth.Null2NaN(),
+                AlligatorLine.Lips => r.Lips.Null2NaN(),
+                _ => throw new ArgumentOutOfRangeException(nameof(line), line, "Invalid line provided.")
+            };
+
+            list.Add(new QuotePart(r.Timestamp, value));
+        }
+
+        return list;
+    }
+
+    /// <summary>
     /// Removes non-essential records containing null values for Jaw, Teeth, and Lips.
     /// </summary>
     /// <param name="results">The Alligator results to evaluate.</param>

--- a/src/a-d/AtrStop/AtrStop.Enums.cs
+++ b/src/a-d/AtrStop/AtrStop.Enums.cs
@@ -1,0 +1,27 @@
+namespace Skender.Stock.Indicators;
+
+/// <summary>
+/// Field selection for ATR Trailing Stop indicator.
+/// </summary>
+public enum AtrStopField
+{
+    /// <summary>
+    /// ATR Trailing Stop value.
+    /// </summary>
+    AtrStop = 0,
+
+    /// <summary>
+    /// Buy stop value.
+    /// </summary>
+    BuyStop = 1,
+
+    /// <summary>
+    /// Sell stop value.
+    /// </summary>
+    SellStop = 2,
+
+    /// <summary>
+    /// ATR value.
+    /// </summary>
+    Atr = 3
+}

--- a/src/a-d/AtrStop/AtrStop.Utilities.cs
+++ b/src/a-d/AtrStop/AtrStop.Utilities.cs
@@ -6,6 +6,38 @@ namespace Skender.Stock.Indicators;
 public static partial class AtrStop
 {
     /// <summary>
+    /// Converts ATR Trailing Stop results to a chainable list using the specified field.
+    /// </summary>
+    /// <param name="results">The list of ATR Trailing Stop results.</param>
+    /// <param name="field">The field to use for chaining.</param>
+    /// <returns>A list of chainable values.</returns>
+    public static IReadOnlyList<QuotePart> Use(
+        this IReadOnlyList<AtrStopResult> results,
+        AtrStopField field = AtrStopField.AtrStop)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+        int length = results.Count;
+        List<QuotePart> list = new(length);
+
+        for (int i = 0; i < length; i++)
+        {
+            AtrStopResult r = results[i];
+
+            double value = field switch {
+                AtrStopField.AtrStop => r.AtrStop.Null2NaN(),
+                AtrStopField.BuyStop => r.BuyStop.Null2NaN(),
+                AtrStopField.SellStop => r.SellStop.Null2NaN(),
+                AtrStopField.Atr => r.Atr.Null2NaN(),
+                _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Invalid field provided.")
+            };
+
+            list.Add(new QuotePart(r.Timestamp, value));
+        }
+
+        return list;
+    }
+
+    /// <summary>
     /// Removes empty (null) periods from the ATR Trailing Stop results.
     /// </summary>
     /// <param name="results">The list of ATR Trailing Stop results.</param>

--- a/src/a-d/Donchian/Donchian.Enums.cs
+++ b/src/a-d/Donchian/Donchian.Enums.cs
@@ -1,0 +1,27 @@
+namespace Skender.Stock.Indicators;
+
+/// <summary>
+/// Field selection for Donchian Channel indicator.
+/// </summary>
+public enum DonchianField
+{
+    /// <summary>
+    /// Centerline (middle band).
+    /// </summary>
+    Centerline = 0,
+
+    /// <summary>
+    /// Upper band.
+    /// </summary>
+    UpperBand = 1,
+
+    /// <summary>
+    /// Lower band.
+    /// </summary>
+    LowerBand = 2,
+
+    /// <summary>
+    /// Width (difference between upper and lower bands).
+    /// </summary>
+    Width = 3
+}

--- a/src/a-d/Donchian/Donchian.Utilities.cs
+++ b/src/a-d/Donchian/Donchian.Utilities.cs
@@ -6,6 +6,38 @@ namespace Skender.Stock.Indicators;
 public static partial class Donchian
 {
     /// <summary>
+    /// Converts Donchian Channel results to a chainable list using the specified field.
+    /// </summary>
+    /// <param name="results">The list of Donchian Channel results.</param>
+    /// <param name="field">The field to use for chaining.</param>
+    /// <returns>A list of chainable values.</returns>
+    public static IReadOnlyList<QuotePart> Use(
+        this IReadOnlyList<DonchianResult> results,
+        DonchianField field = DonchianField.Centerline)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+        int length = results.Count;
+        List<QuotePart> list = new(length);
+
+        for (int i = 0; i < length; i++)
+        {
+            DonchianResult r = results[i];
+
+            double value = field switch {
+                DonchianField.UpperBand => (double?)r.UpperBand ?? double.NaN,
+                DonchianField.Centerline => (double?)r.Centerline ?? double.NaN,
+                DonchianField.LowerBand => (double?)r.LowerBand ?? double.NaN,
+                DonchianField.Width => (double?)r.Width ?? double.NaN,
+                _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Invalid field provided.")
+            };
+
+            list.Add(new QuotePart(r.Timestamp, value));
+        }
+
+        return list;
+    }
+
+    /// <summary>
     /// Removes empty (null) periods from the Donchian Channel results.
     /// </summary>
     /// <inheritdoc cref="Reusable.Condense{T}(IReadOnlyList{T})"/>

--- a/src/e-k/Fcb/Fcb.Enums.cs
+++ b/src/e-k/Fcb/Fcb.Enums.cs
@@ -1,0 +1,17 @@
+namespace Skender.Stock.Indicators;
+
+/// <summary>
+/// Field selection for FCB (Fractal Chaos Bands) indicator.
+/// </summary>
+public enum FcbField
+{
+    /// <summary>
+    /// Upper band.
+    /// </summary>
+    UpperBand = 0,
+
+    /// <summary>
+    /// Lower band.
+    /// </summary>
+    LowerBand = 1
+}

--- a/src/e-k/Fcb/Fcb.Utilities.cs
+++ b/src/e-k/Fcb/Fcb.Utilities.cs
@@ -6,6 +6,36 @@ namespace Skender.Stock.Indicators;
 public static partial class Fcb
 {
     /// <summary>
+    /// Converts FCB results to a chainable list using the specified field.
+    /// </summary>
+    /// <param name="results">The list of FCB results.</param>
+    /// <param name="field">The field to use for chaining.</param>
+    /// <returns>A list of chainable values.</returns>
+    public static IReadOnlyList<QuotePart> Use(
+        this IReadOnlyList<FcbResult> results,
+        FcbField field = FcbField.UpperBand)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+        int length = results.Count;
+        List<QuotePart> list = new(length);
+
+        for (int i = 0; i < length; i++)
+        {
+            FcbResult r = results[i];
+
+            double value = field switch {
+                FcbField.UpperBand => (double?)r.UpperBand ?? double.NaN,
+                FcbField.LowerBand => (double?)r.LowerBand ?? double.NaN,
+                _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Invalid field provided.")
+            };
+
+            list.Add(new QuotePart(r.Timestamp, value));
+        }
+
+        return list;
+    }
+
+    /// <summary>
     /// Removes empty (null) periods from the FCB results.
     /// </summary>
     /// <inheritdoc cref="Reusable.Condense{T}(IReadOnlyList{T})"/>

--- a/src/e-k/Fractal/Fractal.Enums.cs
+++ b/src/e-k/Fractal/Fractal.Enums.cs
@@ -1,0 +1,17 @@
+namespace Skender.Stock.Indicators;
+
+/// <summary>
+/// Side selection for Fractal indicator.
+/// </summary>
+public enum FractalSide
+{
+    /// <summary>
+    /// Bear fractal (resistance).
+    /// </summary>
+    Bear = 0,
+
+    /// <summary>
+    /// Bull fractal (support).
+    /// </summary>
+    Bull = 1
+}

--- a/src/e-k/Fractal/Fractal.Utilities.cs
+++ b/src/e-k/Fractal/Fractal.Utilities.cs
@@ -6,6 +6,36 @@ namespace Skender.Stock.Indicators;
 public static partial class Fractal
 {
     /// <summary>
+    /// Converts Fractal results to a chainable list using the specified side.
+    /// </summary>
+    /// <param name="results">The list of Fractal results.</param>
+    /// <param name="side">The fractal side to use for chaining.</param>
+    /// <returns>A list of chainable values.</returns>
+    public static IReadOnlyList<QuotePart> Use(
+        this IReadOnlyList<FractalResult> results,
+        FractalSide side = FractalSide.Bear)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+        int length = results.Count;
+        List<QuotePart> list = new(length);
+
+        for (int i = 0; i < length; i++)
+        {
+            FractalResult r = results[i];
+
+            double value = side switch {
+                FractalSide.Bear => (double?)r.FractalBear ?? double.NaN,
+                FractalSide.Bull => (double?)r.FractalBull ?? double.NaN,
+                _ => throw new ArgumentOutOfRangeException(nameof(side), side, "Invalid side provided.")
+            };
+
+            list.Add(new QuotePart(r.Timestamp, value));
+        }
+
+        return list;
+    }
+
+    /// <summary>
     /// Removes empty (null) periods from the Fractal results.
     /// </summary>
     /// <inheritdoc cref="Reusable.Condense{T}(IReadOnlyList{T})"/>

--- a/src/e-k/Gator/Gator.Enums.cs
+++ b/src/e-k/Gator/Gator.Enums.cs
@@ -1,0 +1,17 @@
+namespace Skender.Stock.Indicators;
+
+/// <summary>
+/// Side selection for Gator Oscillator indicator.
+/// </summary>
+public enum GatorSide
+{
+    /// <summary>
+    /// Upper histogram (distance between Jaw and Teeth).
+    /// </summary>
+    Upper = 0,
+
+    /// <summary>
+    /// Lower histogram (distance between Teeth and Lips).
+    /// </summary>
+    Lower = 1
+}

--- a/src/e-k/Gator/Gator.Utilities.cs
+++ b/src/e-k/Gator/Gator.Utilities.cs
@@ -6,6 +6,36 @@ namespace Skender.Stock.Indicators;
 public static partial class Gator
 {
     /// <summary>
+    /// Converts Gator Oscillator results to a chainable list using the specified side.
+    /// </summary>
+    /// <param name="results">The list of Gator Oscillator results.</param>
+    /// <param name="side">The histogram side to use for chaining.</param>
+    /// <returns>A list of chainable values.</returns>
+    public static IReadOnlyList<QuotePart> Use(
+        this IReadOnlyList<GatorResult> results,
+        GatorSide side = GatorSide.Upper)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+        int length = results.Count;
+        List<QuotePart> list = new(length);
+
+        for (int i = 0; i < length; i++)
+        {
+            GatorResult r = results[i];
+
+            double value = side switch {
+                GatorSide.Upper => r.Upper.Null2NaN(),
+                GatorSide.Lower => r.Lower.Null2NaN(),
+                _ => throw new ArgumentOutOfRangeException(nameof(side), side, "Invalid side provided.")
+            };
+
+            list.Add(new QuotePart(r.Timestamp, value));
+        }
+
+        return list;
+    }
+
+    /// <summary>
     /// Removes empty (null) periods from the Gator Oscillator results.
     /// </summary>
     /// <inheritdoc cref="Reusable.Condense{T}(IReadOnlyList{T})"/>

--- a/src/e-k/Ichimoku/Ichimoku.Enums.cs
+++ b/src/e-k/Ichimoku/Ichimoku.Enums.cs
@@ -1,0 +1,32 @@
+namespace Skender.Stock.Indicators;
+
+/// <summary>
+/// Line selection for Ichimoku Cloud indicator.
+/// </summary>
+public enum IchimokuLine
+{
+    /// <summary>
+    /// Tenkan-sen (Conversion Line) - 9-period midpoint.
+    /// </summary>
+    TenkanSen = 0,
+
+    /// <summary>
+    /// Kijun-sen (Base Line) - 26-period midpoint.
+    /// </summary>
+    KijunSen = 1,
+
+    /// <summary>
+    /// Senkou Span A (Leading Span A) - average of Tenkan and Kijun, projected forward.
+    /// </summary>
+    SenkouSpanA = 2,
+
+    /// <summary>
+    /// Senkou Span B (Leading Span B) - 52-period midpoint, projected forward.
+    /// </summary>
+    SenkouSpanB = 3,
+
+    /// <summary>
+    /// Chikou Span (Lagging Span) - Close price projected backwards.
+    /// </summary>
+    ChikouSpan = 4
+}

--- a/src/e-k/Ichimoku/Ichimoku.Utilities.cs
+++ b/src/e-k/Ichimoku/Ichimoku.Utilities.cs
@@ -6,6 +6,39 @@ namespace Skender.Stock.Indicators;
 public static partial class Ichimoku
 {
     /// <summary>
+    /// Converts Ichimoku Cloud results to a chainable list using the specified line.
+    /// </summary>
+    /// <param name="results">The list of Ichimoku Cloud results.</param>
+    /// <param name="line">The Ichimoku line to use for chaining.</param>
+    /// <returns>A list of chainable values.</returns>
+    public static IReadOnlyList<QuotePart> Use(
+        this IReadOnlyList<IchimokuResult> results,
+        IchimokuLine line = IchimokuLine.TenkanSen)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+        int length = results.Count;
+        List<QuotePart> list = new(length);
+
+        for (int i = 0; i < length; i++)
+        {
+            IchimokuResult r = results[i];
+
+            double value = line switch {
+                IchimokuLine.TenkanSen => (double?)r.TenkanSen ?? double.NaN,
+                IchimokuLine.KijunSen => (double?)r.KijunSen ?? double.NaN,
+                IchimokuLine.SenkouSpanA => (double?)r.SenkouSpanA ?? double.NaN,
+                IchimokuLine.SenkouSpanB => (double?)r.SenkouSpanB ?? double.NaN,
+                IchimokuLine.ChikouSpan => (double?)r.ChikouSpan ?? double.NaN,
+                _ => throw new ArgumentOutOfRangeException(nameof(line), line, "Invalid line provided.")
+            };
+
+            list.Add(new QuotePart(r.Timestamp, value));
+        }
+
+        return list;
+    }
+
+    /// <summary>
     /// Removes empty (null) periods from the Ichimoku Cloud results.
     /// </summary>
     /// <param name="results">The list of Ichimoku Cloud results to condense.</param>

--- a/src/e-k/Keltner/Keltner.Enums.cs
+++ b/src/e-k/Keltner/Keltner.Enums.cs
@@ -1,0 +1,27 @@
+namespace Skender.Stock.Indicators;
+
+/// <summary>
+/// Field selection for Keltner Channel indicator.
+/// </summary>
+public enum KeltnerField
+{
+    /// <summary>
+    /// Centerline (moving average).
+    /// </summary>
+    Centerline = 0,
+
+    /// <summary>
+    /// Upper band.
+    /// </summary>
+    UpperBand = 1,
+
+    /// <summary>
+    /// Lower band.
+    /// </summary>
+    LowerBand = 2,
+
+    /// <summary>
+    /// Width (difference between upper and lower bands).
+    /// </summary>
+    Width = 3
+}

--- a/src/e-k/Keltner/Keltner.Utilities.cs
+++ b/src/e-k/Keltner/Keltner.Utilities.cs
@@ -6,6 +6,38 @@ namespace Skender.Stock.Indicators;
 public static partial class Keltner
 {
     /// <summary>
+    /// Converts Keltner Channel results to a chainable list using the specified field.
+    /// </summary>
+    /// <param name="results">The list of Keltner Channel results.</param>
+    /// <param name="field">The field to use for chaining.</param>
+    /// <returns>A list of chainable values.</returns>
+    public static IReadOnlyList<QuotePart> Use(
+        this IReadOnlyList<KeltnerResult> results,
+        KeltnerField field = KeltnerField.Centerline)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+        int length = results.Count;
+        List<QuotePart> list = new(length);
+
+        for (int i = 0; i < length; i++)
+        {
+            KeltnerResult r = results[i];
+
+            double value = field switch {
+                KeltnerField.UpperBand => r.UpperBand.Null2NaN(),
+                KeltnerField.Centerline => r.Centerline.Null2NaN(),
+                KeltnerField.LowerBand => r.LowerBand.Null2NaN(),
+                KeltnerField.Width => r.Width.Null2NaN(),
+                _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Invalid field provided.")
+            };
+
+            list.Add(new QuotePart(r.Timestamp, value));
+        }
+
+        return list;
+    }
+
+    /// <summary>
     /// Removes empty (null) periods from the Keltner Channel results.
     /// </summary>
     /// <param name="results">The list of Keltner Channel results to condense.</param>

--- a/src/m-r/MaEnvelopes/MaEnvelopes.Enums.cs
+++ b/src/m-r/MaEnvelopes/MaEnvelopes.Enums.cs
@@ -1,0 +1,22 @@
+namespace Skender.Stock.Indicators;
+
+/// <summary>
+/// Field selection for Moving Average Envelope indicator.
+/// </summary>
+public enum MaEnvelopeField
+{
+    /// <summary>
+    /// Centerline (moving average).
+    /// </summary>
+    Centerline = 0,
+
+    /// <summary>
+    /// Upper envelope.
+    /// </summary>
+    UpperEnvelope = 1,
+
+    /// <summary>
+    /// Lower envelope.
+    /// </summary>
+    LowerEnvelope = 2
+}

--- a/src/m-r/MaEnvelopes/MaEnvelopes.Utilities.cs
+++ b/src/m-r/MaEnvelopes/MaEnvelopes.Utilities.cs
@@ -6,6 +6,37 @@ namespace Skender.Stock.Indicators;
 public static partial class MaEnvelopes
 {
     /// <summary>
+    /// Converts Moving Average Envelope results to a chainable list using the specified field.
+    /// </summary>
+    /// <param name="results">The list of Moving Average Envelope results.</param>
+    /// <param name="field">The field to use for chaining.</param>
+    /// <returns>A list of chainable values.</returns>
+    public static IReadOnlyList<QuotePart> Use(
+        this IReadOnlyList<MaEnvelopeResult> results,
+        MaEnvelopeField field = MaEnvelopeField.Centerline)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+        int length = results.Count;
+        List<QuotePart> list = new(length);
+
+        for (int i = 0; i < length; i++)
+        {
+            MaEnvelopeResult r = results[i];
+
+            double value = field switch {
+                MaEnvelopeField.Centerline => r.Centerline.Null2NaN(),
+                MaEnvelopeField.UpperEnvelope => r.UpperEnvelope.Null2NaN(),
+                MaEnvelopeField.LowerEnvelope => r.LowerEnvelope.Null2NaN(),
+                _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Invalid field provided.")
+            };
+
+            list.Add(new QuotePart(r.Timestamp, value));
+        }
+
+        return list;
+    }
+
+    /// <summary>
     /// Removes empty (null) periods from the Moving Average Envelope results.
     /// </summary>
     /// <param name="results">The list of Moving Average Envelope results.</param>

--- a/src/m-r/PivotPoints/PivotPoints.Enums.cs
+++ b/src/m-r/PivotPoints/PivotPoints.Enums.cs
@@ -1,0 +1,52 @@
+namespace Skender.Stock.Indicators;
+
+/// <summary>
+/// Field selection for Pivot Points indicator.
+/// </summary>
+public enum PivotField
+{
+    /// <summary>
+    /// Pivot Point.
+    /// </summary>
+    PP = 0,
+
+    /// <summary>
+    /// First support level.
+    /// </summary>
+    S1 = 1,
+
+    /// <summary>
+    /// Second support level.
+    /// </summary>
+    S2 = 2,
+
+    /// <summary>
+    /// Third support level.
+    /// </summary>
+    S3 = 3,
+
+    /// <summary>
+    /// Fourth support level.
+    /// </summary>
+    S4 = 4,
+
+    /// <summary>
+    /// First resistance level.
+    /// </summary>
+    R1 = 5,
+
+    /// <summary>
+    /// Second resistance level.
+    /// </summary>
+    R2 = 6,
+
+    /// <summary>
+    /// Third resistance level.
+    /// </summary>
+    R3 = 7,
+
+    /// <summary>
+    /// Fourth resistance level.
+    /// </summary>
+    R4 = 8
+}

--- a/src/m-r/PivotPoints/PivotPoints.Utilities.cs
+++ b/src/m-r/PivotPoints/PivotPoints.Utilities.cs
@@ -20,6 +20,43 @@ public static partial class PivotPoints
         = invariantCulture.DateTimeFormat.FirstDayOfWeek;
 
     /// <summary>
+    /// Converts Pivot Points results to a chainable list using the specified field.
+    /// </summary>
+    /// <param name="results">The list of Pivot Points results.</param>
+    /// <param name="field">The field to use for chaining.</param>
+    /// <returns>A list of chainable values.</returns>
+    public static IReadOnlyList<QuotePart> Use(
+        this IReadOnlyList<PivotPointsResult> results,
+        PivotField field = PivotField.PP)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+        int length = results.Count;
+        List<QuotePart> list = new(length);
+
+        for (int i = 0; i < length; i++)
+        {
+            PivotPointsResult r = results[i];
+
+            double value = field switch {
+                PivotField.PP => (double?)r.PP ?? double.NaN,
+                PivotField.S1 => (double?)r.S1 ?? double.NaN,
+                PivotField.S2 => (double?)r.S2 ?? double.NaN,
+                PivotField.S3 => (double?)r.S3 ?? double.NaN,
+                PivotField.S4 => (double?)r.S4 ?? double.NaN,
+                PivotField.R1 => (double?)r.R1 ?? double.NaN,
+                PivotField.R2 => (double?)r.R2 ?? double.NaN,
+                PivotField.R3 => (double?)r.R3 ?? double.NaN,
+                PivotField.R4 => (double?)r.R4 ?? double.NaN,
+                _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Invalid field provided.")
+            };
+
+            list.Add(new QuotePart(r.Timestamp, value));
+        }
+
+        return list;
+    }
+
+    /// <summary>
     /// Removes the warmup periods from the pivot points results.
     /// </summary>
     /// <param name="results">The list of pivot points results.</param>

--- a/src/m-r/Pivots/Pivots.Enums.cs
+++ b/src/m-r/Pivots/Pivots.Enums.cs
@@ -1,0 +1,27 @@
+namespace Skender.Stock.Indicators;
+
+/// <summary>
+/// Field selection for Pivots indicator.
+/// </summary>
+public enum PivotPointField
+{
+    /// <summary>
+    /// High pivot point.
+    /// </summary>
+    HighPoint = 0,
+
+    /// <summary>
+    /// Low pivot point.
+    /// </summary>
+    LowPoint = 1,
+
+    /// <summary>
+    /// High line (connecting high points).
+    /// </summary>
+    HighLine = 2,
+
+    /// <summary>
+    /// Low line (connecting low points).
+    /// </summary>
+    LowLine = 3
+}

--- a/src/m-r/Pivots/Pivots.Utilities.cs
+++ b/src/m-r/Pivots/Pivots.Utilities.cs
@@ -6,6 +6,38 @@ namespace Skender.Stock.Indicators;
 public static partial class Pivots
 {
     /// <summary>
+    /// Converts Pivots results to a chainable list using the specified field.
+    /// </summary>
+    /// <param name="results">The list of Pivots results.</param>
+    /// <param name="field">The field to use for chaining.</param>
+    /// <returns>A list of chainable values.</returns>
+    public static IReadOnlyList<QuotePart> Use(
+        this IReadOnlyList<PivotsResult> results,
+        PivotPointField field = PivotPointField.HighPoint)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+        int length = results.Count;
+        List<QuotePart> list = new(length);
+
+        for (int i = 0; i < length; i++)
+        {
+            PivotsResult r = results[i];
+
+            double value = field switch {
+                PivotPointField.HighPoint => (double?)r.HighPoint ?? double.NaN,
+                PivotPointField.LowPoint => (double?)r.LowPoint ?? double.NaN,
+                PivotPointField.HighLine => (double?)r.HighLine ?? double.NaN,
+                PivotPointField.LowLine => (double?)r.LowLine ?? double.NaN,
+                _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Invalid field provided.")
+            };
+
+            list.Add(new QuotePart(r.Timestamp, value));
+        }
+
+        return list;
+    }
+
+    /// <summary>
     /// Removes empty (null) periods from the pivot points results.
     /// </summary>
     /// <inheritdoc cref="Reusable.Condense{T}(IReadOnlyList{T})"/>

--- a/src/m-r/RollingPivots/RollingPivots.Utilities.cs
+++ b/src/m-r/RollingPivots/RollingPivots.Utilities.cs
@@ -6,6 +6,43 @@ namespace Skender.Stock.Indicators;
 public static partial class RollingPivots
 {
     /// <summary>
+    /// Converts Rolling Pivot Points results to a chainable list using the specified field.
+    /// </summary>
+    /// <param name="results">The list of Rolling Pivot Points results.</param>
+    /// <param name="field">The field to use for chaining.</param>
+    /// <returns>A list of chainable values.</returns>
+    public static IReadOnlyList<QuotePart> Use(
+        this IReadOnlyList<RollingPivotsResult> results,
+        PivotField field = PivotField.PP)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+        int length = results.Count;
+        List<QuotePart> list = new(length);
+
+        for (int i = 0; i < length; i++)
+        {
+            RollingPivotsResult r = results[i];
+
+            double value = field switch {
+                PivotField.PP => (double?)r.PP ?? double.NaN,
+                PivotField.S1 => (double?)r.S1 ?? double.NaN,
+                PivotField.S2 => (double?)r.S2 ?? double.NaN,
+                PivotField.S3 => (double?)r.S3 ?? double.NaN,
+                PivotField.S4 => (double?)r.S4 ?? double.NaN,
+                PivotField.R1 => (double?)r.R1 ?? double.NaN,
+                PivotField.R2 => (double?)r.R2 ?? double.NaN,
+                PivotField.R3 => (double?)r.R3 ?? double.NaN,
+                PivotField.R4 => (double?)r.R4 ?? double.NaN,
+                _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Invalid field provided.")
+            };
+
+            list.Add(new QuotePart(r.Timestamp, value));
+        }
+
+        return list;
+    }
+
+    /// <summary>
     /// Removes the recommended warmup periods from the Rolling Pivots results.
     /// </summary>
     /// <inheritdoc cref="Reusable.RemoveWarmupPeriods{T}(IReadOnlyList{T})"/>

--- a/src/s-z/StarcBands/StarcBands.Enums.cs
+++ b/src/s-z/StarcBands/StarcBands.Enums.cs
@@ -1,0 +1,22 @@
+namespace Skender.Stock.Indicators;
+
+/// <summary>
+/// Field selection for STARC Bands indicator.
+/// </summary>
+public enum StarcBandsField
+{
+    /// <summary>
+    /// Centerline (moving average).
+    /// </summary>
+    Centerline = 0,
+
+    /// <summary>
+    /// Upper band.
+    /// </summary>
+    UpperBand = 1,
+
+    /// <summary>
+    /// Lower band.
+    /// </summary>
+    LowerBand = 2
+}

--- a/src/s-z/StarcBands/StarcBands.Utilities.cs
+++ b/src/s-z/StarcBands/StarcBands.Utilities.cs
@@ -6,6 +6,37 @@ namespace Skender.Stock.Indicators;
 public static partial class StarcBands
 {
     /// <summary>
+    /// Converts STARC Bands results to a chainable list using the specified field.
+    /// </summary>
+    /// <param name="results">The list of STARC Bands results.</param>
+    /// <param name="field">The field to use for chaining.</param>
+    /// <returns>A list of chainable values.</returns>
+    public static IReadOnlyList<QuotePart> Use(
+        this IReadOnlyList<StarcBandsResult> results,
+        StarcBandsField field = StarcBandsField.Centerline)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+        int length = results.Count;
+        List<QuotePart> list = new(length);
+
+        for (int i = 0; i < length; i++)
+        {
+            StarcBandsResult r = results[i];
+
+            double value = field switch {
+                StarcBandsField.UpperBand => r.UpperBand.Null2NaN(),
+                StarcBandsField.Centerline => r.Centerline.Null2NaN(),
+                StarcBandsField.LowerBand => r.LowerBand.Null2NaN(),
+                _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Invalid field provided.")
+            };
+
+            list.Add(new QuotePart(r.Timestamp, value));
+        }
+
+        return list;
+    }
+
+    /// <summary>
     /// Removes empty (null) periods from the results.
     /// </summary>
     /// <param name="results">The list of STARC Bands results.</param>

--- a/src/s-z/StdDevChannels/StdDevChannels.Enums.cs
+++ b/src/s-z/StdDevChannels/StdDevChannels.Enums.cs
@@ -1,0 +1,22 @@
+namespace Skender.Stock.Indicators;
+
+/// <summary>
+/// Field selection for Standard Deviation Channels indicator.
+/// </summary>
+public enum StdDevChannelsField
+{
+    /// <summary>
+    /// Centerline (linear regression).
+    /// </summary>
+    Centerline = 0,
+
+    /// <summary>
+    /// Upper channel.
+    /// </summary>
+    UpperChannel = 1,
+
+    /// <summary>
+    /// Lower channel.
+    /// </summary>
+    LowerChannel = 2
+}

--- a/src/s-z/StdDevChannels/StdDevChannels.Utilities.cs
+++ b/src/s-z/StdDevChannels/StdDevChannels.Utilities.cs
@@ -6,6 +6,37 @@ namespace Skender.Stock.Indicators;
 public static partial class StdDevChannels
 {
     /// <summary>
+    /// Converts Standard Deviation Channels results to a chainable list using the specified field.
+    /// </summary>
+    /// <param name="results">The list of Standard Deviation Channels results.</param>
+    /// <param name="field">The field to use for chaining.</param>
+    /// <returns>A list of chainable values.</returns>
+    public static IReadOnlyList<QuotePart> Use(
+        this IReadOnlyList<StdDevChannelsResult> results,
+        StdDevChannelsField field = StdDevChannelsField.Centerline)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+        int length = results.Count;
+        List<QuotePart> list = new(length);
+
+        for (int i = 0; i < length; i++)
+        {
+            StdDevChannelsResult r = results[i];
+
+            double value = field switch {
+                StdDevChannelsField.Centerline => r.Centerline.Null2NaN(),
+                StdDevChannelsField.UpperChannel => r.UpperChannel.Null2NaN(),
+                StdDevChannelsField.LowerChannel => r.LowerChannel.Null2NaN(),
+                _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Invalid field provided.")
+            };
+
+            list.Add(new QuotePart(r.Timestamp, value));
+        }
+
+        return list;
+    }
+
+    /// <summary>
     /// Removes empty (null) periods from the results.
     /// </summary>
     /// <param name="results">The list of results to condense.</param>

--- a/src/s-z/SuperTrend/SuperTrend.Enums.cs
+++ b/src/s-z/SuperTrend/SuperTrend.Enums.cs
@@ -1,0 +1,22 @@
+namespace Skender.Stock.Indicators;
+
+/// <summary>
+/// Field selection for SuperTrend indicator.
+/// </summary>
+public enum SuperTrendField
+{
+    /// <summary>
+    /// SuperTrend value.
+    /// </summary>
+    SuperTrend = 0,
+
+    /// <summary>
+    /// Upper band.
+    /// </summary>
+    UpperBand = 1,
+
+    /// <summary>
+    /// Lower band.
+    /// </summary>
+    LowerBand = 2
+}

--- a/src/s-z/SuperTrend/SuperTrend.Utilities.cs
+++ b/src/s-z/SuperTrend/SuperTrend.Utilities.cs
@@ -6,6 +6,37 @@ namespace Skender.Stock.Indicators;
 public static partial class SuperTrend
 {
     /// <summary>
+    /// Converts SuperTrend results to a chainable list using the specified field.
+    /// </summary>
+    /// <param name="results">The list of SuperTrend results.</param>
+    /// <param name="field">The field to use for chaining.</param>
+    /// <returns>A list of chainable values.</returns>
+    public static IReadOnlyList<QuotePart> Use(
+        this IReadOnlyList<SuperTrendResult> results,
+        SuperTrendField field = SuperTrendField.SuperTrend)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+        int length = results.Count;
+        List<QuotePart> list = new(length);
+
+        for (int i = 0; i < length; i++)
+        {
+            SuperTrendResult r = results[i];
+
+            double value = field switch {
+                SuperTrendField.SuperTrend => (double?)r.SuperTrend ?? double.NaN,
+                SuperTrendField.UpperBand => (double?)r.UpperBand ?? double.NaN,
+                SuperTrendField.LowerBand => (double?)r.LowerBand ?? double.NaN,
+                _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Invalid field provided.")
+            };
+
+            list.Add(new QuotePart(r.Timestamp, value));
+        }
+
+        return list;
+    }
+
+    /// <summary>
     /// Removes empty (null) periods from the results.
     /// </summary>
     /// <param name="results">The list of SuperTrend results.</param>

--- a/src/s-z/Vortex/Vortex.Enums.cs
+++ b/src/s-z/Vortex/Vortex.Enums.cs
@@ -1,0 +1,17 @@
+namespace Skender.Stock.Indicators;
+
+/// <summary>
+/// Field selection for Vortex Indicator.
+/// </summary>
+public enum VortexField
+{
+    /// <summary>
+    /// Positive Vortex Indicator.
+    /// </summary>
+    Pvi = 0,
+
+    /// <summary>
+    /// Negative Vortex Indicator.
+    /// </summary>
+    Nvi = 1
+}

--- a/src/s-z/Vortex/Vortex.Utilities.cs
+++ b/src/s-z/Vortex/Vortex.Utilities.cs
@@ -5,6 +5,36 @@ namespace Skender.Stock.Indicators;
 /// </summary>
 public static partial class Vortex
 {
+    /// <summary>
+    /// Converts Vortex results to a chainable list using the specified field.
+    /// </summary>
+    /// <param name="results">The list of Vortex results.</param>
+    /// <param name="field">The field to use for chaining.</param>
+    /// <returns>A list of chainable values.</returns>
+    public static IReadOnlyList<QuotePart> Use(
+        this IReadOnlyList<VortexResult> results,
+        VortexField field = VortexField.Pvi)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+        int length = results.Count;
+        List<QuotePart> list = new(length);
+
+        for (int i = 0; i < length; i++)
+        {
+            VortexResult r = results[i];
+
+            double value = field switch {
+                VortexField.Pvi => r.Pvi.Null2NaN(),
+                VortexField.Nvi => r.Nvi.Null2NaN(),
+                _ => throw new ArgumentOutOfRangeException(nameof(field), field, "Invalid field provided.")
+            };
+
+            list.Add(new QuotePart(r.Timestamp, value));
+        }
+
+        return list;
+    }
+
     // remove empty (null) periods
     /// <summary>
     /// Condenses the Vortex results by removing periods with null values.

--- a/tests/indicators/_common/QuotePart/QuotePart.StaticSeries.Tests.cs
+++ b/tests/indicators/_common/QuotePart/QuotePart.StaticSeries.Tests.cs
@@ -7,16 +7,16 @@ public class QuoteParts : StaticSeriesTestBase
     public override void DefaultParameters_ReturnsExpectedResults()
     {
         // compose data
-        IReadOnlyList<QuotePart> o = Quotes.Use(CandlePart.Open);
-        IReadOnlyList<QuotePart> h = Quotes.Use(CandlePart.High);
-        IReadOnlyList<QuotePart> l = Quotes.Use(CandlePart.Low);
-        IReadOnlyList<QuotePart> c = Quotes.Use(CandlePart.Close);
-        IReadOnlyList<QuotePart> v = Quotes.Use(CandlePart.Volume);
-        IReadOnlyList<QuotePart> hl = Quotes.Use(CandlePart.HL2);
-        IReadOnlyList<QuotePart> hlc = Quotes.Use(CandlePart.HLC3);
-        IReadOnlyList<QuotePart> oc = Quotes.Use(CandlePart.OC2);
-        IReadOnlyList<QuotePart> ohl = Quotes.Use(CandlePart.OHL3);
-        IReadOnlyList<QuotePart> ohlc = Quotes.Use(CandlePart.OHLC4);
+        IReadOnlyList<QuotePart> o = (IReadOnlyList<QuotePart>)Quotes.Use(CandlePart.Open);
+        IReadOnlyList<QuotePart> h = (IReadOnlyList<QuotePart>)Quotes.Use(CandlePart.High);
+        IReadOnlyList<QuotePart> l = (IReadOnlyList<QuotePart>)Quotes.Use(CandlePart.Low);
+        IReadOnlyList<QuotePart> c = (IReadOnlyList<QuotePart>)Quotes.Use(CandlePart.Close);
+        IReadOnlyList<QuotePart> v = (IReadOnlyList<QuotePart>)Quotes.Use(CandlePart.Volume);
+        IReadOnlyList<QuotePart> hl = (IReadOnlyList<QuotePart>)Quotes.Use(CandlePart.HL2);
+        IReadOnlyList<QuotePart> hlc = (IReadOnlyList<QuotePart>)Quotes.Use(CandlePart.HLC3);
+        IReadOnlyList<QuotePart> oc = (IReadOnlyList<QuotePart>)Quotes.Use(CandlePart.OC2);
+        IReadOnlyList<QuotePart> ohl = (IReadOnlyList<QuotePart>)Quotes.Use(CandlePart.OHL3);
+        IReadOnlyList<QuotePart> ohlc = (IReadOnlyList<QuotePart>)Quotes.Use(CandlePart.OHLC4);
 
         // proper quantities
         c.Should().HaveCount(502);
@@ -65,7 +65,7 @@ public class QuoteParts : StaticSeriesTestBase
     [TestMethod]
     public override void BadQuotes_DoesNotFail()
     {
-        IReadOnlyList<QuotePart> r = BadQuotes
+        IReadOnlyList<QuotePart> r = (IReadOnlyList<QuotePart>)BadQuotes
             .Use(CandlePart.Close);
 
         r.Should().HaveCount(502);
@@ -75,12 +75,12 @@ public class QuoteParts : StaticSeriesTestBase
     [TestMethod]
     public override void NoQuotes_ReturnsEmpty()
     {
-        IReadOnlyList<QuotePart> r0 = Noquotes
+        IReadOnlyList<QuotePart> r0 = (IReadOnlyList<QuotePart>)Noquotes
             .Use(CandlePart.Close);
 
         r0.Should().BeEmpty();
 
-        IReadOnlyList<QuotePart> r1 = Onequote
+        IReadOnlyList<QuotePart> r1 = (IReadOnlyList<QuotePart>)Onequote
             .Use(CandlePart.Close);
 
         r1.Should().HaveCount(1);

--- a/tests/indicators/_common/QuotePart/QuotePart.StreamHub.Tests.cs
+++ b/tests/indicators/_common/QuotePart/QuotePart.StreamHub.Tests.cs
@@ -36,13 +36,13 @@ public class QuotePartHubTests : StreamHubTestBase, ITestQuoteObserver, ITestCha
         // late arrival, should equal series
         quoteHub.Insert(Quotes[80]);
 
-        IReadOnlyList<QuotePart> expectedOriginal = Quotes.Use(candlePart);
+        IReadOnlyList<QuotePart> expectedOriginal = (IReadOnlyList<QuotePart>)Quotes.Use(candlePart);
         sut.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
         quoteHub.Remove(Quotes[removeAtIndex]);
 
-        IReadOnlyList<QuotePart> expectedRevised = RevisedQuotes.Use(candlePart);
+        IReadOnlyList<QuotePart> expectedRevised = (IReadOnlyList<QuotePart>)RevisedQuotes.Use(candlePart);
 
         // assert, should equal series
         sut.Should().HaveCount(quotesCount - 1);

--- a/tests/indicators/_common/Use/Use.Utilities.Tests.cs
+++ b/tests/indicators/_common/Use/Use.Utilities.Tests.cs
@@ -1,0 +1,315 @@
+using Test.Data;
+
+namespace StaticSeries;
+
+[TestClass]
+public class UseUtilitiesTests
+{
+    private static IReadOnlyList<IQuote> Quotes => Data.GetDefault();
+
+    [TestMethod]
+    public void MaEnvelopes_Use_ReturnsChainableValues()
+    {
+        // Calculate MA Envelopes
+        IReadOnlyList<MaEnvelopeResult> results = Quotes.ToMaEnvelopes(20, 2.5);
+
+        // Test each field
+        IReadOnlyList<QuotePart> centerline = results.Use(MaEnvelopeField.Centerline);
+        IReadOnlyList<QuotePart> upperEnvelope = results.Use(MaEnvelopeField.UpperEnvelope);
+        IReadOnlyList<QuotePart> lowerEnvelope = results.Use(MaEnvelopeField.LowerEnvelope);
+
+        // Assert proper count
+        centerline.Should().HaveCount(502);
+        upperEnvelope.Should().HaveCount(502);
+        lowerEnvelope.Should().HaveCount(502);
+
+        // Assert values are correct for non-null results
+        MaEnvelopeResult lastResult = results[501];
+        QuotePart lastCenterline = centerline[501];
+        QuotePart lastUpper = upperEnvelope[501];
+        QuotePart lastLower = lowerEnvelope[501];
+
+        lastCenterline.Value.Should().BeApproximately(lastResult.Centerline!.Value, 0.0001);
+        lastUpper.Value.Should().BeApproximately(lastResult.UpperEnvelope!.Value, 0.0001);
+        lastLower.Value.Should().BeApproximately(lastResult.LowerEnvelope!.Value, 0.0001);
+
+        // Assert default is Centerline
+        IReadOnlyList<QuotePart> defaultField = results.Use();
+        defaultField[501].Value.Should().Be(centerline[501].Value);
+    }
+
+    [TestMethod]
+    public void Alligator_Use_ReturnsChainableValues()
+    {
+        IReadOnlyList<AlligatorResult> results = Quotes.ToAlligator();
+
+        IReadOnlyList<QuotePart> jaw = results.Use(AlligatorLine.Jaw);
+        IReadOnlyList<QuotePart> teeth = results.Use(AlligatorLine.Teeth);
+        IReadOnlyList<QuotePart> lips = results.Use(AlligatorLine.Lips);
+
+        jaw.Should().HaveCount(502);
+        teeth.Should().HaveCount(502);
+        lips.Should().HaveCount(502);
+
+        // Verify non-null values match
+        AlligatorResult lastResult = results[501];
+        lastResult.Jaw.Should().NotBeNull();
+        jaw[501].Value.Should().BeApproximately(lastResult.Jaw!.Value, 0.0001);
+    }
+
+    [TestMethod]
+    public void AtrStop_Use_ReturnsChainableValues()
+    {
+        IReadOnlyList<AtrStopResult> results = Quotes.ToAtrStop(21, 3);
+
+        IReadOnlyList<QuotePart> atrStop = results.Use(AtrStopField.AtrStop);
+        IReadOnlyList<QuotePart> buyStop = results.Use(AtrStopField.BuyStop);
+        IReadOnlyList<QuotePart> sellStop = results.Use(AtrStopField.SellStop);
+        IReadOnlyList<QuotePart> atr = results.Use(AtrStopField.Atr);
+
+        atrStop.Should().HaveCount(502);
+        buyStop.Should().HaveCount(502);
+        sellStop.Should().HaveCount(502);
+        atr.Should().HaveCount(502);
+    }
+
+    [TestMethod]
+    public void Donchian_Use_ReturnsChainableValues()
+    {
+        IReadOnlyList<DonchianResult> results = Quotes.ToDonchian(20);
+
+        IReadOnlyList<QuotePart> centerline = results.Use(DonchianField.Centerline);
+        IReadOnlyList<QuotePart> upperBand = results.Use(DonchianField.UpperBand);
+        IReadOnlyList<QuotePart> lowerBand = results.Use(DonchianField.LowerBand);
+        IReadOnlyList<QuotePart> width = results.Use(DonchianField.Width);
+
+        centerline.Should().HaveCount(502);
+        upperBand.Should().HaveCount(502);
+        lowerBand.Should().HaveCount(502);
+        width.Should().HaveCount(502);
+
+        // Verify default is Centerline (enum value 0)
+        IReadOnlyList<QuotePart> defaultField = results.Use();
+        defaultField[501].Value.Should().Be(centerline[501].Value);
+    }
+
+    [TestMethod]
+    public void Fcb_Use_ReturnsChainableValues()
+    {
+        IReadOnlyList<FcbResult> results = Quotes.ToFcb(2);
+
+        IReadOnlyList<QuotePart> upperBand = results.Use(FcbField.UpperBand);
+        IReadOnlyList<QuotePart> lowerBand = results.Use(FcbField.LowerBand);
+
+        upperBand.Should().HaveCount(502);
+        lowerBand.Should().HaveCount(502);
+    }
+
+    [TestMethod]
+    public void Fractal_Use_ReturnsChainableValues()
+    {
+        IReadOnlyList<FractalResult> results = Quotes.ToFractal(5);
+
+        IReadOnlyList<QuotePart> bear = results.Use(FractalSide.Bear);
+        IReadOnlyList<QuotePart> bull = results.Use(FractalSide.Bull);
+
+        bear.Should().HaveCount(502);
+        bull.Should().HaveCount(502);
+    }
+
+    [TestMethod]
+    public void Gator_Use_ReturnsChainableValues()
+    {
+        IReadOnlyList<GatorResult> results = Quotes.ToGator();
+
+        IReadOnlyList<QuotePart> upper = results.Use(GatorSide.Upper);
+        IReadOnlyList<QuotePart> lower = results.Use(GatorSide.Lower);
+
+        upper.Should().HaveCount(502);
+        lower.Should().HaveCount(502);
+    }
+
+    [TestMethod]
+    public void Ichimoku_Use_ReturnsChainableValues()
+    {
+        IReadOnlyList<IchimokuResult> results = Quotes.ToIchimoku();
+
+        IReadOnlyList<QuotePart> tenkanSen = results.Use(IchimokuLine.TenkanSen);
+        IReadOnlyList<QuotePart> kijunSen = results.Use(IchimokuLine.KijunSen);
+        IReadOnlyList<QuotePart> senkouSpanA = results.Use(IchimokuLine.SenkouSpanA);
+        IReadOnlyList<QuotePart> senkouSpanB = results.Use(IchimokuLine.SenkouSpanB);
+        IReadOnlyList<QuotePart> chikouSpan = results.Use(IchimokuLine.ChikouSpan);
+
+        tenkanSen.Should().HaveCount(502);
+        kijunSen.Should().HaveCount(502);
+        senkouSpanA.Should().HaveCount(502);
+        senkouSpanB.Should().HaveCount(502);
+        chikouSpan.Should().HaveCount(502);
+    }
+
+    [TestMethod]
+    public void Keltner_Use_ReturnsChainableValues()
+    {
+        IReadOnlyList<KeltnerResult> results = Quotes.ToKeltner(20, 2, 10);
+
+        IReadOnlyList<QuotePart> centerline = results.Use(KeltnerField.Centerline);
+        IReadOnlyList<QuotePart> upperBand = results.Use(KeltnerField.UpperBand);
+        IReadOnlyList<QuotePart> lowerBand = results.Use(KeltnerField.LowerBand);
+        IReadOnlyList<QuotePart> width = results.Use(KeltnerField.Width);
+
+        centerline.Should().HaveCount(502);
+        upperBand.Should().HaveCount(502);
+        lowerBand.Should().HaveCount(502);
+        width.Should().HaveCount(502);
+
+        // Verify default is Centerline (enum value 0)
+        IReadOnlyList<QuotePart> defaultField = results.Use();
+        defaultField[501].Value.Should().Be(centerline[501].Value);
+    }
+
+    [TestMethod]
+    public void Pivots_Use_ReturnsChainableValues()
+    {
+        IReadOnlyList<PivotsResult> results = Quotes.ToPivots(2, 2, 20);
+
+        IReadOnlyList<QuotePart> highPoint = results.Use(PivotPointField.HighPoint);
+        IReadOnlyList<QuotePart> lowPoint = results.Use(PivotPointField.LowPoint);
+        IReadOnlyList<QuotePart> highLine = results.Use(PivotPointField.HighLine);
+        IReadOnlyList<QuotePart> lowLine = results.Use(PivotPointField.LowLine);
+
+        highPoint.Should().HaveCount(502);
+        lowPoint.Should().HaveCount(502);
+        highLine.Should().HaveCount(502);
+        lowLine.Should().HaveCount(502);
+    }
+
+    [TestMethod]
+    public void PivotPoints_Use_ReturnsChainableValues()
+    {
+        IReadOnlyList<PivotPointsResult> results = Quotes.ToPivotPoints(PeriodSize.Month, PivotPointType.Standard);
+
+        IReadOnlyList<QuotePart> pp = results.Use(PivotField.PP);
+        IReadOnlyList<QuotePart> s1 = results.Use(PivotField.S1);
+        IReadOnlyList<QuotePart> r1 = results.Use(PivotField.R1);
+
+        pp.Should().HaveCount(502);
+        s1.Should().HaveCount(502);
+        r1.Should().HaveCount(502);
+
+        // Verify default is PP (enum value 0)
+        IReadOnlyList<QuotePart> defaultField = results.Use();
+        defaultField[501].Value.Should().Be(pp[501].Value);
+    }
+
+    [TestMethod]
+    public void RollingPivots_Use_ReturnsChainableValues()
+    {
+        IReadOnlyList<RollingPivotsResult> results = Quotes.ToRollingPivots(11, 9, PivotPointType.Standard);
+
+        IReadOnlyList<QuotePart> pp = results.Use(PivotField.PP);
+        IReadOnlyList<QuotePart> s1 = results.Use(PivotField.S1);
+        IReadOnlyList<QuotePart> r1 = results.Use(PivotField.R1);
+
+        pp.Should().HaveCount(502);
+        s1.Should().HaveCount(502);
+        r1.Should().HaveCount(502);
+
+        // Verify default is PP (enum value 0)
+        IReadOnlyList<QuotePart> defaultField = results.Use();
+        defaultField[501].Value.Should().Be(pp[501].Value);
+    }
+
+    [TestMethod]
+    public void StarcBands_Use_ReturnsChainableValues()
+    {
+        IReadOnlyList<StarcBandsResult> results = Quotes.ToStarcBands(20, 2, 10);
+
+        IReadOnlyList<QuotePart> centerline = results.Use(StarcBandsField.Centerline);
+        IReadOnlyList<QuotePart> upperBand = results.Use(StarcBandsField.UpperBand);
+        IReadOnlyList<QuotePart> lowerBand = results.Use(StarcBandsField.LowerBand);
+
+        centerline.Should().HaveCount(502);
+        upperBand.Should().HaveCount(502);
+        lowerBand.Should().HaveCount(502);
+
+        // Verify default is Centerline (enum value 0)
+        IReadOnlyList<QuotePart> defaultField = results.Use();
+        defaultField[501].Value.Should().Be(centerline[501].Value);
+    }
+
+    [TestMethod]
+    public void StdDevChannels_Use_ReturnsChainableValues()
+    {
+        IReadOnlyList<StdDevChannelsResult> results = Quotes.ToStdDevChannels(20, 2);
+
+        IReadOnlyList<QuotePart> centerline = results.Use(StdDevChannelsField.Centerline);
+        IReadOnlyList<QuotePart> upperChannel = results.Use(StdDevChannelsField.UpperChannel);
+        IReadOnlyList<QuotePart> lowerChannel = results.Use(StdDevChannelsField.LowerChannel);
+
+        centerline.Should().HaveCount(502);
+        upperChannel.Should().HaveCount(502);
+        lowerChannel.Should().HaveCount(502);
+
+        // Verify default is Centerline (enum value 0)
+        IReadOnlyList<QuotePart> defaultField = results.Use();
+        defaultField[501].Value.Should().Be(centerline[501].Value);
+    }
+
+    [TestMethod]
+    public void SuperTrend_Use_ReturnsChainableValues()
+    {
+        IReadOnlyList<SuperTrendResult> results = Quotes.ToSuperTrend(10, 3);
+
+        IReadOnlyList<QuotePart> superTrend = results.Use(SuperTrendField.SuperTrend);
+        IReadOnlyList<QuotePart> upperBand = results.Use(SuperTrendField.UpperBand);
+        IReadOnlyList<QuotePart> lowerBand = results.Use(SuperTrendField.LowerBand);
+
+        superTrend.Should().HaveCount(502);
+        upperBand.Should().HaveCount(502);
+        lowerBand.Should().HaveCount(502);
+
+        // Verify default is SuperTrend (enum value 0)
+        IReadOnlyList<QuotePart> defaultField = results.Use();
+        defaultField[501].Value.Should().Be(superTrend[501].Value);
+    }
+
+    [TestMethod]
+    public void Vortex_Use_ReturnsChainableValues()
+    {
+        IReadOnlyList<VortexResult> results = Quotes.ToVortex(14);
+
+        IReadOnlyList<QuotePart> pvi = results.Use(VortexField.Pvi);
+        IReadOnlyList<QuotePart> nvi = results.Use(VortexField.Nvi);
+
+        pvi.Should().HaveCount(502);
+        nvi.Should().HaveCount(502);
+    }
+
+    [TestMethod]
+    public void CandleResult_Use_ReturnsChainableValues()
+    {
+        IReadOnlyList<CandleResult> results = Quotes.ToMarubozu();
+
+        IReadOnlyList<QuotePart> prices = results.Use();
+
+        prices.Should().HaveCount(502);
+
+        // Verify Price field is extracted
+        CandleResult lastResult = results[501];
+        QuotePart lastPrice = prices[501];
+        lastPrice.Value.Should().Be((double?)lastResult.Price ?? double.NaN);
+    }
+
+    [TestMethod]
+    public void Use_CanBeChained()
+    {
+        // Test that Use() output can be chained to another indicator
+        IReadOnlyList<SmaResult> chainedResult = Quotes
+            .ToMaEnvelopes(20, 2.5)
+            .Use(MaEnvelopeField.Centerline)
+            .ToSma(10);
+
+        chainedResult.Should().HaveCount(502);
+        chainedResult.Where(static x => x.Sma != null).Should().NotBeEmpty();
+    }
+}

--- a/tests/public-api/indicators/PublicApi.Interface.Tests.cs
+++ b/tests/public-api/indicators/PublicApi.Interface.Tests.cs
@@ -109,7 +109,7 @@ public class UserInterface
         IReadOnlyList<AtrStopResult> staticAtrStop = quotes.ToAtrStop();
         IReadOnlyList<AlligatorResult> staticAlligator = quotes.ToAlligator();
         IReadOnlyList<EmaResult> staticEma = quotes.ToEma(20);
-        IReadOnlyList<QuotePart> staticQuotePart = quotes.Use(CandlePart.OHL3);
+        IReadOnlyList<QuotePart> staticQuotePart = (IReadOnlyList<QuotePart>)quotes.Use(CandlePart.OHL3);
         IReadOnlyList<SmaResult> staticSma = quotes.ToSma(20);
         IReadOnlyList<TrResult> staticTr = quotes.ToTr();
 


### PR DESCRIPTION
Expenses the `Use` extension utility to handle other ISeries types of indicator results that don’t have a natural.  Currently `quotes.Use(…)` only supports converting `IQuote` list types to `QuotePart` types.  This implements `series.Use(“my-property-name”)` for wider use.  We may need to rename `QuotePart` to `Reuseable`.

Related to:
- #1865 
- #1866 
- #1878
