### PR TITLE
feat: Add out variance to IStreamHub

### DIFF
--- a/src/_common/Candles/CandleResult.cs
+++ b/src/_common/Candles/CandleResult.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Represents the result of a candlestick analysis.
 /// </summary>
 [Serializable]
-public record CandleResult : ISeries
+public record CandleResult : IReusable
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="CandleResult"/> record.
@@ -64,4 +64,6 @@ public record CandleResult : ISeries
     /// Gets the candlestick properties.
     /// </summary>
     public CandleProperties Candle { get; init; }
+
+    public double Value => double.NaN;
 }

--- a/src/_common/StreamHub/IStreamHub.cs
+++ b/src/_common/StreamHub/IStreamHub.cs
@@ -1,14 +1,5 @@
 namespace Skender.Stock.Indicators;
 
-public interface IStreamHubBase<out TOut>
-    where TOut : IReusable
-{
-    /// <summary>
-    /// Read-only list of the stored cache values.
-    /// </summary>
-    IReadOnlyList<TOut> Results { get; }
-}
-
 /// <summary>
 /// Streaming hub: management of observer
 /// and observable indicator data

--- a/src/_common/StreamHub/IStreamHub.cs
+++ b/src/_common/StreamHub/IStreamHub.cs
@@ -20,7 +20,7 @@ public interface IStreamHubBase<out TOut>
 /// Type of outbound indicator data.
 /// </typeparam>
 public interface IStreamHub<in TIn, TOut> : IStreamHubBase<TOut>
-    where TIn : ISeries
+    where TIn : IReusable
     where TOut : IReusable
 {
     /// <summary>

--- a/src/_common/StreamHub/IStreamHub.cs
+++ b/src/_common/StreamHub/IStreamHub.cs
@@ -1,7 +1,7 @@
 namespace Skender.Stock.Indicators;
 
 public interface IStreamHubBase<out TOut>
-    where TOut : ISeries
+    where TOut : IReusable
 {
     /// <summary>
     /// Read-only list of the stored cache values.
@@ -21,7 +21,7 @@ public interface IStreamHubBase<out TOut>
 /// </typeparam>
 public interface IStreamHub<in TIn, TOut> : IStreamHubBase<TOut>
     where TIn : ISeries
-    where TOut : ISeries
+    where TOut : IReusable
 {
     /// <summary>
     /// The cache and provider failed and is no longer operational.

--- a/src/_common/StreamHub/IStreamHub.cs
+++ b/src/_common/StreamHub/IStreamHub.cs
@@ -1,5 +1,14 @@
 namespace Skender.Stock.Indicators;
 
+public interface IStreamHubBase<out TOut>
+    where TOut : ISeries
+{
+    /// <summary>
+    /// Read-only list of the stored cache values.
+    /// </summary>
+    IReadOnlyList<TOut> Results { get; }
+}
+
 /// <summary>
 /// Streaming hub: management of observer
 /// and observable indicator data
@@ -10,14 +19,10 @@ namespace Skender.Stock.Indicators;
 /// <typeparam name="TOut">
 /// Type of outbound indicator data.
 /// </typeparam>
-public interface IStreamHub<in TIn, TOut>
+public interface IStreamHub<in TIn, TOut> : IStreamHubBase<TOut>
     where TIn : ISeries
+    where TOut : ISeries
 {
-    /// <summary>
-    /// Read-only list of the stored cache values.
-    /// </summary>
-    IReadOnlyList<TOut> Results { get; }
-
     /// <summary>
     /// The cache and provider failed and is no longer operational.
     /// </summary>

--- a/src/_common/StreamHub/IStreamHubBase.cs
+++ b/src/_common/StreamHub/IStreamHubBase.cs
@@ -1,5 +1,12 @@
 namespace Skender.Stock.Indicators;
 
+/// <summary>
+/// Base interface for stream hubs that expose cached indicator results.
+/// Provides a covariant (<c>out</c>) result type for use by <see cref="IStreamHub{TOut}"/> implementations.
+/// </summary>
+/// <typeparam name="TOut">
+/// Reusable result type returned by the stream hub and stored in the <see cref="Results"/> cache.
+/// </typeparam>
 public interface IStreamHubBase<out TOut>
     where TOut : IReusable
 {

--- a/src/_common/StreamHub/IStreamHubBase.cs
+++ b/src/_common/StreamHub/IStreamHubBase.cs
@@ -1,0 +1,10 @@
+namespace Skender.Stock.Indicators;
+
+public interface IStreamHubBase<out TOut>
+    where TOut : IReusable
+{
+    /// <summary>
+    /// Read-only list of the stored cache values.
+    /// </summary>
+    IReadOnlyList<TOut> Results { get; }
+}

--- a/src/_common/StreamHub/IStreamHubBase.cs
+++ b/src/_common/StreamHub/IStreamHubBase.cs
@@ -14,4 +14,6 @@ public interface IStreamHubBase<out TOut>
     /// Read-only list of the stored cache values.
     /// </summary>
     IReadOnlyList<TOut> Results { get; }
+
+    IReusable? LastItem { get; }
 }

--- a/src/_common/StreamHub/StreamHub.cs
+++ b/src/_common/StreamHub/StreamHub.cs
@@ -51,7 +51,9 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamHub<TIn, TOut>
     /// <summary>
     /// Gets or sets the most recent item saved to cache.
     /// </summary>
-    private TOut? LastItem { get; set; }
+    private TOut? LastItemInternal { get; set; }
+
+    public IReusable? LastItem => LastItemInternal;
 
     /// <summary>
     /// Resets the fault flag and condition.
@@ -207,14 +209,14 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamHub<TIn, TOut>
     private bool IsOverflowing(TOut item)
     {
         // skip first arrival
-        if (LastItem is null)
+        if (LastItemInternal is null)
         {
-            LastItem = item;
+            LastItemInternal = item;
             return false;
         }
 
         // track/check for overflow condition
-        if (item.Timestamp == LastItem.Timestamp && item.Equals(LastItem))
+        if (item.Timestamp == LastItemInternal.Timestamp && item.Equals(LastItemInternal))
         {
             // ^^ using progressive check to avoid Equals() on every item
 
@@ -247,7 +249,7 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamHub<TIn, TOut>
 
         // not repeating
         OverflowCount = 0;
-        LastItem = item;
+        LastItemInternal = item;
         return false;
     }
 

--- a/src/_common/StreamHub/StreamHub.cs
+++ b/src/_common/StreamHub/StreamHub.cs
@@ -2,19 +2,9 @@ namespace Skender.Stock.Indicators;
 #pragma warning disable IDE0010 // Missing cases in switch expression
 
 // STREAM HUB (BASE/CACHE)
-public abstract class StreamHubBase
-{
-    /// <inheritdoc/>
-    public string Name { get; private protected init; } = null!;
-
-    public object? LastItem { get; set; }
-
-    /// <inheritdoc/>
-    public override string ToString() => Name;
-}
 
 /// <inheritdoc cref="IStreamHub{TIn, TOut}"/>
-public abstract partial class StreamHub<TIn, TOut> : StreamHubBase, IStreamHub<TIn, TOut>
+public abstract partial class StreamHub<TIn, TOut> : IStreamHub<TIn, TOut>
     where TIn : ISeries
     where TOut : ISeries
 {
@@ -39,6 +29,9 @@ public abstract partial class StreamHub<TIn, TOut> : StreamHubBase, IStreamHub<T
     /// <inheritdoc/>
     public bool IsFaulted { get; private set; }
 
+    /// <inheritdoc/>
+    public string Name { get; private protected init; } = null!;
+
     /// <summary>
     /// Gets the cache of stored values (base).
     /// </summary>
@@ -58,17 +51,7 @@ public abstract partial class StreamHub<TIn, TOut> : StreamHubBase, IStreamHub<T
     /// <summary>
     /// Gets or sets the most recent item saved to cache.
     /// </summary>
-    private TOut? _lastItem;
-    public new TOut? LastItem
-    {
-        get {
-            return _lastItem;
-        }
-        set {
-            base.LastItem = value;
-            _lastItem = value;
-        }
-    }
+    private TOut? LastItem { get; set; }
 
     /// <summary>
     /// Resets the fault flag and condition.
@@ -88,6 +71,9 @@ public abstract partial class StreamHub<TIn, TOut> : StreamHubBase, IStreamHub<T
     /// </remarks>
     /// <returns>The read-only cache reference.</returns>
     public IReadOnlyList<TOut> GetCacheRef() => Cache.AsReadOnly();
+
+    /// <inheritdoc/>
+    public override string ToString() => Name;
 
     /// <summary>
     /// Converts incremental value into an indicator candidate and cache position.

--- a/src/_common/StreamHub/StreamHub.cs
+++ b/src/_common/StreamHub/StreamHub.cs
@@ -5,7 +5,7 @@ namespace Skender.Stock.Indicators;
 
 /// <inheritdoc cref="IStreamHub{TIn, TOut}"/>
 public abstract partial class StreamHub<TIn, TOut> : IStreamHub<TIn, TOut>
-    where TIn : ISeries
+    where TIn : IReusable
     where TOut : IReusable
 {
     private protected StreamHub(IStreamObservable<TIn> provider)

--- a/src/_common/StreamHub/StreamHub.cs
+++ b/src/_common/StreamHub/StreamHub.cs
@@ -6,7 +6,7 @@ namespace Skender.Stock.Indicators;
 /// <inheritdoc cref="IStreamHub{TIn, TOut}"/>
 public abstract partial class StreamHub<TIn, TOut> : IStreamHub<TIn, TOut>
     where TIn : ISeries
-    where TOut : ISeries
+    where TOut : IReusable
 {
     private protected StreamHub(IStreamObservable<TIn> provider)
     {

--- a/src/_common/StreamHub/StreamHub.cs
+++ b/src/_common/StreamHub/StreamHub.cs
@@ -2,9 +2,19 @@ namespace Skender.Stock.Indicators;
 #pragma warning disable IDE0010 // Missing cases in switch expression
 
 // STREAM HUB (BASE/CACHE)
+public abstract class StreamHubBase
+{
+    /// <inheritdoc/>
+    public string Name { get; private protected init; } = null!;
+
+    public object? LastItem { get; set; }
+
+    /// <inheritdoc/>
+    public override string ToString() => Name;
+}
 
 /// <inheritdoc cref="IStreamHub{TIn, TOut}"/>
-public abstract partial class StreamHub<TIn, TOut> : IStreamHub<TIn, TOut>
+public abstract partial class StreamHub<TIn, TOut> : StreamHubBase, IStreamHub<TIn, TOut>
     where TIn : ISeries
     where TOut : ISeries
 {
@@ -29,9 +39,6 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamHub<TIn, TOut>
     /// <inheritdoc/>
     public bool IsFaulted { get; private set; }
 
-    /// <inheritdoc/>
-    public string Name { get; private protected init; } = null!;
-
     /// <summary>
     /// Gets the cache of stored values (base).
     /// </summary>
@@ -51,7 +58,17 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamHub<TIn, TOut>
     /// <summary>
     /// Gets or sets the most recent item saved to cache.
     /// </summary>
-    private TOut? LastItem { get; set; }
+    private TOut? _lastItem;
+    public new TOut? LastItem
+    {
+        get {
+            return _lastItem;
+        }
+        set {
+            base.LastItem = value;
+            _lastItem = value;
+        }
+    }
 
     /// <summary>
     /// Resets the fault flag and condition.
@@ -71,9 +88,6 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamHub<TIn, TOut>
     /// </remarks>
     /// <returns>The read-only cache reference.</returns>
     public IReadOnlyList<TOut> GetCacheRef() => Cache.AsReadOnly();
-
-    /// <inheritdoc/>
-    public override string ToString() => Name;
 
     /// <summary>
     /// Converts incremental value into an indicator candidate and cache position.

--- a/src/a-d/Alligator/Alligator.Models.cs
+++ b/src/a-d/Alligator/Alligator.Models.cs
@@ -14,7 +14,6 @@ public record AlligatorResult
     double? Jaw,
     double? Teeth,
     double? Lips
-
 ) : IReusable
 {
     public double Value => double.NaN;

--- a/src/a-d/Alligator/Alligator.Models.cs
+++ b/src/a-d/Alligator/Alligator.Models.cs
@@ -14,4 +14,8 @@ public record AlligatorResult
     double? Jaw,
     double? Teeth,
     double? Lips
-) : ISeries;
+
+) : IReusable
+{
+    public double Value => double.NaN;
+}

--- a/src/a-d/AtrStop/AtrStop.Models.cs
+++ b/src/a-d/AtrStop/AtrStop.Models.cs
@@ -25,4 +25,7 @@ public record AtrStopResult(
     double? BuyStop = null,
     double? SellStop = null,
     double? Atr = null
-) : ISeries;
+) : IReusable
+{
+    public double Value => double.NaN;
+}

--- a/src/a-d/Donchian/Donchian.Models.cs
+++ b/src/a-d/Donchian/Donchian.Models.cs
@@ -16,4 +16,7 @@ public record DonchianResult
     decimal? Centerline = null,
     decimal? LowerBand = null,
     decimal? Width = null
-) : ISeries;
+) : IReusable
+{
+    public double Value => double.NaN;
+}

--- a/src/e-k/Fcb/Fcb.Models.cs
+++ b/src/e-k/Fcb/Fcb.Models.cs
@@ -12,4 +12,7 @@ public record FcbResult
     DateTime Timestamp,
     decimal? UpperBand,
     decimal? LowerBand
-) : ISeries;
+) : IReusable
+{
+    public double Value => double.NaN;
+}

--- a/src/e-k/Fractal/Fractal.Models.cs
+++ b/src/e-k/Fractal/Fractal.Models.cs
@@ -12,4 +12,7 @@ public record FractalResult
     DateTime Timestamp,
     decimal? FractalBear,
     decimal? FractalBull
-) : ISeries;
+) : IReusable
+{
+    public double Value => double.NaN;
+}

--- a/src/e-k/Gator/Gator.Models.cs
+++ b/src/e-k/Gator/Gator.Models.cs
@@ -16,4 +16,7 @@ public record GatorResult
     double? Lower = null,
     bool? UpperIsExpanding = null,
     bool? LowerIsExpanding = null
-) : ISeries;
+) : IReusable
+{
+    public double Value => double.NaN;
+}

--- a/src/e-k/Ichimoku/Ichimoku.Models.cs
+++ b/src/e-k/Ichimoku/Ichimoku.Models.cs
@@ -18,4 +18,7 @@ public record IchimokuResult
    decimal? SenkouSpanA, // leading span A
    decimal? SenkouSpanB, // leading span B
    decimal? ChikouSpan   // lagging span
-) : ISeries;
+) : IReusable
+{
+    public double Value => double.NaN;
+}

--- a/src/e-k/Keltner/Keltner.Models.cs
+++ b/src/e-k/Keltner/Keltner.Models.cs
@@ -16,8 +16,10 @@ public record KeltnerResult
     double? Centerline = null,
     double? LowerBand = null,
     double? Width = null
-) : ISeries
+) : IReusable
 {
+    public double Value => double.NaN;
+
     /// <summary>
     /// Gets the Average True Range value (interim data for internal streaming calculations).
     /// </summary>

--- a/src/m-r/MaEnvelopes/MaEnvelopes.Models.cs
+++ b/src/m-r/MaEnvelopes/MaEnvelopes.Models.cs
@@ -18,4 +18,3 @@ public record MaEnvelopeResult
 {
     public double Value => double.NaN;
 }
-

--- a/src/m-r/MaEnvelopes/MaEnvelopes.Models.cs
+++ b/src/m-r/MaEnvelopes/MaEnvelopes.Models.cs
@@ -14,4 +14,8 @@ public record MaEnvelopeResult
     double? Centerline,
     double? UpperEnvelope,
     double? LowerEnvelope
-) : ISeries;
+) : IReusable
+{
+    public double Value => double.NaN;
+}
+

--- a/src/m-r/PivotPoints/PivotPoints.Models.cs
+++ b/src/m-r/PivotPoints/PivotPoints.Models.cs
@@ -55,7 +55,7 @@ internal interface IPivotPoint
 /// Represents the result of pivot points calculation.
 /// </summary>
 [Serializable]
-public record PivotPointsResult : IPivotPoint, ISeries
+public record PivotPointsResult : IPivotPoint, IReusable
 {
     /// <summary>
     /// Gets the timestamp of the result.
@@ -82,6 +82,8 @@ public record PivotPointsResult : IPivotPoint, ISeries
     public decimal? R3 { get; init; }
     /// <inheritdoc/>
     public decimal? R4 { get; init; }
+
+    public double Value => double.NaN;
 }
 
 /// <summary>

--- a/src/m-r/Pivots/Pivots.Models.cs
+++ b/src/m-r/Pivots/Pivots.Models.cs
@@ -20,7 +20,10 @@ public record PivotsResult
    decimal? LowLine,
    PivotTrend? HighTrend,
    PivotTrend? LowTrend
-) : ISeries;
+) : IReusable
+{
+    public double Value => double.NaN;
+}
 
 /// <summary>
 /// Represents the trend direction of a pivot point.

--- a/src/m-r/RollingPivots/RollingPivots.Models.cs
+++ b/src/m-r/RollingPivots/RollingPivots.Models.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Represents the result of a Rolling Pivots calculation.
 /// </summary>
 [Serializable]
-public record RollingPivotsResult : ISeries, IPivotPoint
+public record RollingPivotsResult : IReusable, IPivotPoint
 {
     /// <summary>
     /// Gets the timestamp of the Rolling Pivots result.
@@ -55,4 +55,6 @@ public record RollingPivotsResult : ISeries, IPivotPoint
     /// Gets the fourth resistance level (R4).
     /// </summary>
     public decimal? R4 { get; init; }
+
+    public double Value => double.NaN;
 }

--- a/src/s-z/StarcBands/StarcBands.Models.cs
+++ b/src/s-z/StarcBands/StarcBands.Models.cs
@@ -14,4 +14,7 @@ public record StarcBandsResult
     double? UpperBand,
     double? Centerline,
     double? LowerBand
-) : ISeries;
+) : IReusable
+{
+    public double Value => double.NaN;
+}

--- a/src/s-z/SuperTrend/SuperTrend.Models.cs
+++ b/src/s-z/SuperTrend/SuperTrend.Models.cs
@@ -14,4 +14,7 @@ public record SuperTrendResult
     decimal? SuperTrend,
     decimal? UpperBand,
     decimal? LowerBand
-) : ISeries;
+) : IReusable
+{
+    public double Value => double.NaN;
+}

--- a/src/s-z/Vortex/Vortex.Models.cs
+++ b/src/s-z/Vortex/Vortex.Models.cs
@@ -12,4 +12,7 @@ public record VortexResult
     DateTime Timestamp,
     double? Pvi = null,
     double? Nvi = null
-) : ISeries;
+) : IReusable
+{
+    public double Value => double.NaN;
+}


### PR DESCRIPTION
This PR:
1) Adds virtuals to the concrete type (allows state-caching experiments)
2) Does NOT include the StreamHubState experiment ^
3) Adds out variance to IStreamHub via the IStreamHubBase interface
4) Changes the constraints from ISeries to IReusable
5) All results now implement IReusable. Modified result classes return double.NaN for Value. (including CandleResult)

No build errors.
All hubs can now be cast to IStreamHubBase<IReusable>.
Value can be retrieved without knowing anything about the hub.

This makes retrieval for heuristics O(minimal).
```
Dictionary<(symbol, interval, name, paramsHash) hubkey, IStreamHubBase<IReusable> hub> _hubs;
_hubs[hubkey].Results.LastOrDefault().Value;
```

This works!!!