### PR TITLE
feat: Add extensible ReusableObserver implementing IStreamObserver<IReusable>

### DIFF
--- a/src/_common/StreamHub/ReusableObserver.cs
+++ b/src/_common/StreamHub/ReusableObserver.cs
@@ -6,6 +6,7 @@ namespace Skender.Stock.Indicators;
 /// </summary>
 public class ReusableObserver : IStreamObserver<IReusable>
 {
+    private readonly Func<bool> _isSubscribed;
     private readonly Action<Exception>? _onError;
     private readonly Action? _onCompleted;
     private readonly Action? _onUnsubscribe;
@@ -16,11 +17,11 @@ public class ReusableObserver : IStreamObserver<IReusable>
     private readonly Action? _rebuild;
     private readonly Action<DateTime>? _rebuildTimestamp;
     private readonly Action<int>? _rebuildIndex;
-    private bool _isSubscribed;
 
-    public bool IsSubscribed => _isSubscribed;
+    public bool IsSubscribed => _isSubscribed();
 
     public ReusableObserver(
+        Func<bool> isSubscribed,
         Action<Exception>? onError = null,
         Action? onCompleted = null,
         Action? onUnsubscribe = null,
@@ -32,6 +33,7 @@ public class ReusableObserver : IStreamObserver<IReusable>
         Action<DateTime>? rebuildTimestamp = null,
         Action<int>? rebuildIndex = null)
     {
+        _isSubscribed = isSubscribed;
         _onError = onError;
         _onCompleted = onCompleted;
         _onUnsubscribe = onUnsubscribe;
@@ -48,7 +50,7 @@ public class ReusableObserver : IStreamObserver<IReusable>
 
     public void OnCompleted() => _onCompleted?.Invoke();
 
-    public void Unsubscribe() { _isSubscribed = false; _onUnsubscribe?.Invoke(); }
+    public void Unsubscribe() { _onUnsubscribe?.Invoke(); }
 
     // OnAdd is called when a new item is added to the hub's cache
     public void OnAdd(IReusable item, bool notify, int? indexHint) => _onAdd?.Invoke(item, notify, indexHint);
@@ -60,7 +62,7 @@ public class ReusableObserver : IStreamObserver<IReusable>
     public void OnPrune(DateTime toTimestamp) => _onPrune?.Invoke(toTimestamp);
 
     // Reinitialize is called to reset the observer state
-    public void Reinitialize() { _isSubscribed = true; _onReinitialize?.Invoke(); }
+    public void Reinitialize() { _onReinitialize?.Invoke(); }
 
     // Rebuild methods trigger recalculation
     public void Rebuild() => _rebuild?.Invoke();

--- a/src/_common/StreamHub/ReusableObserver.cs
+++ b/src/_common/StreamHub/ReusableObserver.cs
@@ -6,7 +6,6 @@ namespace Skender.Stock.Indicators;
 /// </summary>
 public class ReusableObserver : IStreamObserver<IReusable>
 {
-    private readonly Action<IReusable>? _onNext;
     private readonly Action<Exception>? _onError;
     private readonly Action? _onCompleted;
     private readonly Action? _onUnsubscribe;
@@ -22,7 +21,6 @@ public class ReusableObserver : IStreamObserver<IReusable>
     public bool IsSubscribed => _isSubscribed;
 
     public ReusableObserver(
-        Action<IReusable>? onNext,
         Action<Exception>? onError = null,
         Action? onCompleted = null,
         Action? onUnsubscribe = null,
@@ -34,7 +32,6 @@ public class ReusableObserver : IStreamObserver<IReusable>
         Action<DateTime>? rebuildTimestamp = null,
         Action<int>? rebuildIndex = null)
     {
-        _onNext = onNext;
         _onError = onError;
         _onCompleted = onCompleted;
         _onUnsubscribe = onUnsubscribe;
@@ -46,8 +43,6 @@ public class ReusableObserver : IStreamObserver<IReusable>
         _rebuildTimestamp = rebuildTimestamp;
         _rebuildIndex = rebuildIndex;
     }
-
-    public void OnNext(IReusable value) { _onNext?.Invoke(value); }
 
     public void OnError(Exception exception) => _onError?.Invoke(exception);
 

--- a/src/_common/StreamHub/ReusableObserver.cs
+++ b/src/_common/StreamHub/ReusableObserver.cs
@@ -1,0 +1,76 @@
+namespace Skender.Stock.Indicators;
+
+/// <summary>
+/// Flexible IStreamObserver implementation with customizable callbacks for all lifecycle methods.
+/// Most callbacks are optional (nullable) except onNext which is required.
+/// </summary>
+public class ReusableObserver : IStreamObserver<IReusable>
+{
+    private readonly Action<IReusable> _onNext;
+    private readonly Action<Exception>? _onError;
+    private readonly Action? _onCompleted;
+    private readonly Action? _onUnsubscribe;
+    private readonly Action<IReusable, bool, int?>? _onAdd;
+    private readonly Action<DateTime>? _onRebuildFromTimestamp;
+    private readonly Action<DateTime>? _onPrune;
+    private readonly Action? _onReinitialize;
+    private readonly Action? _onRebuild;
+    private readonly Action<DateTime>? _onRebuildTimestamp;
+    private readonly Action<int>? _onRebuildIndex;
+    private bool _isSubscribed = false;
+
+    public bool IsSubscribed => _isSubscribed;
+
+    public ReusableObserver(
+        Action<IReusable> onNext,
+        Action<Exception>? onError = null,
+        Action? onCompleted = null,
+        Action? onUnsubscribe = null,
+        Action<IReusable, bool, int?>? onAdd = null,
+        Action<DateTime>? onRebuildFromTimestamp = null,
+        Action<DateTime>? onPrune = null,
+        Action? onReinitialize = null,
+        Action? onRebuild = null,
+        Action<DateTime>? onRebuildTimestamp = null,
+        Action<int>? onRebuildIndex = null)
+    {
+        _onNext = onNext ?? throw new ArgumentNullException(nameof(onNext));
+        _onError = onError;
+        _onCompleted = onCompleted;
+        _onUnsubscribe = onUnsubscribe;
+        _onAdd = onAdd;
+        _onRebuildFromTimestamp = onRebuildFromTimestamp;
+        _onPrune = onPrune;
+        _onReinitialize = onReinitialize;
+        _onRebuild = onRebuild;
+        _onRebuildTimestamp = onRebuildTimestamp;
+        _onRebuildIndex = onRebuildIndex;
+    }
+
+    public void OnNext(IReusable value) { _onNext(value); }
+
+    public void OnError(Exception error) => _onError?.Invoke(error);
+
+    public void OnCompleted() => _onCompleted?.Invoke();
+
+    public void Unsubscribe() { _isSubscribed = false; _onUnsubscribe?.Invoke(); }
+
+    // OnAdd is called when a new item is added to the hub's cache
+    public void OnAdd(IReusable item, bool notify, int? indexHint) => _onAdd?.Invoke(item, notify, indexHint);
+
+    // OnRebuild is called when the hub recalculates from a specific timestamp
+    public void OnRebuild(DateTime fromTimestamp) => _onRebuildFromTimestamp?.Invoke(fromTimestamp);
+
+    // OnPrune is called when old items are removed from the hub's cache
+    public void OnPrune(DateTime toTimestamp) => _onPrune?.Invoke(toTimestamp);
+
+    // Reinitialize is called to reset the observer state
+    public void Reinitialize() { _isSubscribed = true; _onReinitialize?.Invoke(); }
+
+    // Rebuild methods trigger recalculation
+    public void Rebuild() => _onRebuild?.Invoke();
+
+    public void Rebuild(DateTime fromTimestamp) => _onRebuildTimestamp?.Invoke(fromTimestamp);
+
+    public void Rebuild(int fromIndex) => _onRebuildIndex?.Invoke(fromIndex);
+}

--- a/src/_common/StreamHub/ReusableObserver.cs
+++ b/src/_common/StreamHub/ReusableObserver.cs
@@ -2,7 +2,7 @@ namespace Skender.Stock.Indicators;
 
 /// <summary>
 /// Flexible IStreamObserver implementation with customizable callbacks for all lifecycle methods.
-/// Most callbacks are optional (nullable) except onNext which is required.
+/// All callbacks are optional (nullable).
 /// </summary>
 public class ReusableObserver : IStreamObserver<IReusable>
 {

--- a/src/_common/StreamHub/ReusableObserver.cs
+++ b/src/_common/StreamHub/ReusableObserver.cs
@@ -6,50 +6,50 @@ namespace Skender.Stock.Indicators;
 /// </summary>
 public class ReusableObserver : IStreamObserver<IReusable>
 {
-    private readonly Action<IReusable> _onNext;
+    private readonly Action<IReusable>? _onNext;
     private readonly Action<Exception>? _onError;
     private readonly Action? _onCompleted;
     private readonly Action? _onUnsubscribe;
     private readonly Action<IReusable, bool, int?>? _onAdd;
-    private readonly Action<DateTime>? _onRebuildFromTimestamp;
+    private readonly Action<DateTime>? _onRebuild;
     private readonly Action<DateTime>? _onPrune;
     private readonly Action? _onReinitialize;
-    private readonly Action? _onRebuild;
-    private readonly Action<DateTime>? _onRebuildTimestamp;
-    private readonly Action<int>? _onRebuildIndex;
-    private bool _isSubscribed = false;
+    private readonly Action? _rebuild;
+    private readonly Action<DateTime>? _rebuildTimestamp;
+    private readonly Action<int>? _rebuildIndex;
+    private bool _isSubscribed;
 
     public bool IsSubscribed => _isSubscribed;
 
     public ReusableObserver(
-        Action<IReusable> onNext,
+        Action<IReusable>? onNext,
         Action<Exception>? onError = null,
         Action? onCompleted = null,
         Action? onUnsubscribe = null,
         Action<IReusable, bool, int?>? onAdd = null,
-        Action<DateTime>? onRebuildFromTimestamp = null,
+        Action<DateTime>? onRebuild = null,
         Action<DateTime>? onPrune = null,
         Action? onReinitialize = null,
-        Action? onRebuild = null,
-        Action<DateTime>? onRebuildTimestamp = null,
-        Action<int>? onRebuildIndex = null)
+        Action? rebuild = null,
+        Action<DateTime>? rebuildTimestamp = null,
+        Action<int>? rebuildIndex = null)
     {
-        _onNext = onNext ?? throw new ArgumentNullException(nameof(onNext));
+        _onNext = onNext;
         _onError = onError;
         _onCompleted = onCompleted;
         _onUnsubscribe = onUnsubscribe;
         _onAdd = onAdd;
-        _onRebuildFromTimestamp = onRebuildFromTimestamp;
+        _onRebuild = onRebuild;
         _onPrune = onPrune;
         _onReinitialize = onReinitialize;
-        _onRebuild = onRebuild;
-        _onRebuildTimestamp = onRebuildTimestamp;
-        _onRebuildIndex = onRebuildIndex;
+        _rebuild = rebuild;
+        _rebuildTimestamp = rebuildTimestamp;
+        _rebuildIndex = rebuildIndex;
     }
 
-    public void OnNext(IReusable value) { _onNext(value); }
+    public void OnNext(IReusable value) { _onNext?.Invoke(value); }
 
-    public void OnError(Exception error) => _onError?.Invoke(error);
+    public void OnError(Exception exception) => _onError?.Invoke(exception);
 
     public void OnCompleted() => _onCompleted?.Invoke();
 
@@ -59,7 +59,7 @@ public class ReusableObserver : IStreamObserver<IReusable>
     public void OnAdd(IReusable item, bool notify, int? indexHint) => _onAdd?.Invoke(item, notify, indexHint);
 
     // OnRebuild is called when the hub recalculates from a specific timestamp
-    public void OnRebuild(DateTime fromTimestamp) => _onRebuildFromTimestamp?.Invoke(fromTimestamp);
+    public void OnRebuild(DateTime fromTimestamp) => _onRebuild?.Invoke(fromTimestamp);
 
     // OnPrune is called when old items are removed from the hub's cache
     public void OnPrune(DateTime toTimestamp) => _onPrune?.Invoke(toTimestamp);
@@ -68,9 +68,9 @@ public class ReusableObserver : IStreamObserver<IReusable>
     public void Reinitialize() { _isSubscribed = true; _onReinitialize?.Invoke(); }
 
     // Rebuild methods trigger recalculation
-    public void Rebuild() => _onRebuild?.Invoke();
+    public void Rebuild() => _rebuild?.Invoke();
 
-    public void Rebuild(DateTime fromTimestamp) => _onRebuildTimestamp?.Invoke(fromTimestamp);
+    public void Rebuild(DateTime fromTimestamp) => _rebuildTimestamp?.Invoke(fromTimestamp);
 
-    public void Rebuild(int fromIndex) => _onRebuildIndex?.Invoke(fromIndex);
+    public void Rebuild(int fromIndex) => _rebuildIndex?.Invoke(fromIndex);
 }

--- a/src/_common/StreamHub/ReusableObserver.cs
+++ b/src/_common/StreamHub/ReusableObserver.cs
@@ -33,7 +33,7 @@ public class ReusableObserver<TResult> : IStreamObserver<TResult>
     public bool IsSubscribed => _isSubscribed();
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ReusableObserver"/> class
+    /// Initializes a new instance of the <see cref="ReusableObserver{TResult}"/> class
     /// with customizable callbacks for all lifecycle methods.
     /// </summary>
     /// <param name="isSubscribed">

--- a/src/_common/StreamHub/ReusableObserver.cs
+++ b/src/_common/StreamHub/ReusableObserver.cs
@@ -4,13 +4,14 @@ namespace Skender.Stock.Indicators;
 /// Flexible IStreamObserver implementation with customizable callbacks for all lifecycle methods.
 /// All callbacks are optional (nullable).
 /// </summary>
-public class ReusableObserver : IStreamObserver<ISeries>
+public class ReusableObserver<TResult> : IStreamObserver<TResult>
+    where TResult : ISeries
 {
     private readonly Func<bool> _isSubscribed;
     private readonly Action<Exception>? _onError;
     private readonly Action? _onCompleted;
     private readonly Action? _onUnsubscribe;
-    private readonly Action<ISeries, bool, int?>? _onAdd;
+    private readonly Action<TResult, bool, int?>? _onAdd;
     private readonly Action<DateTime>? _onRebuild;
     private readonly Action<DateTime>? _onPrune;
     private readonly Action? _onReinitialize;
@@ -81,7 +82,7 @@ public class ReusableObserver : IStreamObserver<ISeries>
         Action<Exception>? onError = null,
         Action? onCompleted = null,
         Action? onUnsubscribe = null,
-        Action<ISeries, bool, int?>? onAdd = null,
+        Action<TResult, bool, int?>? onAdd = null,
         Action<DateTime>? onRebuild = null,
         Action<DateTime>? onPrune = null,
         Action? onReinitialize = null,
@@ -149,7 +150,7 @@ public class ReusableObserver : IStreamObserver<ISeries>
     /// <remarks>
     /// Invokes the optional <c>_onAdd</c> callback if provided during construction.
     /// </remarks>
-    public void OnAdd(ISeries item, bool notify, int? indexHint) => _onAdd?.Invoke(item, notify, indexHint);
+    public void OnAdd(TResult item, bool notify, int? indexHint) => _onAdd?.Invoke(item, notify, indexHint);
 
     /// <summary>
     /// Provides the observer with starting point in timeline to rebuild
@@ -228,33 +229,4 @@ public class ReusableObserver : IStreamObserver<ISeries>
     /// Invokes the optional <c>_rebuildIndex</c> callback if provided during construction.
     /// </remarks>
     public void Rebuild(int fromIndex) => _rebuildIndex?.Invoke(fromIndex);
-}
-
-public class ReusableObserver<TResult> : ReusableObserver, IStreamObserver<TResult>
-    where TResult : IReusable
-{
-    public ReusableObserver(
-        Func<bool> isSubscribed,
-        Action<Exception>? onError = null,
-        Action? onCompleted = null,
-        Action? onUnsubscribe = null,
-        Action<TResult, bool, int?>? onAdd = null,
-        Action<DateTime>? onRebuild = null,
-        Action<DateTime>? onPrune = null,
-        Action? onReinitialize = null,
-        Action? rebuild = null,
-        Action<DateTime>? rebuildTimestamp = null,
-        Action<int>? rebuildIndex = null)
-        : base(isSubscribed, onError, onCompleted, onUnsubscribe, null, onRebuild, onPrune, onReinitialize, rebuild, rebuildTimestamp, rebuildIndex)
-    {
-        _onAdd = onAdd;
-    }
-
-    private readonly Action<TResult, bool, int?>? _onAdd;
-
-    public void OnAdd(TResult item, bool notify, int? indexHint)
-    {
-        //Don't invoke base.OnAdd to avoid boxing
-        _onAdd?.Invoke(item, notify, indexHint);
-    }
 }

--- a/src/_common/StreamHub/ReusableObserver.cs
+++ b/src/_common/StreamHub/ReusableObserver.cs
@@ -4,13 +4,13 @@ namespace Skender.Stock.Indicators;
 /// Flexible IStreamObserver implementation with customizable callbacks for all lifecycle methods.
 /// All callbacks are optional (nullable).
 /// </summary>
-public class ReusableObserver : IStreamObserver<IReusable>
+public class ReusableObserver : IStreamObserver<ISeries>
 {
     private readonly Func<bool> _isSubscribed;
     private readonly Action<Exception>? _onError;
     private readonly Action? _onCompleted;
     private readonly Action? _onUnsubscribe;
-    private readonly Action<IReusable, bool, int?>? _onAdd;
+    private readonly Action<ISeries, bool, int?>? _onAdd;
     private readonly Action<DateTime>? _onRebuild;
     private readonly Action<DateTime>? _onPrune;
     private readonly Action? _onReinitialize;
@@ -81,7 +81,7 @@ public class ReusableObserver : IStreamObserver<IReusable>
         Action<Exception>? onError = null,
         Action? onCompleted = null,
         Action? onUnsubscribe = null,
-        Action<IReusable, bool, int?>? onAdd = null,
+        Action<ISeries, bool, int?>? onAdd = null,
         Action<DateTime>? onRebuild = null,
         Action<DateTime>? onPrune = null,
         Action? onReinitialize = null,
@@ -149,7 +149,7 @@ public class ReusableObserver : IStreamObserver<IReusable>
     /// <remarks>
     /// Invokes the optional <c>_onAdd</c> callback if provided during construction.
     /// </remarks>
-    public void OnAdd(IReusable item, bool notify, int? indexHint) => _onAdd?.Invoke(item, notify, indexHint);
+    public void OnAdd(ISeries item, bool notify, int? indexHint) => _onAdd?.Invoke(item, notify, indexHint);
 
     /// <summary>
     /// Provides the observer with starting point in timeline to rebuild
@@ -228,4 +228,33 @@ public class ReusableObserver : IStreamObserver<IReusable>
     /// Invokes the optional <c>_rebuildIndex</c> callback if provided during construction.
     /// </remarks>
     public void Rebuild(int fromIndex) => _rebuildIndex?.Invoke(fromIndex);
+}
+
+public class ReusableObserver<TResult> : ReusableObserver, IStreamObserver<TResult>
+    where TResult : IReusable
+{
+    public ReusableObserver(
+        Func<bool> isSubscribed,
+        Action<Exception>? onError = null,
+        Action? onCompleted = null,
+        Action? onUnsubscribe = null,
+        Action<TResult, bool, int?>? onAdd = null,
+        Action<DateTime>? onRebuild = null,
+        Action<DateTime>? onPrune = null,
+        Action? onReinitialize = null,
+        Action? rebuild = null,
+        Action<DateTime>? rebuildTimestamp = null,
+        Action<int>? rebuildIndex = null)
+        : base(isSubscribed, onError, onCompleted, onUnsubscribe, null, onRebuild, onPrune, onReinitialize, rebuild, rebuildTimestamp, rebuildIndex)
+    {
+        _onAdd = onAdd;
+    }
+
+    private readonly Action<TResult, bool, int?>? _onAdd;
+
+    public void OnAdd(TResult item, bool notify, int? indexHint)
+    {
+        //Don't invoke base.OnAdd to avoid boxing
+        _onAdd?.Invoke(item, notify, indexHint);
+    }
 }

--- a/src/_common/StreamHub/ReusableObserver.cs
+++ b/src/_common/StreamHub/ReusableObserver.cs
@@ -18,8 +18,64 @@ public class ReusableObserver : IStreamObserver<IReusable>
     private readonly Action<DateTime>? _rebuildTimestamp;
     private readonly Action<int>? _rebuildIndex;
 
+    /// <summary>
+    /// Gets a value indicating whether the observer is currently subscribed to the data provider.
+    /// </summary>
+    /// <value>
+    /// <c>true</c> if the observer is subscribed; otherwise, <c>false</c>.
+    /// </value>
+    /// <remarks>
+    /// This property is thread-safe and returns the current subscription state
+    /// by invoking the backing delegate <see cref="_isSubscribed"/>.
+    /// The value is determined by the provider at the time of invocation.
+    /// </remarks>
     public bool IsSubscribed => _isSubscribed();
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReusableObserver"/> class
+    /// with customizable callbacks for all lifecycle methods.
+    /// </summary>
+    /// <param name="isSubscribed">
+    /// A function that returns the current subscription state. This parameter is required.
+    /// </param>
+    /// <param name="onError">
+    /// Optional callback invoked when an error occurs in the data provider.
+    /// </param>
+    /// <param name="onCompleted">
+    /// Optional callback invoked when the data provider has finished sending notifications.
+    /// </param>
+    /// <param name="onUnsubscribe">
+    /// Optional callback invoked when unsubscribing from the data provider.
+    /// </param>
+    /// <param name="onAdd">
+    /// Optional callback invoked when a new item is added to the hub's cache.
+    /// </param>
+    /// <param name="onRebuild">
+    /// Optional callback invoked when the hub recalculates from a specific timestamp.
+    /// </param>
+    /// <param name="onPrune">
+    /// Optional callback invoked when old items are removed from the hub's cache.
+    /// </param>
+    /// <param name="onReinitialize">
+    /// Optional callback invoked to reset the observer state.
+    /// </param>
+    /// <param name="rebuild">
+    /// Optional callback invoked to trigger a full recalculation of the cache.
+    /// </param>
+    /// <param name="rebuildTimestamp">
+    /// Optional callback invoked to trigger a recalculation from a specific timestamp.
+    /// </param>
+    /// <param name="rebuildIndex">
+    /// Optional callback invoked to trigger a recalculation from a specific index position.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="isSubscribed"/> is <c>null</c>.
+    /// </exception>
+    /// <remarks>
+    /// All callback parameters except <paramref name="isSubscribed"/> are optional (nullable).
+    /// The <paramref name="isSubscribed"/> delegate is assigned to the <see cref="_isSubscribed"/> field
+    /// and must not be <c>null</c>.
+    /// </remarks>
     public ReusableObserver(
         Func<bool> isSubscribed,
         Action<Exception>? onError = null,
@@ -33,6 +89,8 @@ public class ReusableObserver : IStreamObserver<IReusable>
         Action<DateTime>? rebuildTimestamp = null,
         Action<int>? rebuildIndex = null)
     {
+        ArgumentNullException.ThrowIfNull(isSubscribed);
+
         _isSubscribed = isSubscribed;
         _onError = onError;
         _onCompleted = onCompleted;
@@ -46,28 +104,128 @@ public class ReusableObserver : IStreamObserver<IReusable>
         _rebuildIndex = rebuildIndex;
     }
 
+    /// <summary>
+    /// Provides the observer with errors from the provider that have produced a faulted state.
+    /// </summary>
+    /// <param name="exception">
+    /// An exception with additional information about the error.
+    /// </param>
+    /// <remarks>
+    /// Invokes the optional <c>_onError</c> callback if provided during construction.
+    /// </remarks>
     public void OnError(Exception exception) => _onError?.Invoke(exception);
 
+    /// <summary>
+    /// Provides the observer with final notice that the data provider has finished sending
+    /// push-based notifications.
+    /// </summary>
+    /// <remarks>
+    /// Completion indicates that publisher will never send additional data.
+    /// This is only used for finite data streams and is different from faulted <see cref="OnError(Exception)"/>.
+    /// Invokes the optional <c>_onCompleted</c> callback if provided during construction.
+    /// </remarks>
     public void OnCompleted() => _onCompleted?.Invoke();
 
+    /// <summary>
+    /// Unsubscribe from the data provider.
+    /// </summary>
+    /// <remarks>
+    /// Invokes the optional <c>_onUnsubscribe</c> callback if provided during construction.
+    /// </remarks>
     public void Unsubscribe() { _onUnsubscribe?.Invoke(); }
 
-    // OnAdd is called when a new item is added to the hub's cache
+    /// <summary>
+    /// Provides the observer with new data when an item is added to the hub's cache.
+    /// </summary>
+    /// <param name="item">
+    /// The current notification information containing the data item to add.
+    /// </param>
+    /// <param name="notify">
+    /// Notify subscribers of the new item.
+    /// </param>
+    /// <param name="indexHint">
+    /// Provider index hint, if known. This parameter is nullable.
+    /// </param>
+    /// <remarks>
+    /// Invokes the optional <c>_onAdd</c> callback if provided during construction.
+    /// </remarks>
     public void OnAdd(IReusable item, bool notify, int? indexHint) => _onAdd?.Invoke(item, notify, indexHint);
 
-    // OnRebuild is called when the hub recalculates from a specific timestamp
+    /// <summary>
+    /// Provides the observer with starting point in timeline to rebuild
+    /// and cascade to all its own subscribers.
+    /// </summary>
+    /// <param name="fromTimestamp">
+    /// Starting point in timeline to rebuild. All periods (inclusive) after this date/time
+    /// will be removed and recalculated.
+    /// </param>
+    /// <remarks>
+    /// Invokes the optional <c>_onRebuild</c> callback if provided during construction.
+    /// </remarks>
     public void OnRebuild(DateTime fromTimestamp) => _onRebuild?.Invoke(fromTimestamp);
 
-    // OnPrune is called when old items are removed from the hub's cache
+    /// <summary>
+    /// Provides the observer with notification to prune data.
+    /// </summary>
+    /// <param name="toTimestamp">
+    /// Ending point in timeline to prune. Old items up to this timestamp
+    /// will be removed from the hub's cache.
+    /// </param>
+    /// <remarks>
+    /// Invokes the optional <c>_onPrune</c> callback if provided during construction.
+    /// </remarks>
     public void OnPrune(DateTime toTimestamp) => _onPrune?.Invoke(toTimestamp);
 
-    // Reinitialize is called to reset the observer state
+    /// <summary>
+    /// Full reset of the provider subscription.
+    /// </summary>
+    /// <remarks>
+    /// This unsubscribes from the provider,
+    /// rebuilds the cache, resets faulted states,
+    /// and then re-subscribes to the provider.
+    /// Invokes the optional <c>_onReinitialize</c> callback if provided during construction.
+    /// <para>
+    /// This is done automatically on hub instantiation, so it's only needed if you
+    /// want to manually reset the hub.
+    /// </para>
+    /// <para>
+    /// If you only need to rebuild the cache, use <see cref="Rebuild()"/> instead.
+    /// </para>
+    /// </remarks>
     public void Reinitialize() { _onReinitialize?.Invoke(); }
 
-    // Rebuild methods trigger recalculation
+    /// <summary>
+    /// Resets the entire results cache and rebuilds it from provider sources,
+    /// with cascading updates to subscribers.
+    /// </summary>
+    /// <remarks>
+    /// This is different from <see cref="Reinitialize()"/>.
+    /// It does not reset the provider subscription.
+    /// Invokes the optional <c>_rebuild</c> callback if provided during construction.
+    /// </remarks>
     public void Rebuild() => _rebuild?.Invoke();
 
+    /// <summary>
+    /// Resets the results cache from a point in time and rebuilds it from provider sources,
+    /// with cascading updates to subscribers.
+    /// </summary>
+    /// <param name="fromTimestamp">
+    /// All periods (inclusive) after this date/time will be removed and recalculated.
+    /// </param>
+    /// <remarks>
+    /// Invokes the optional <c>_rebuildTimestamp</c> callback if provided during construction.
+    /// </remarks>
     public void Rebuild(DateTime fromTimestamp) => _rebuildTimestamp?.Invoke(fromTimestamp);
 
+    /// <summary>
+    /// Resets the results cache from an index position and rebuilds it from provider sources,
+    /// with cascading updates to subscribers.
+    /// </summary>
+    /// <param name="fromIndex">
+    /// All periods (inclusive) after this index position will be removed and recalculated.
+    /// </param>
+    /// <remarks>
+    /// Invokes the optional <c>_rebuildIndex</c> callback if provided during construction.
+    /// </remarks>
     public void Rebuild(int fromIndex) => _rebuildIndex?.Invoke(fromIndex);
 }

--- a/tests/indicators/_common/StreamHub/StreamHub.Observer.Tests.cs
+++ b/tests/indicators/_common/StreamHub/StreamHub.Observer.Tests.cs
@@ -59,4 +59,15 @@ public class StreamObservers : TestBase
         observer.Cache[1000].Value.Should().NotBe(12345);
         observer.Cache[1000].Value.Should().Be((double)quotesList[1000].Close);
     }
+
+    [TestMethod]
+    public void ReusableObserver_ThrowsArgumentNullException_WhenIsSubscribedIsNull()
+    {
+        // arrange & act
+        Action act = () => _ = new ReusableObserver(isSubscribed: null!);
+
+        // assert
+        act.Should().Throw<ArgumentNullException>()
+            .WithParameterName("isSubscribed");
+    }
 }


### PR DESCRIPTION
Everything I was trying to gain access to by modifying the base interfaces (observables) was already available at the other end (observer).
This class generically implements a specific run-time configuration of `IStreamObserver<IReusable>`.

TODO: It could probably be made generic to provide type-safety to hard-wired instances.