### PR TITLE
feat: Add `Hubcollection` and covariant `IStreamHub`

### DIFF
--- a/src/_common/Candles/CandleResult.cs
+++ b/src/_common/Candles/CandleResult.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Represents the result of a candlestick analysis.
 /// </summary>
 [Serializable]
-public record CandleResult : ISeries
+public record CandleResult : IReusable
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="CandleResult"/> record.
@@ -64,4 +64,8 @@ public record CandleResult : ISeries
     /// Gets the candlestick properties.
     /// </summary>
     public CandleProperties Candle { get; init; }
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public double Value => Price.Null2NaN();
 }

--- a/src/_common/StreamHub/HubCollection.cs
+++ b/src/_common/StreamHub/HubCollection.cs
@@ -24,8 +24,13 @@ namespace Skender.Stock.Indicators;
 ///     quoteHub.ToRsiHub(14)
 /// ];
 ///
-/// var results = hubs.GetResults();
-/// var latestEma12 = results[0][^1];
+/// // Access results from all hubs
+/// IEnumerable&lt;IReadOnlyList&lt;ISeries&gt;&gt; results = hubs.Results;
+/// var latestEma12 = results.ElementAt(0)[^1];
+///
+/// // Get last values from all hubs
+/// IEnumerable&lt;double&gt; lastValues = hubs.LastValues;
+/// double ema12Value = lastValues.ElementAt(0);
 /// </code>
 /// </example>
 public class HubCollection : Collection<IStreamObservable<ISeries>>
@@ -40,8 +45,12 @@ public class HubCollection : Collection<IStreamObservable<ISeries>>
     /// that contains elements copied from the specified collection.
     /// </summary>
     /// <param name="collection">The collection whose elements are copied to the new collection.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="collection"/> is null.</exception>
     public HubCollection(IEnumerable<IStreamObservable<ISeries>> collection)
-        : base(new List<IStreamObservable<ISeries>>(collection)) { }
+        : base(new List<IStreamObservable<ISeries>>(
+            collection
+                ?? throw new ArgumentNullException(nameof(collection))))
+    { }
 
     /// <summary>
     /// Gets the collection of result sets produced by each hub in the sequence.

--- a/src/_common/StreamHub/HubCollection.cs
+++ b/src/_common/StreamHub/HubCollection.cs
@@ -1,0 +1,65 @@
+using System.Collections.ObjectModel;
+
+namespace Skender.Stock.Indicators;
+
+/// <summary>
+/// Represents a strongly typed collection of StreamHub objects.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This collection stores hubs using the covariant <see cref="IStreamObservable{T}"/> interface
+/// to support heterogeneous hub types (e.g., EmaHub, RsiHub, QuoteHub) in a single collection.
+/// All concrete hub implementations inherit from <see cref="StreamHub{TIn, TOut}"/> which implements
+/// both <see cref="IStreamHub{TIn, TOut}"/> and <see cref="IStreamObservable{T}"/>.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// QuoteHub quoteHub = new();
+///
+/// HubCollection hubs =
+/// [
+///     quoteHub.ToEmaHub(12),
+///     quoteHub.ToEmaHub(26),
+///     quoteHub.ToRsiHub(14)
+/// ];
+///
+/// var results = hubs.GetResults();
+/// var latestEma12 = results[0][^1];
+/// </code>
+/// </example>
+public class HubCollection : Collection<IStreamObservable<ISeries>>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HubCollection"/> class that is empty.
+    /// </summary>
+    public HubCollection() { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HubCollection"/> class
+    /// that contains elements copied from the specified collection.
+    /// </summary>
+    /// <param name="collection">The collection whose elements are copied to the new collection.</param>
+    public HubCollection(IEnumerable<IStreamObservable<ISeries>> collection)
+        : base(new List<IStreamObservable<ISeries>>(collection)) { }
+
+    /// <summary>
+    /// Gets the collection of result sets produced by each hub in the sequence.
+    /// </summary>
+    public IEnumerable<IReadOnlyList<ISeries>> Results => this.Select(hub => hub.Results);
+
+    /// <summary>
+    /// Gets the last value from each hub's results.
+    /// </summary>
+    /// <returns>
+    /// An enumerable of double values where each element corresponds to a hub in the collection.
+    /// Returns the <see cref="IReusable.Value"/> of the last result for hubs with <see cref="IReusable"/> results,
+    /// or <see cref="double.NaN"/> for hubs with non-reusable results or empty result sets.
+    /// </returns>
+    public IEnumerable<double> LastValues => this
+        .Select(hub
+            => hub.Results is IReadOnlyList<IReusable> reusableResults
+            && reusableResults.Count > 0
+                ? reusableResults[^1].Value
+                : double.NaN);
+}

--- a/src/_common/StreamHub/IStreamHub.cs
+++ b/src/_common/StreamHub/IStreamHub.cs
@@ -10,19 +10,13 @@ namespace Skender.Stock.Indicators;
 /// <typeparam name="TOut">
 /// Type of outbound indicator data.
 /// </typeparam>
-public interface IStreamHub<in TIn, TOut> : IStreamObserver<TIn>, IStreamObservable<TOut>
+public interface IStreamHub<in TIn, out TOut> : IStreamObserver<TIn>, IStreamObservable<TOut>
     where TIn : ISeries
 {
     /// <summary>
     /// Name of this hub instance.
     /// </summary>
     string Name { get; }
-
-    /// <summary>
-    /// Read-only list of the stored cache values.
-    /// </summary>
-    /// <remarks>This is an alias for <see cref="IStreamObservable{T}.ReadCache"/></remarks>
-    IReadOnlyList<TOut> Results { get; }
 
     /// <summary>
     /// The cache and provider failed and is no longer operational.
@@ -78,13 +72,6 @@ public interface IStreamHub<in TIn, TOut> : IStreamObserver<TIn>, IStreamObserva
     /// Item to insert
     /// </param>
     void Insert(TIn newIn);
-
-    /// <summary>
-    /// Delete an item from the cache.
-    /// </summary>
-    /// <param name="cachedItem">Cached item to delete</param>
-    /// <exception cref="ArgumentOutOfRangeException"/>
-    void Remove(TOut cachedItem);
 
     /// <summary>
     /// Delete an item from the cache, from a specific position.

--- a/src/_common/StreamHub/IStreamObservable.cs
+++ b/src/_common/StreamHub/IStreamObservable.cs
@@ -44,12 +44,7 @@ public interface IStreamObservable<out T>
     /// <summary>
     /// Read-only list of the stored cache values.
     /// </summary>
-    IReadOnlyList<T> ReadCache { get; }
-
-    /// <summary>
-    /// Read-only list of the stored cache values.
-    /// </summary>
-    /// <remarks>This is an alias for <see cref="ReadCache"/></remarks>
+    /// <remarks>This is read-only access to internal <see cref="StreamHub{TIn, TOut}.Cache"/></remarks>
     IReadOnlyList<T> Results { get; }
 
     /// <summary>

--- a/src/_common/StreamHub/IStreamObservable.cs
+++ b/src/_common/StreamHub/IStreamObservable.cs
@@ -47,6 +47,12 @@ public interface IStreamObservable<out T>
     IReadOnlyList<T> ReadCache { get; }
 
     /// <summary>
+    /// Read-only list of the stored cache values.
+    /// </summary>
+    /// <remarks>This is an alias for <see cref="ReadCache"/></remarks>
+    IReadOnlyList<T> Results { get; }
+
+    /// <summary>
     /// Gets the maximum size of the Cache list.
     /// </summary>
     int MaxCacheSize { get; }

--- a/src/_common/StreamHub/Providers/BaseProvider.cs
+++ b/src/_common/StreamHub/Providers/BaseProvider.cs
@@ -36,6 +36,12 @@ public class BaseProvider<T>
     /// </remarks>
     public IReadOnlyList<T> ReadCache => _providerCache;
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// <see cref="BaseProvider{T}"/> does not have cached values."
+    /// </remarks>
+    public IReadOnlyList<T> Results => _providerCache;
+
     /// <inheritdoc/>
     public int MaxCacheSize => 0;
 

--- a/src/_common/StreamHub/Providers/BaseProvider.cs
+++ b/src/_common/StreamHub/Providers/BaseProvider.cs
@@ -34,12 +34,6 @@ public class BaseProvider<T>
     /// <remarks>
     /// <see cref="BaseProvider{T}"/> does not have cached values."
     /// </remarks>
-    public IReadOnlyList<T> ReadCache => _providerCache;
-
-    /// <inheritdoc />
-    /// <remarks>
-    /// <see cref="BaseProvider{T}"/> does not have cached values."
-    /// </remarks>
     public IReadOnlyList<T> Results => _providerCache;
 
     /// <inheritdoc/>

--- a/src/_common/StreamHub/StreamHub.Observable.cs
+++ b/src/_common/StreamHub/StreamHub.Observable.cs
@@ -12,9 +12,6 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamObservable<TOut>
     public virtual BinarySettings Properties { get; init; } = new(0); // default 0b00000000
 
     /// <inheritdoc/>
-    public IReadOnlyList<TOut> ReadCache { get; }
-
-    /// <inheritdoc/>
     public int MaxCacheSize { get; init; }
 
     /// <inheritdoc/>

--- a/src/_common/StreamHub/StreamHub.cs
+++ b/src/_common/StreamHub/StreamHub.cs
@@ -122,17 +122,6 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamHub<TIn, TOut>
         }
     }
 
-
-    /// <summary>
-    /// Removes a cached item.
-    /// </summary>
-    /// <inheritdoc/>
-    public void Remove(TOut cachedItem)
-    {
-        Cache.Remove(cachedItem);
-        NotifyObserversOnRebuild(cachedItem.Timestamp);
-    }
-
     /// <summary>
     /// Removes a cached item at a specific index position.
     /// </summary>

--- a/src/_common/StreamHub/StreamHub.cs
+++ b/src/_common/StreamHub/StreamHub.cs
@@ -13,8 +13,8 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamHub<TIn, TOut>
         // store provider reference
         Provider = provider;
 
-        // cache provider's ReadCache reference (wrapped for safety)
-        ProviderCache = provider.ReadCache;
+        // provider's Cache reference (wrapped for safety)
+        ProviderCache = provider.Results;
 
         // inherit settings (reinstantiate struct on heap)
         Properties = Properties.Combine(provider.Properties);
@@ -29,7 +29,7 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamHub<TIn, TOut>
         }
 
         // build read-only cache reference
-        ReadCache = Cache.AsReadOnly();
+        Results = Cache.AsReadOnly();
     }
 
     // PROPERTIES
@@ -38,7 +38,7 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamHub<TIn, TOut>
     public string Name { get; private protected init; } = string.Empty;
 
     /// <inheritdoc/>
-    public IReadOnlyList<TOut> Results => ReadCache;
+    public IReadOnlyList<TOut> Results { get; }
 
     /// <inheritdoc/>
     public bool IsFaulted { get; private set; }

--- a/src/a-d/AtrStop/AtrStop.Models.cs
+++ b/src/a-d/AtrStop/AtrStop.Models.cs
@@ -25,4 +25,9 @@ public record AtrStopResult(
     double? BuyStop = null,
     double? SellStop = null,
     double? Atr = null
-) : ISeries;
+) : IReusable
+{
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public double Value => AtrStop.Null2NaN();
+}

--- a/src/m-r/PivotPoints/PivotPoints.Models.cs
+++ b/src/m-r/PivotPoints/PivotPoints.Models.cs
@@ -55,7 +55,7 @@ internal interface IPivotPoint
 /// Represents the result of pivot points calculation.
 /// </summary>
 [Serializable]
-public record PivotPointsResult : IPivotPoint, ISeries
+public record PivotPointsResult : IPivotPoint, IReusable
 {
     /// <summary>
     /// Gets the timestamp of the result.
@@ -82,6 +82,10 @@ public record PivotPointsResult : IPivotPoint, ISeries
     public decimal? R3 { get; init; }
     /// <inheritdoc/>
     public decimal? R4 { get; init; }
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public double Value => PP.Null2NaN();
 }
 
 /// <summary>

--- a/src/m-r/RollingPivots/RollingPivots.Models.cs
+++ b/src/m-r/RollingPivots/RollingPivots.Models.cs
@@ -4,7 +4,7 @@ namespace Skender.Stock.Indicators;
 /// Represents the result of a Rolling Pivots calculation.
 /// </summary>
 [Serializable]
-public record RollingPivotsResult : ISeries, IPivotPoint
+public record RollingPivotsResult : IPivotPoint, IReusable
 {
     /// <summary>
     /// Gets the timestamp of the Rolling Pivots result.
@@ -55,4 +55,8 @@ public record RollingPivotsResult : ISeries, IPivotPoint
     /// Gets the fourth resistance level (R4).
     /// </summary>
     public decimal? R4 { get; init; }
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public double Value => PP.Null2NaN();
 }

--- a/src/s-z/StochRsi/StochRsi.StreamHub.cs
+++ b/src/s-z/StochRsi/StochRsi.StreamHub.cs
@@ -125,7 +125,7 @@ public sealed class StochRsiHub
             return;
         }
 
-        IReadOnlyList<RsiResult> rsiResults = rsiHub.ReadCache;
+        List<RsiResult> rsiResults = rsiHub.Cache;
         int replayLimit = Math.Min(providerIndex, rsiResults.Count);
 
         for (int i = 0; i < replayLimit; i++)

--- a/src/s-z/SuperTrend/SuperTrend.Models.cs
+++ b/src/s-z/SuperTrend/SuperTrend.Models.cs
@@ -14,4 +14,9 @@ public record SuperTrendResult
     decimal? SuperTrend,
     decimal? UpperBand,
     decimal? LowerBand
-) : ISeries;
+) : IReusable
+{
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public double Value => SuperTrend.Null2NaN();
+}

--- a/tests/indicators/_common/QuotePart/QuotePart.StreamHub.Tests.cs
+++ b/tests/indicators/_common/QuotePart/QuotePart.StreamHub.Tests.cs
@@ -40,7 +40,7 @@ public class QuotePartHubTests : StreamHubTestBase, ITestQuoteObserver, ITestCha
         sut.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<QuotePart> expectedRevised = RevisedQuotes.Use(candlePart);
 
@@ -79,7 +79,7 @@ public class QuotePartHubTests : StreamHubTestBase, ITestQuoteObserver, ITestCha
         }
 
         quoteHub.Insert(Quotes[80]);  // Late arrival
-        quoteHub.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // final results
         IReadOnlyList<SmaResult> sut = observer.Results;

--- a/tests/indicators/_common/Quotes/Quote.StreamHub.Tests.cs
+++ b/tests/indicators/_common/Quotes/Quote.StreamHub.Tests.cs
@@ -37,7 +37,7 @@ public class QuoteHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainPr
         sut.IsExactly(Quotes);
 
         // delete, should equal series (revised)
-        provider.Remove(Quotes[removeAtIndex]);
+        provider.RemoveAt(removeAtIndex);
 
         sut.IsExactly(RevisedQuotes);
         sut.Should().HaveCount(quotesCount - 1);
@@ -72,7 +72,7 @@ public class QuoteHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainPr
         }
 
         provider.Insert(Quotes[80]);  // Late arrival
-        provider.Remove(Quotes[removeAtIndex]);  // Delete
+        provider.RemoveAt(removeAtIndex);  // Delete
 
         // final results
         IReadOnlyList<EmaResult> sut = observer.Results;

--- a/tests/indicators/_common/StreamHub/HubCollection.Tests.cs
+++ b/tests/indicators/_common/StreamHub/HubCollection.Tests.cs
@@ -1,0 +1,290 @@
+namespace StreamHubs;
+
+[TestClass]
+public class HubCollectionTests : TestBase
+{
+    [TestMethod]
+    public void HubCollection_Ctor_Defaults()
+    {
+        // arrange - empty collection
+        HubCollection emptyHubs = new();
+
+        // assert
+        emptyHubs.Should().NotBeNull();
+        emptyHubs.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void HubCollection_InitializeAsCollection_MixedHubTypes()
+    {
+        // arrange
+        QuoteHub quoteHub = new();
+        EmaHub emaFastHub = quoteHub.ToEmaHub(50);
+        EmaHub emaSlowHub = quoteHub.ToEmaHub(200);
+        RsiHub rsiHub = quoteHub.ToRsiHub(14);
+        DonchianHub donchianHub = quoteHub.ToDonchianHub(20);
+
+        // act - collection initializer syntax with mixed hub types
+        HubCollection hubs =
+        [
+            emaFastHub,
+            emaSlowHub,
+            rsiHub,
+            quoteHub,   // QuoteProvider type
+            donchianHub // Non-reusable types
+        ];
+
+        // assert - verify hub references are the same (not copied)
+        hubs.Should().NotBeNull();
+        hubs.Should().HaveCount(5);
+        quoteHub.ObserverCount.Should().Be(4);
+        hubs[0].Should().BeSameAs(emaFastHub);
+        hubs[1].Should().BeSameAs(emaSlowHub);
+        hubs[2].Should().BeSameAs(rsiHub);
+        hubs[3].Should().BeSameAs(quoteHub);
+        hubs[4].Should().BeSameAs(donchianHub);
+    }
+
+    [TestMethod]
+    public void HubCollection_UsingCtorWithEnumerable_HasHubRefs()
+    {
+        // arrange
+        QuoteHub quoteHub = new();
+
+        EmaHub emaHub = quoteHub.ToEmaHub(200);
+        RsiHub rsiHub = quoteHub.ToRsiHub(14);
+
+        IEnumerable<IStreamObservable<IReusable>> hubEnumerable =
+        [
+            emaHub,
+            rsiHub
+        ];
+
+        // act
+        HubCollection hubs = new(hubEnumerable);
+
+        // assert - verify hub references are the same (not copied)
+        hubs.Should().HaveCount(2);
+        quoteHub.ObserverCount.Should().Be(2);
+        hubs[0].Should().BeSameAs(emaHub);
+        hubs[1].Should().BeSameAs(rsiHub);
+    }
+
+    [TestMethod]
+    public void HubCollection_UseCtorWithList_HasHubRefs()
+    {
+        // arrange
+        QuoteHub quoteHub = new();
+
+        List<IStreamObservable<IReusable>> hubList =
+        [
+            quoteHub.ToEmaHub(20),
+            quoteHub.ToRsiHub(14)
+        ];
+
+        // act
+        HubCollection hubs = new(hubList);
+
+        // assert - verify hub references are the same (not copied)
+        hubs.Should().HaveCount(2);
+        quoteHub.ObserverCount.Should().Be(2);
+        hubs[0].Should().BeSameAs(hubList[0]);
+        hubs[1].Should().BeSameAs(hubList[1]);
+    }
+
+    [TestMethod]
+    public void HubCollection_WithQuoteIncrements_HasCorrectResults()
+    {
+        // arrange
+        QuoteHub quoteHub = new();
+        EmaHub emaHub = quoteHub.ToEmaHub(20);
+        RsiHub rsiHub = quoteHub.ToRsiHub(14);
+
+        HubCollection hubs = [emaHub, rsiHub];
+
+        // assert - initially empty
+        emaHub.Results.Should().BeEmpty();
+        rsiHub.Results.Should().BeEmpty();
+
+        // act - add quotes AFTER collection creation
+        foreach (Quote q in Quotes)
+        {
+            quoteHub.Add(q);
+        }
+
+        // assert - verify exact same instance
+        hubs[0].Should().BeSameAs(emaHub);
+        hubs[1].Should().BeSameAs(rsiHub);
+        quoteHub.ObserverCount.Should().Be(2);
+
+        // assert - contain equivalent results
+        emaHub.Results.Should().HaveCount(502);
+        rsiHub.Results.Should().HaveCount(502);
+        hubs[0].Results.Should().HaveCount(502);
+        hubs[1].Results.Should().HaveCount(502);
+
+        hubs[0].Results.Should().BeEquivalentTo(emaHub.Results);
+        hubs[1].Results.Should().BeEquivalentTo(rsiHub.Results);
+    }
+
+    [TestMethod]
+    public void HubCollection_ResultsSnapshot_ReturnsLiveView()
+    {
+        // arrange
+        QuoteHub quoteHub = new();
+        EmaHub emaHub = quoteHub.ToEmaHub(20);
+        RsiHub rsiHub = quoteHub.ToRsiHub(14);
+
+        HubCollection hubs = [emaHub, rsiHub];
+
+        // act - add initial quotes
+        for (int i = 0; i < 100; i++)
+        {
+            quoteHub.Add(Quotes[i]);
+        }
+
+        // act - store results snapshot
+        List<IReadOnlyList<ISeries>> resultsSnapshot
+            = hubs.Select(h => h.Results).ToList();
+
+        // assert - initial results count
+        int initialCount = resultsSnapshot[0].Count;
+        initialCount.Should().Be(100);
+        resultsSnapshot[0].Should().HaveCount(initialCount);
+        resultsSnapshot[1].Should().HaveCount(initialCount);
+
+        // act - add MORE quotes after getting results
+        for (int i = 100; i < 200; i++)
+        {
+            quoteHub.Add(Quotes[i]);
+        }
+
+        // assert - final results count updated in snapshot
+        int finalCount = resultsSnapshot[0].Count;
+        finalCount.Should().Be(200);
+        resultsSnapshot[0].Should().HaveCount(finalCount);
+        resultsSnapshot[1].Should().HaveCount(finalCount);
+
+        // assert - last element is from the newly added quotes
+        resultsSnapshot[0][^1].Timestamp.Should().Be(Quotes[199].Timestamp);
+
+        // assert - provider shows correct observer count
+        quoteHub.ObserverCount.Should().Be(2);
+    }
+
+    [TestMethod]
+    public void HubCollection_Results_ReturnsAllHubResults()
+    {
+        // arrange
+        QuoteHub quoteHub = new();
+        EmaHub emaHub = quoteHub.ToEmaHub(20);
+        RsiHub rsiHub = quoteHub.ToRsiHub(14);
+        DonchianHub donchianHub = quoteHub.ToDonchianHub(20);
+
+        HubCollection hubs = [emaHub, rsiHub, donchianHub];
+
+        // act - add quotes
+        foreach (Quote q in Quotes.Take(100))
+        {
+            quoteHub.Add(q);
+        }
+
+        // act - get results enumerable
+        IEnumerable<IReadOnlyList<ISeries>> results = hubs.Results;
+
+        // assert - results count matches hub count
+        results.Should().HaveCount(3);
+
+        // assert - each result set has correct count
+        results.ElementAt(0).Should().HaveCount(100);
+        results.ElementAt(1).Should().HaveCount(100);
+        results.ElementAt(2).Should().HaveCount(100);
+
+        // assert - results are live views (same reference)
+        results.ElementAt(0).Should().BeSameAs(emaHub.Results);
+        results.ElementAt(1).Should().BeSameAs(rsiHub.Results);
+        results.ElementAt(2).Should().BeSameAs(donchianHub.Results);
+    }
+
+    [TestMethod]
+    public void HubCollection_LastValues_ReturnsReusableValues()
+    {
+        // arrange
+        QuoteHub quoteHub = new();
+        EmaHub emaHub = quoteHub.ToEmaHub(20);
+        RsiHub rsiHub = quoteHub.ToRsiHub(14);
+
+        HubCollection hubs = [emaHub, rsiHub];
+
+        // act - add quotes
+        foreach (Quote q in Quotes.Take(100))
+        {
+            quoteHub.Add(q);
+        }
+
+        // act - get last values
+        List<double> lastValues = hubs.LastValues.ToList();
+
+        // assert - count matches hub count
+        lastValues.Should().HaveCount(2);
+
+        // assert - values match last result values
+        lastValues[0].Should().Be(emaHub.Results[^1].Value);
+        lastValues[1].Should().Be(rsiHub.Results[^1].Value);
+
+        // assert - values are not NaN
+        lastValues[0].Should().NotBe(double.NaN);
+        lastValues[1].Should().NotBe(double.NaN);
+    }
+
+    [TestMethod]
+    public void HubCollection_LastValues_WithNonReusable_ReturnsNaN()
+    {
+        // arrange
+        QuoteHub quoteHub = new();
+        EmaHub emaHub = quoteHub.ToEmaHub(20);
+        DonchianHub donchianHub = quoteHub.ToDonchianHub(20);  // Non-reusable result
+
+        HubCollection hubs = [emaHub, donchianHub];
+
+        // act - add quotes
+        foreach (Quote q in Quotes.Take(100))
+        {
+            quoteHub.Add(q);
+        }
+
+        // act - get last values
+        List<double> lastValues = hubs.LastValues.ToList();
+
+        // assert - count matches hub count
+        lastValues.Should().HaveCount(2);
+
+        // assert - reusable hub has value
+        lastValues[0].Should().Be(emaHub.Results[^1].Value);
+        lastValues[0].Should().NotBe(double.NaN);
+
+        // assert - non-reusable hub returns NaN
+        lastValues[1].Should().Be(double.NaN);
+    }
+
+    [TestMethod]
+    public void HubCollection_LastValues_WithEmptyResults_ReturnsNaN()
+    {
+        // arrange
+        QuoteHub quoteHub = new();
+        EmaHub emaHub = quoteHub.ToEmaHub(20);
+        RsiHub rsiHub = quoteHub.ToRsiHub(14);
+
+        HubCollection hubs = [emaHub, rsiHub];
+
+        // act - get last values WITHOUT adding quotes
+        List<double> lastValues = hubs.LastValues.ToList();
+
+        // assert - count matches hub count
+        lastValues.Should().HaveCount(2);
+
+        // assert - empty results return NaN
+        lastValues[0].Should().Be(double.NaN);
+        lastValues[1].Should().Be(double.NaN);
+    }
+}

--- a/tests/indicators/_common/StreamHub/StreamHub.CacheMgmt.Tests.cs
+++ b/tests/indicators/_common/StreamHub/StreamHub.CacheMgmt.Tests.cs
@@ -268,8 +268,8 @@ public class CacheManagement : TestBase
         bool canCastResults = results is List<SmaResult>;
         canCastResults.Should().BeFalse("Results should not be castable to List<T>");
 
-        // verify ReadCache cannot be cast to mutable list
-        IReadOnlyList<SmaResult> readCache = observer.ReadCache;
+        // verify Cache cannot be cast to mutable list
+        IReadOnlyList<SmaResult> readCache = observer.Cache;
         bool canCastCacheRef = readCache is List<SmaResult>;
         canCastCacheRef.Should().BeFalse("ReadCache should not be castable to List<T>");
 

--- a/tests/indicators/_common/StreamHub/StreamHub.CacheMgmt.Tests.cs
+++ b/tests/indicators/_common/StreamHub/StreamHub.CacheMgmt.Tests.cs
@@ -23,7 +23,7 @@ public class CacheManagement : TestBase
         List<Quote> quotesAfterRemove = [.. quotes];
         quotesAfterRemove.RemoveAt(14);
 
-        quoteHub.Remove(Quotes[14]);
+        quoteHub.RemoveAt(14);
         quoteHub.EndTransmission();
 
         Console.WriteLine(observer.Results.ToStringOut());

--- a/tests/indicators/_common/StreamHub/StreamHub.CacheMgmt.Tests.cs
+++ b/tests/indicators/_common/StreamHub/StreamHub.CacheMgmt.Tests.cs
@@ -263,15 +263,10 @@ public class CacheManagement : TestBase
         List<Quote> quotes = Quotes.Take(25).ToList();
         quoteHub.Add(quotes);
 
-        // verify Results cannot be cast to mutable list
+        // verify StreamHub.Results cannot be cast to mutable list
         IReadOnlyList<SmaResult> results = observer.Results;
         bool canCastResults = results is List<SmaResult>;
         canCastResults.Should().BeFalse("Results should not be castable to List<T>");
-
-        // verify Cache cannot be cast to mutable list
-        IReadOnlyList<SmaResult> readCache = observer.Cache;
-        bool canCastCacheRef = readCache is List<SmaResult>;
-        canCastCacheRef.Should().BeFalse("ReadCache should not be castable to List<T>");
 
         // verify QuoteHub.Quotes cannot be cast to mutable list
         IReadOnlyList<IQuote> quotesRef = quoteHub.Quotes;

--- a/tests/indicators/a-d/Adl/Adl.StreamHub.Tests.cs
+++ b/tests/indicators/a-d/Adl/Adl.StreamHub.Tests.cs
@@ -38,7 +38,7 @@ public class AdlHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainProv
         sut.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<AdlResult> expectedRevised = RevisedQuotes.ToAdl();
         sut.IsExactly(expectedRevised);
@@ -75,7 +75,7 @@ public class AdlHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainProv
         }
 
         quoteHub.Insert(Quotes[80]);  // Late arrival
-        quoteHub.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // final results
         IReadOnlyList<SmaResult> sut = observer.Results;

--- a/tests/indicators/a-d/Adx/Adx.StreamHub.Tests.cs
+++ b/tests/indicators/a-d/Adx/Adx.StreamHub.Tests.cs
@@ -43,7 +43,7 @@ public class AdxHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainProv
         actuals.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<AdxResult> expectedRevised = RevisedQuotes.ToAdx(lookbackPeriods);
 
@@ -84,7 +84,7 @@ public class AdxHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainProv
         }
 
         quoteHub.Insert(Quotes[80]);  // Late arrival
-        quoteHub.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // results from stream
         IReadOnlyList<EmaResult> sut = observer.Results;
@@ -129,7 +129,7 @@ public class AdxHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainProv
         observer.Results.IsExactly(expectedOriginal);
 
         // Act: Remove a single historical value
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // Assert: Observer should have 501 results and match revised series
         IReadOnlyList<AdxResult> expectedRevised = RevisedQuotes.ToAdx(lookbackPeriods);

--- a/tests/indicators/a-d/Alligator/Alligator.StreamHub.Tests.cs
+++ b/tests/indicators/a-d/Alligator/Alligator.StreamHub.Tests.cs
@@ -38,7 +38,7 @@ public class AlligatorHubTests : StreamHubTestBase, ITestChainObserver
         sut.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<AlligatorResult> expectedRevised = RevisedQuotes.ToAlligator();
         sut.IsExactly(expectedRevised);
@@ -88,7 +88,7 @@ public class AlligatorHubTests : StreamHubTestBase, ITestChainObserver
         quoteHub.Insert(quotesList[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // final results
         IReadOnlyList<AlligatorResult> sut

--- a/tests/indicators/a-d/Alma/Alma.StreamHub.Tests.cs
+++ b/tests/indicators/a-d/Alma/Alma.StreamHub.Tests.cs
@@ -38,7 +38,7 @@ public class AlmaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPro
         sut.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<AlmaResult> expectedRevised = RevisedQuotes.ToAlma(10, 0.85, 6);
         sut.IsExactly(expectedRevised);
@@ -121,7 +121,7 @@ public class AlmaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPro
         }
 
         quoteHub.Insert(Quotes[80]);  // Late arrival
-        quoteHub.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // final results
         IReadOnlyList<SmaResult> sut = smaObserver.Results;

--- a/tests/indicators/a-d/Aroon/Aroon.StreamHub.Tests.cs
+++ b/tests/indicators/a-d/Aroon/Aroon.StreamHub.Tests.cs
@@ -55,7 +55,7 @@ public class AroonHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainPr
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // time-series, for comparison
         IReadOnlyList<AroonResult> expected = RevisedQuotes.ToAroon(25);
@@ -98,7 +98,7 @@ public class AroonHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainPr
         }
 
         quoteHub.Insert(Quotes[80]);  // Late arrival
-        quoteHub.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // Final results
         IReadOnlyList<EmaResult> sut = emaHub.Results;

--- a/tests/indicators/a-d/Atr/Atr.StreamHub.Tests.cs
+++ b/tests/indicators/a-d/Atr/Atr.StreamHub.Tests.cs
@@ -38,7 +38,7 @@ public class AtrHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainProv
         sut.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<AtrResult> expectedRevised = RevisedQuotes.ToAtr(14);
         sut.IsExactly(expectedRevised);
@@ -76,7 +76,7 @@ public class AtrHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainProv
         }
 
         quoteHub.Insert(Quotes[80]);  // Late arrival
-        quoteHub.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // final results
         IReadOnlyList<SmaResult> sut = observer.Results;

--- a/tests/indicators/a-d/AtrStop/AtrStop.StreamHub.Tests.cs
+++ b/tests/indicators/a-d/AtrStop/AtrStop.StreamHub.Tests.cs
@@ -46,7 +46,7 @@ public class AtrStopHubTests : StreamHubTestBase, ITestQuoteObserver
         quoteHub.Insert(Quotes[80]);  // rebuilds from last reversal
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // time-series, for comparison
         IReadOnlyList<AtrStopResult> expected = RevisedQuotes.ToAtrStop();

--- a/tests/indicators/a-d/Awesome/Awesome.StreamHub.Tests.cs
+++ b/tests/indicators/a-d/Awesome/Awesome.StreamHub.Tests.cs
@@ -46,7 +46,7 @@ public class AwesomeHubTests : StreamHubTestBase, ITestChainObserver, ITestChain
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // time-series, for comparison
         IReadOnlyList<AwesomeResult> expected = RevisedQuotes.ToAwesome(5, 34);
@@ -129,7 +129,7 @@ public class AwesomeHubTests : StreamHubTestBase, ITestChainObserver, ITestChain
         }
 
         quoteHub.Insert(Quotes[80]);  // Late arrival
-        quoteHub.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // final results
         IReadOnlyList<EmaResult> sut = emaHub.Results;

--- a/tests/indicators/a-d/BollingerBands/BollingerBands.StreamHub.Tests.cs
+++ b/tests/indicators/a-d/BollingerBands/BollingerBands.StreamHub.Tests.cs
@@ -44,7 +44,7 @@ public class BollingerBandsHubTests : StreamHubTestBase, ITestQuoteObserver, ITe
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // time-series, for comparison
         IReadOnlyList<BollingerBandsResult> expected = RevisedQuotes.ToBollingerBands(20, 2);
@@ -96,7 +96,7 @@ public class BollingerBandsHubTests : StreamHubTestBase, ITestQuoteObserver, ITe
         }
 
         quoteHub.Insert(Quotes[80]);  // Late arrival
-        quoteHub.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // final results
         IReadOnlyList<SmaResult> sut = observer.Results;

--- a/tests/indicators/a-d/Bop/Bop.StreamHub.Tests.cs
+++ b/tests/indicators/a-d/Bop/Bop.StreamHub.Tests.cs
@@ -46,7 +46,7 @@ public class BopHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainProv
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // time-series, for comparison
         IReadOnlyList<BopResult> expected = RevisedQuotes.ToBop(14);
@@ -133,7 +133,7 @@ public class BopHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainProv
         }
 
         quoteHub.Insert(Quotes[80]);  // Late arrival
-        quoteHub.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // final results
         IReadOnlyList<EmaResult> sut = emaHub.Results;

--- a/tests/indicators/a-d/Cci/Cci.StreamHub.Tests.cs
+++ b/tests/indicators/a-d/Cci/Cci.StreamHub.Tests.cs
@@ -46,7 +46,7 @@ public class CciHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainProv
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // time-series, for comparison
         IReadOnlyList<CciResult> expected = RevisedQuotes.ToCci(20);
@@ -83,7 +83,7 @@ public class CciHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainProv
         }
 
         quoteHub.Insert(Quotes[80]);  // Late arrival
-        quoteHub.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // final results
         IReadOnlyList<CciResult> sut = cciHub.Results;

--- a/tests/indicators/a-d/ChaikinOsc/ChaikinOsc.StreamHub.Tests.cs
+++ b/tests/indicators/a-d/ChaikinOsc/ChaikinOsc.StreamHub.Tests.cs
@@ -46,7 +46,7 @@ public class ChaikinOscHubTests : StreamHubTestBase, ITestQuoteObserver, ITestCh
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // time-series, for comparison
         IReadOnlyList<ChaikinOscResult> expected = RevisedQuotes.ToChaikinOsc(3, 10);
@@ -127,7 +127,7 @@ public class ChaikinOscHubTests : StreamHubTestBase, ITestQuoteObserver, ITestCh
         }
 
         quoteHub.Insert(Quotes[80]);  // Late arrival
-        quoteHub.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // final results
         IReadOnlyList<EmaResult> sut = emaHub.Results;

--- a/tests/indicators/a-d/Chandelier/Chandelier.StreamHub.Tests.cs
+++ b/tests/indicators/a-d/Chandelier/Chandelier.StreamHub.Tests.cs
@@ -45,7 +45,7 @@ public class Chandelier : StreamHubTestBase, ITestQuoteObserver
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // time-series, for comparison
         IReadOnlyList<ChandelierResult> expected = RevisedQuotes.ToChandelier(22, 3);

--- a/tests/indicators/a-d/Chop/Chop.StreamHub.Tests.cs
+++ b/tests/indicators/a-d/Chop/Chop.StreamHub.Tests.cs
@@ -53,7 +53,7 @@ public class ChopHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainPro
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // time-series, for comparison
         IReadOnlyList<ChopResult> expected = RevisedQuotes.ToChop(14);
@@ -93,7 +93,7 @@ public class ChopHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainPro
         }
 
         quoteHub.Insert(Quotes[80]);  // Late arrival
-        quoteHub.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // final results
         IReadOnlyList<SmaResult> sut = observer.Results;

--- a/tests/indicators/a-d/Cmf/Cmf.StreamHub.Tests.cs
+++ b/tests/indicators/a-d/Cmf/Cmf.StreamHub.Tests.cs
@@ -43,7 +43,7 @@ public class CmfHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainProv
         actuals.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<CmfResult> expectedRevised = RevisedQuotes.ToCmf(lookbackPeriods);
 
@@ -84,7 +84,7 @@ public class CmfHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainProv
         }
 
         quoteHub.Insert(Quotes[80]);  // Late arrival
-        quoteHub.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // results from stream
         IReadOnlyList<EmaResult> sut = observer.Results;
@@ -136,7 +136,7 @@ public class CmfHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainProv
         observer.Results.IsExactly(expectedOriginal);
 
         // Act: Remove a single historical value
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // Assert: Observer should have 501 results and match revised series
         IReadOnlyList<CmfResult> expectedRevised = RevisedQuotes.ToCmf(lookbackPeriods);

--- a/tests/indicators/a-d/Cmo/Cmo.StreamHub.Tests.cs
+++ b/tests/indicators/a-d/Cmo/Cmo.StreamHub.Tests.cs
@@ -53,7 +53,7 @@ public class CmoHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // time-series, for comparison
         IReadOnlyList<CmoResult> expected = RevisedQuotes.ToCmo(14);
@@ -136,7 +136,7 @@ public class CmoHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
         }
 
         quoteHub.Insert(Quotes[80]);  // Late arrival
-        quoteHub.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // final results
         IReadOnlyList<EmaResult> sut = observer.Results;

--- a/tests/indicators/a-d/ConnorsRsi/ConnorsRsi.StreamHub.Tests.cs
+++ b/tests/indicators/a-d/ConnorsRsi/ConnorsRsi.StreamHub.Tests.cs
@@ -67,7 +67,7 @@ public class ConnorsRsiHubTests : StreamHubTestBase, ITestChainObserver, ITestCh
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // time-series, for comparison
         IReadOnlyList<ConnorsRsiResult> expected = RevisedQuotes.ToConnorsRsi(rsiPeriods, streakPeriods, rankPeriods);
@@ -146,7 +146,7 @@ public class ConnorsRsiHubTests : StreamHubTestBase, ITestChainObserver, ITestCh
         }
 
         quoteHub.Insert(Quotes[80]);  // Late arrival
-        quoteHub.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // final results
         IReadOnlyList<EmaResult> sut = observer.Results;

--- a/tests/indicators/a-d/Dema/Dema.StreamHub.Tests.cs
+++ b/tests/indicators/a-d/Dema/Dema.StreamHub.Tests.cs
@@ -38,7 +38,7 @@ public class DemaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPro
         sut.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
         IReadOnlyList<DemaResult> expectedRevised = RevisedQuotes.ToDema(5);
         sut.IsExactly(expectedRevised);
         sut.Should().HaveCount(quotesCount - 1);
@@ -113,7 +113,7 @@ public class DemaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPro
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // final results
         IReadOnlyList<SmaResult> sut = observer.Results;

--- a/tests/indicators/a-d/Doji/Doji.StreamHub.Tests.cs
+++ b/tests/indicators/a-d/Doji/Doji.StreamHub.Tests.cs
@@ -46,7 +46,7 @@ public class DojiHubTests : StreamHubTestBase, ITestQuoteObserver
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // time-series, for comparison
         IReadOnlyList<CandleResult> expected = RevisedQuotes.ToDoji(0.1);

--- a/tests/indicators/a-d/Donchian/Donchian.StreamHub.Tests.cs
+++ b/tests/indicators/a-d/Donchian/Donchian.StreamHub.Tests.cs
@@ -45,7 +45,7 @@ public class Donchian : StreamHubTestBase, ITestQuoteObserver
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // time-series, for comparison
         IReadOnlyList<DonchianResult> expected = RevisedQuotes.ToDonchian(20);

--- a/tests/indicators/a-d/Dpo/Dpo.StreamHub.Tests.cs
+++ b/tests/indicators/a-d/Dpo/Dpo.StreamHub.Tests.cs
@@ -40,7 +40,7 @@ public class DpoHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
         sut.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<DpoResult> expectedRevised = RevisedQuotes.ToDpo(lookbackPeriods);
         sut.IsExactly(expectedRevised);
@@ -130,7 +130,7 @@ public class DpoHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // final results
         IReadOnlyList<SmaResult> sut = observer.Results;

--- a/tests/indicators/a-d/Dynamic/Dynamic.StreamHub.Tests.cs
+++ b/tests/indicators/a-d/Dynamic/Dynamic.StreamHub.Tests.cs
@@ -42,7 +42,7 @@ public class DynamicHubTests : StreamHubTestBase, ITestChainObserver, ITestChain
         actuals.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<DynamicResult> expectedRevised = RevisedQuotes.ToDynamic(lookbackPeriods, kFactor);
 
@@ -121,7 +121,7 @@ public class DynamicHubTests : StreamHubTestBase, ITestChainObserver, ITestChain
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // final results
         IReadOnlyList<SmaResult> actuals

--- a/tests/indicators/e-k/ElderRay/ElderRay.StreamHub.Tests.cs
+++ b/tests/indicators/e-k/ElderRay/ElderRay.StreamHub.Tests.cs
@@ -9,14 +9,14 @@ public class ElderRay : StreamHubTestBase, ITestQuoteObserver
     [TestMethod]
     public void QuoteObserver_WithWarmupLateArrivalAndRemoval_MatchesSeriesExactly()
     {
-        List<Quote> quotesList = Quotes.ToList();
-        int length = quotesList.Count;
+        List<Quote> quotes = Quotes.ToList();
+        int length = quotes.Count;
 
         // setup quote provider hub
         QuoteHub quoteHub = new();
 
         // prefill quotes at provider
-        quoteHub.Add(quotesList.Take(20));
+        quoteHub.Add(quotes.Take(20));
 
         // initialize observer
         ElderRayHub observer = quoteHub.ToElderRayHub(lookbackPeriods);
@@ -30,7 +30,7 @@ public class ElderRay : StreamHubTestBase, ITestQuoteObserver
             // skip one (add later)
             if (i == 80) { continue; }
 
-            Quote q = quotesList[i];
+            Quote q = quotes[i];
             quoteHub.Add(q);
 
             // resend duplicate quotes
@@ -38,14 +38,14 @@ public class ElderRay : StreamHubTestBase, ITestQuoteObserver
         }
 
         // late arrival, should equal series
-        quoteHub.Insert(quotesList[80]);
+        quoteHub.Insert(quotes[80]);
         actuals.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(quotesList[removeAtIndex]);
-        quotesList.RemoveAt(removeAtIndex);
+        quoteHub.RemoveAt(removeAtIndex);
+        quotes.RemoveAt(removeAtIndex);
 
-        IReadOnlyList<ElderRayResult> expectedRevised = quotesList.ToElderRay(lookbackPeriods);
+        IReadOnlyList<ElderRayResult> expectedRevised = quotes.ToElderRay(lookbackPeriods);
 
         actuals.Should().HaveCount(501);
         actuals.IsExactly(expectedRevised);

--- a/tests/indicators/e-k/Ema/Ema.StreamHub.Tests.cs
+++ b/tests/indicators/e-k/Ema/Ema.StreamHub.Tests.cs
@@ -40,7 +40,7 @@ public class EmaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
         sut.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<EmaResult> expectedRevised = RevisedQuotes.ToEma(lookbackPeriods);
         sut.IsExactly(expectedRevised);
@@ -116,7 +116,7 @@ public class EmaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // final results
         IReadOnlyList<SmaResult> sut = observer.Results;

--- a/tests/indicators/e-k/Epma/Epma.StreamHub.Tests.cs
+++ b/tests/indicators/e-k/Epma/Epma.StreamHub.Tests.cs
@@ -45,7 +45,7 @@ public class EpmaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPro
         actuals.IsExactly(series);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<EpmaResult> expectedRevised = RevisedQuotes.ToEpma(lookbackPeriods);
 
@@ -166,7 +166,7 @@ public class EpmaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPro
         }
 
         quoteHub.Insert(Quotes[80]);  // Late arrival
-        quoteHub.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         IReadOnlyList<SmaResult> sut = smaHub.Results;
         IReadOnlyList<SmaResult> expected = RevisedQuotes

--- a/tests/indicators/e-k/Fcb/Fcb.StreamHub.Tests.cs
+++ b/tests/indicators/e-k/Fcb/Fcb.StreamHub.Tests.cs
@@ -45,7 +45,7 @@ public class FcbHubTests : StreamHubTestBase, ITestQuoteObserver
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // time-series, for comparison
         IReadOnlyList<FcbResult> expected

--- a/tests/indicators/e-k/FisherTransform/FisherTransform.StreamHub.Tests.cs
+++ b/tests/indicators/e-k/FisherTransform/FisherTransform.StreamHub.Tests.cs
@@ -41,7 +41,7 @@ public class FisherTransformHubTests : StreamHubTestBase, ITestChainObserver, IT
         actuals.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<FisherTransformResult> expectedRevised = RevisedQuotes.ToFisherTransform(lookbackPeriods);
 
@@ -120,7 +120,7 @@ public class FisherTransformHubTests : StreamHubTestBase, ITestChainObserver, IT
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // final results
         IReadOnlyList<SmaResult> actuals

--- a/tests/indicators/e-k/ForceIndex/ForceIndex.StreamHub.Tests.cs
+++ b/tests/indicators/e-k/ForceIndex/ForceIndex.StreamHub.Tests.cs
@@ -41,7 +41,7 @@ public class ForceIndex : StreamHubTestBase, ITestQuoteObserver, ITestChainProvi
         actuals.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<ForceIndexResult> expectedRevised = RevisedQuotes.ToForceIndex(lookbackPeriods);
 
@@ -85,7 +85,7 @@ public class ForceIndex : StreamHubTestBase, ITestQuoteObserver, ITestChainProvi
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // final results
         IReadOnlyList<SmaResult> actuals

--- a/tests/indicators/e-k/Fractal/Fractal.StreamHub.Tests.cs
+++ b/tests/indicators/e-k/Fractal/Fractal.StreamHub.Tests.cs
@@ -46,7 +46,7 @@ public class FractalHubTests : StreamHubTestBase, ITestQuoteObserver
         quoteHub.Insert(Quotes[80]);  // rebuilds from insertion point
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // Ensure all fractals are calculated with full context
         observer.Rebuild(0);

--- a/tests/indicators/e-k/Gator/Gator.StreamHub.Tests.cs
+++ b/tests/indicators/e-k/Gator/Gator.StreamHub.Tests.cs
@@ -46,7 +46,7 @@ public class GatorHubTests : StreamHubTestBase, ITestChainObserver
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // time-series, for comparison
         IReadOnlyList<GatorResult> expected = RevisedQuotes.ToGator();
@@ -99,7 +99,7 @@ public class GatorHubTests : StreamHubTestBase, ITestChainObserver
         quoteHub.Insert(quotesList[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // final results
         IReadOnlyList<GatorResult> sut

--- a/tests/indicators/e-k/HeikinAshi/HeikinAshi.StreamHub.Tests.cs
+++ b/tests/indicators/e-k/HeikinAshi/HeikinAshi.StreamHub.Tests.cs
@@ -46,7 +46,7 @@ public class HeikinAshiHubTests : StreamHubTestBase, ITestQuoteObserver, ITestCh
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // time-series, for comparison
         IReadOnlyList<HeikinAshiResult> expected = RevisedQuotes.ToHeikinAshi();
@@ -84,7 +84,7 @@ public class HeikinAshiHubTests : StreamHubTestBase, ITestQuoteObserver, ITestCh
         }
 
         quoteHub.Insert(Quotes[80]);  // Late arrival
-        quoteHub.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // final results
         IReadOnlyList<SmaResult> sut = observer.Results;

--- a/tests/indicators/e-k/Hma/Hma.StreamHub.Tests.cs
+++ b/tests/indicators/e-k/Hma/Hma.StreamHub.Tests.cs
@@ -40,7 +40,7 @@ public class HmaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
         sut.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
         IReadOnlyList<HmaResult> expectedRevised = RevisedQuotes.ToHma(LookbackPeriods);
         sut.IsExactly(expectedRevised);
         sut.Should().HaveCount(quotesCount - 1);
@@ -114,7 +114,7 @@ public class HmaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // final results
         IReadOnlyList<SmaResult> sut = observer.Results;
@@ -161,7 +161,7 @@ public class HmaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
             Close = original.Close + delta
         };
 
-        quoteHub.Remove(original);
+        quoteHub.RemoveAt(targetIndex);
         quoteHub.Insert(mutated);
         quotesList[targetIndex] = mutated;
 

--- a/tests/indicators/e-k/HtTrendline/HtTrendline.StreamHub.Tests.cs
+++ b/tests/indicators/e-k/HtTrendline/HtTrendline.StreamHub.Tests.cs
@@ -40,7 +40,7 @@ public class HtTrendlineHubTests : StreamHubTestBase, ITestChainObserver, ITestC
         actuals.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<HtlResult> expectedRevised = RevisedQuotes.ToHtTrendline();
 
@@ -117,7 +117,7 @@ public class HtTrendlineHubTests : StreamHubTestBase, ITestChainObserver, ITestC
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // final results
         IReadOnlyList<SmaResult> actuals

--- a/tests/indicators/e-k/Hurst/Hurst.StreamHub.Tests.cs
+++ b/tests/indicators/e-k/Hurst/Hurst.StreamHub.Tests.cs
@@ -41,7 +41,7 @@ public class HurstHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPr
         actuals.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<HurstResult> expectedRevised = RevisedQuotes.ToHurst(lookbackPeriods);
 
@@ -120,7 +120,7 @@ public class HurstHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPr
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // final results
         IReadOnlyList<SmaResult> actuals

--- a/tests/indicators/e-k/Ichimoku/Ichimoku.StreamHub.Tests.cs
+++ b/tests/indicators/e-k/Ichimoku/Ichimoku.StreamHub.Tests.cs
@@ -48,7 +48,7 @@ public class IchimokuHubTests : StreamHubTestBase, ITestQuoteObserver
         actuals.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<IchimokuResult> expectedRevised
             = RevisedQuotes.ToIchimoku(tenkanPeriods, kijunPeriods, senkouBPeriods);

--- a/tests/indicators/e-k/Kama/Kama.StreamHub.Tests.cs
+++ b/tests/indicators/e-k/Kama/Kama.StreamHub.Tests.cs
@@ -46,7 +46,7 @@ public class KamaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPro
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // time-series, for comparison
         IReadOnlyList<KamaResult> expected = RevisedQuotes.ToKama(10, 2, 30);
@@ -113,9 +113,9 @@ public class KamaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPro
         const int slowPeriods = 30;
         const int smaPeriods = 10;
 
-        List<Quote> quotesList = Quotes.ToList();
+        List<Quote> quotes = Quotes.ToList();
 
-        int length = quotesList.Count;
+        int length = quotes.Count;
 
         // setup quote provider hub
         QuoteHub quoteHub = new();
@@ -145,11 +145,11 @@ public class KamaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPro
         }
 
         // late arrival
-        quoteHub.Insert(quotesList[80]);
+        quoteHub.Insert(quotes[80]);
 
         // delete
-        quoteHub.Remove(quotesList[400]);
-        quotesList.RemoveAt(400);
+        quoteHub.RemoveAt(removeAtIndex);
+        quotes.RemoveAt(removeAtIndex);
 
         // final results
         IReadOnlyList<SmaResult> streamList
@@ -157,7 +157,7 @@ public class KamaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPro
 
         // time-series, for comparison
         IReadOnlyList<SmaResult> seriesList
-           = quotesList.ToKama(erPeriods, fastPeriods, slowPeriods)
+           = quotes.ToKama(erPeriods, fastPeriods, slowPeriods)
             .ToSma(smaPeriods);
 
         // assert, should equal series

--- a/tests/indicators/e-k/Keltner/Keltner.StreamHub.Tests.cs
+++ b/tests/indicators/e-k/Keltner/Keltner.StreamHub.Tests.cs
@@ -44,7 +44,7 @@ public class KeltnerHubTests : StreamHubTestBase, ITestQuoteObserver
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // time-series, for comparison
         IReadOnlyList<KeltnerResult> expected = RevisedQuotes.ToKeltner(20, 2, 10);

--- a/tests/indicators/e-k/Kvo/Kvo.StreamHub.Tests.cs
+++ b/tests/indicators/e-k/Kvo/Kvo.StreamHub.Tests.cs
@@ -44,7 +44,7 @@ public class KvoHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainProv
         quoteHub.Insert(Quotes[80]);
 
         // removal
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // final results
         IReadOnlyList<KvoResult> expected = RevisedQuotes.ToKvo(34, 55, 13);
@@ -154,7 +154,7 @@ public class KvoHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainProv
         }
 
         quoteHub.Insert(Quotes[80]);  // Late arrival
-        quoteHub.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // final results
         IReadOnlyList<SmaResult> sut = observer.Results;

--- a/tests/indicators/m-r/MaEnvelopes/MaEnvelopes.StreamHub.Tests.cs
+++ b/tests/indicators/m-r/MaEnvelopes/MaEnvelopes.StreamHub.Tests.cs
@@ -42,7 +42,7 @@ public class MaEnvelopesHubTests : StreamHubTestBase, ITestChainObserver
         actuals.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<MaEnvelopeResult> expectedRevised = RevisedQuotes.ToMaEnvelopes(lookbackPeriods, percentOffset);
 

--- a/tests/indicators/m-r/Macd/Macd.StreamHub.Tests.cs
+++ b/tests/indicators/m-r/Macd/Macd.StreamHub.Tests.cs
@@ -70,7 +70,7 @@ public class MacdHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPro
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // time-series, for comparison
         IReadOnlyList<MacdResult> expected = RevisedQuotes.ToMacd(12, 26, 9);
@@ -138,11 +138,11 @@ public class MacdHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPro
         const int macdSignal = 3;
 
         // setup chain quoteHub
-        QuoteHub quoteProvider = new();
-        SmaHub quoteHub = quoteProvider.ToSmaHub(smaPeriods);
+        QuoteHub quoteHub = new();
+        SmaHub smaHub = quoteHub.ToSmaHub(smaPeriods);
 
         // initialize observer
-        MacdHub observer = quoteHub
+        MacdHub observer = smaHub
             .ToMacdHub(macdFast, macdSlow, macdSignal);
 
         // emulate live quotes
@@ -151,13 +151,13 @@ public class MacdHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPro
             if (i == 80) { continue; }  // Skip for late arrival
 
             Quote q = Quotes[i];
-            quoteProvider.Add(q);
+            quoteHub.Add(q);
 
-            if (i is > 100 and < 105) { quoteProvider.Add(q); }  // Duplicate quotes
+            if (i is > 100 and < 105) { quoteHub.Add(q); }  // Duplicate quotes
         }
 
-        quoteProvider.Insert(Quotes[80]);  // Late arrival
-        quoteProvider.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.Insert(Quotes[80]);  // Late arrival
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // final results
         IReadOnlyList<MacdResult> sut = observer.Results;
@@ -173,8 +173,8 @@ public class MacdHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPro
 
         // cleanup
         observer.Unsubscribe();
+        smaHub.EndTransmission();
         quoteHub.EndTransmission();
-        quoteProvider.EndTransmission();
     }
 
     [TestMethod]

--- a/tests/indicators/m-r/Mama/Mama.StreamHub.Tests.cs
+++ b/tests/indicators/m-r/Mama/Mama.StreamHub.Tests.cs
@@ -49,7 +49,7 @@ public class MamaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPro
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // time-series, for comparison
         IReadOnlyList<MamaResult> expected = RevisedQuotes.ToMama(fastLimit, slowLimit);
@@ -110,9 +110,9 @@ public class MamaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPro
     {
         const int smaPeriods = 10;
 
-        List<Quote> quotesList = Quotes.ToList();
+        List<Quote> quotes = Quotes.ToList();
 
-        int length = quotesList.Count;
+        int length = quotes.Count;
 
         // setup quote provider hub
         QuoteHub quoteHub = new();
@@ -131,7 +131,7 @@ public class MamaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPro
                 continue;
             }
 
-            Quote q = quotesList[i];
+            Quote q = quotes[i];
             quoteHub.Add(q);
 
             // resend duplicate quotes
@@ -142,11 +142,11 @@ public class MamaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPro
         }
 
         // late arrival
-        quoteHub.Insert(quotesList[80]);
+        quoteHub.Insert(quotes[80]);
 
         // delete
-        quoteHub.Remove(quotesList[400]);
-        quotesList.RemoveAt(400);
+        quoteHub.RemoveAt(removeAtIndex);
+        quotes.RemoveAt(removeAtIndex);
 
         // final results
         IReadOnlyList<SmaResult> streamList
@@ -154,7 +154,7 @@ public class MamaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPro
 
         // time-series, for comparison
         IReadOnlyList<SmaResult> seriesList
-           = quotesList.ToMama(fastLimit, slowLimit)
+           = quotes.ToMama(fastLimit, slowLimit)
             .ToSma(smaPeriods);
 
         // assert, should equal series

--- a/tests/indicators/m-r/Marubozu/Marubozu.StreamHub.Tests.cs
+++ b/tests/indicators/m-r/Marubozu/Marubozu.StreamHub.Tests.cs
@@ -46,7 +46,7 @@ public class MarubozuHubTests : StreamHubTestBase, ITestQuoteObserver
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // time-series, for comparison
         IReadOnlyList<CandleResult> expected = RevisedQuotes.ToMarubozu(95);

--- a/tests/indicators/m-r/Mfi/Mfi.StreamHub.Tests.cs
+++ b/tests/indicators/m-r/Mfi/Mfi.StreamHub.Tests.cs
@@ -48,7 +48,7 @@ public class MfiHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainProv
         actuals.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<MfiResult> expectedRevised = RevisedQuotes.ToMfi(lookbackPeriods);
 
@@ -89,7 +89,7 @@ public class MfiHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainProv
         }
 
         quoteHub.Insert(Quotes[80]);  // Late arrival
-        quoteHub.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // results from stream
         IReadOnlyList<EmaResult> sut = observer.Results;

--- a/tests/indicators/m-r/Obv/Obv.StreamHub.Tests.cs
+++ b/tests/indicators/m-r/Obv/Obv.StreamHub.Tests.cs
@@ -44,7 +44,7 @@ public class ObvHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainProv
         quoteHub.Insert(Quotes[80]);
 
         // removal
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // final results
         IReadOnlyList<ObvResult> expected = RevisedQuotes.ToObv();
@@ -82,7 +82,7 @@ public class ObvHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainProv
         }
 
         quoteHub.Insert(Quotes[80]);  // Late arrival
-        quoteHub.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // final results
         IReadOnlyList<SmaResult> sut = observer.Results;

--- a/tests/indicators/m-r/ParabolicSar/ParabolicSar.StreamHub.Tests.cs
+++ b/tests/indicators/m-r/ParabolicSar/ParabolicSar.StreamHub.Tests.cs
@@ -9,8 +9,8 @@ public class ParabolicSarHubTests : StreamHubTestBase, ITestQuoteObserver, ITest
     [TestMethod]
     public void QuoteObserver_WithWarmupLateArrivalAndRemoval_MatchesSeriesExactly()
     {
-        List<Quote> quotesList = Quotes.ToList();
-        int length = quotesList.Count;
+        List<Quote> quotes = Quotes.ToList();
+        int length = quotes.Count;
 
         // setup quote provider hub
         QuoteHub quoteHub = new();
@@ -18,7 +18,7 @@ public class ParabolicSarHubTests : StreamHubTestBase, ITestQuoteObserver, ITest
         // prefill quotes at provider
         for (int i = 0; i < 50; i++)
         {
-            quoteHub.Add(quotesList[i]);
+            quoteHub.Add(quotes[i]);
         }
 
         // initialize observer
@@ -37,7 +37,7 @@ public class ParabolicSarHubTests : StreamHubTestBase, ITestQuoteObserver, ITest
                 continue;
             }
 
-            Quote q = quotesList[i];
+            Quote q = quotes[i];
             quoteHub.Add(q);
 
             // resend duplicate quotes
@@ -48,20 +48,20 @@ public class ParabolicSarHubTests : StreamHubTestBase, ITestQuoteObserver, ITest
         }
 
         // late arrival
-        quoteHub.Insert(quotesList[80]);
+        quoteHub.Insert(quotes[80]);
 
         // Should match series after all quotes added
-        IReadOnlyList<ParabolicSarResult> expectedOriginal = quotesList
+        IReadOnlyList<ParabolicSarResult> expectedOriginal = quotes
             .ToParabolicSar(accelerationStep, maxAccelerationFactor);
 
         streamList.IsExactly(expectedOriginal);
 
         // delete
-        quoteHub.Remove(quotesList[removeAtIndex]);
-        quotesList.RemoveAt(removeAtIndex);
+        quoteHub.RemoveAt(removeAtIndex);
+        quotes.RemoveAt(removeAtIndex);
 
         // time-series, for comparison (revised)
-        IReadOnlyList<ParabolicSarResult> seriesList = quotesList
+        IReadOnlyList<ParabolicSarResult> seriesList = quotes
             .ToParabolicSar(accelerationStep, maxAccelerationFactor);
 
         // assert, should equal series (revised)
@@ -77,8 +77,8 @@ public class ParabolicSarHubTests : StreamHubTestBase, ITestQuoteObserver, ITest
     public void ChainProvider_MatchesSeriesExactly()
     {
         const int smaPeriods = 10;
-        List<Quote> quotesList = Quotes.ToList();
-        int length = quotesList.Count;
+        List<Quote> quotes = Quotes.ToList();
+        int length = quotes.Count;
 
         // setup quote provider hub
         QuoteHub quoteHub = new();
@@ -97,7 +97,7 @@ public class ParabolicSarHubTests : StreamHubTestBase, ITestQuoteObserver, ITest
                 continue;
             }
 
-            Quote q = quotesList[i];
+            Quote q = quotes[i];
             quoteHub.Add(q);
 
             // resend duplicate quotes
@@ -108,17 +108,17 @@ public class ParabolicSarHubTests : StreamHubTestBase, ITestQuoteObserver, ITest
         }
 
         // late arrival
-        quoteHub.Insert(quotesList[80]);
+        quoteHub.Insert(quotes[80]);
 
         // delete
-        quoteHub.Remove(quotesList[removeAtIndex]);
-        quotesList.RemoveAt(removeAtIndex);
+        quoteHub.RemoveAt(removeAtIndex);
+        quotes.RemoveAt(removeAtIndex);
 
         // final results
         IReadOnlyList<SmaResult> streamList = observer.Results;
 
         // time-series, for comparison (revised)
-        IReadOnlyList<SmaResult> seriesList = quotesList
+        IReadOnlyList<SmaResult> seriesList = quotes
             .ToParabolicSar(accelerationStep, maxAccelerationFactor)
             .ToSma(smaPeriods);
 

--- a/tests/indicators/m-r/PivotPoints/PivotPoints.StreamHub.Tests.cs
+++ b/tests/indicators/m-r/PivotPoints/PivotPoints.StreamHub.Tests.cs
@@ -46,7 +46,7 @@ public class PivotPointsHubTests : StreamHubTestBase, ITestQuoteObserver
         quoteHub.Insert(Quotes[80]);  // rebuilds from insertion point
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // time-series, for comparison
         IReadOnlyList<PivotPointsResult> expected = RevisedQuotes.ToPivotPoints();

--- a/tests/indicators/m-r/Pivots/Pivots.StreamHub.Tests.cs
+++ b/tests/indicators/m-r/Pivots/Pivots.StreamHub.Tests.cs
@@ -46,7 +46,7 @@ public class PivotsHubTests : StreamHubTestBase, ITestQuoteObserver
         quoteHub.Insert(Quotes[80]);  // rebuilds from insertion point
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // Ensure all pivots are calculated with full context
         observer.Rebuild(0);

--- a/tests/indicators/m-r/Pmo/Pmo.StreamHub.Tests.cs
+++ b/tests/indicators/m-r/Pmo/Pmo.StreamHub.Tests.cs
@@ -66,7 +66,7 @@ public class PmoHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // time-series, for comparison
         IReadOnlyList<PmoResult> expected = RevisedQuotes.ToPmo(35, 20, 10);
@@ -134,11 +134,11 @@ public class PmoHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
         const int signalPeriods = 10;
 
         // setup chain quoteHub
-        QuoteHub quoteProvider = new();
-        SmaHub quoteHub = quoteProvider.ToSmaHub(smaPeriods);
+        QuoteHub quoteHub = new();
+        SmaHub smaHub = quoteHub.ToSmaHub(smaPeriods);
 
         // initialize observer
-        SmaHub observer = quoteHub
+        SmaHub observer = smaHub
             .ToPmoHub(timePeriods, smoothPeriods, signalPeriods)
             .ToSmaHub(smaPeriods);
 
@@ -148,13 +148,13 @@ public class PmoHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
             if (i == 80) { continue; }  // Skip for late arrival
 
             Quote q = Quotes[i];
-            quoteProvider.Add(q);
+            quoteHub.Add(q);
 
-            if (i is > 100 and < 105) { quoteProvider.Add(q); }  // Duplicate quotes
+            if (i is > 100 and < 105) { quoteHub.Add(q); }  // Duplicate quotes
         }
 
-        quoteProvider.Insert(Quotes[80]);  // Late arrival
-        quoteProvider.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.Insert(Quotes[80]);  // Late arrival
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // final results
         IReadOnlyList<SmaResult> sut = observer.Results;
@@ -171,7 +171,7 @@ public class PmoHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
 
         // cleanup
         observer.Unsubscribe();
-        quoteHub.Unsubscribe();
-        quoteProvider.EndTransmission();
+        smaHub.Unsubscribe();
+        quoteHub.EndTransmission();
     }
 }

--- a/tests/indicators/m-r/Pvo/Pvo.StreamHub.Tests.cs
+++ b/tests/indicators/m-r/Pvo/Pvo.StreamHub.Tests.cs
@@ -62,7 +62,7 @@ public class PvoHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // time-series, for comparison
         IReadOnlyList<PvoResult> expected = RevisedQuotes.ToPvo(12, 26, 9);
@@ -128,8 +128,8 @@ public class PvoHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
         const int emaPeriods = 10;
 
         // setup chain quoteHub
-        QuoteHub quoteProvider = new();
-        PvoHub pvoHub = quoteProvider.ToPvoHub(pvoFast, pvoSlow, pvoSignal);
+        QuoteHub quoteHub = new();
+        PvoHub pvoHub = quoteHub.ToPvoHub(pvoFast, pvoSlow, pvoSignal);
 
         // initialize observer (EMA of PVO)
         EmaHub observer = pvoHub
@@ -141,13 +141,13 @@ public class PvoHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
             if (i == 80) { continue; }  // Skip for late arrival
 
             Quote q = Quotes[i];
-            quoteProvider.Add(q);
+            quoteHub.Add(q);
 
-            if (i is > 100 and < 105) { quoteProvider.Add(q); }  // Duplicate quotes
+            if (i is > 100 and < 105) { quoteHub.Add(q); }  // Duplicate quotes
         }
 
-        quoteProvider.Insert(Quotes[80]);  // Late arrival
-        quoteProvider.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.Insert(Quotes[80]);  // Late arrival
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // final results
         IReadOnlyList<EmaResult> sut = observer.Results;
@@ -164,7 +164,7 @@ public class PvoHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
         // cleanup
         observer.Unsubscribe();
         pvoHub.EndTransmission();
-        quoteProvider.EndTransmission();
+        quoteHub.EndTransmission();
     }
 
     [TestMethod]

--- a/tests/indicators/m-r/Renko/Renko.StreamHub.Tests.cs
+++ b/tests/indicators/m-r/Renko/Renko.StreamHub.Tests.cs
@@ -14,9 +14,9 @@ public class RenkoHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainPr
         const decimal brickSize = 2.5m;
         const EndType endType = EndType.HighLow;
 
-        List<Quote> quotesList = Quotes.ToList();
+        List<Quote> quotes = Quotes.ToList();
 
-        int length = quotesList.Count;
+        int length = quotes.Count;
 
         // setup quote provider hub
         QuoteHub quoteHub = new();
@@ -24,7 +24,7 @@ public class RenkoHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainPr
         // prefill quotes at provider
         for (int i = 0; i < 50; i++)
         {
-            quoteHub.Add(quotesList[i]);
+            quoteHub.Add(quotes[i]);
         }
 
         // initialize observer
@@ -44,7 +44,7 @@ public class RenkoHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainPr
                 continue;
             }
 
-            Quote q = quotesList[i];
+            Quote q = quotes[i];
             quoteHub.Add(q);
 
             // resend duplicate quotes
@@ -55,14 +55,14 @@ public class RenkoHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainPr
         }
 
         // late arrival
-        quoteHub.Insert(quotesList[80]);
+        quoteHub.Insert(quotes[80]);
 
         // delete
-        quoteHub.Remove(quotesList[400]);
-        quotesList.RemoveAt(400);
+        quoteHub.RemoveAt(350);
+        quotes.RemoveAt(350);
 
         // time-series, for comparison
-        IReadOnlyList<RenkoResult> seriesList = quotesList
+        IReadOnlyList<RenkoResult> seriesList = quotes
             .ToRenko(brickSize, endType);
 
         // assert, should equal series

--- a/tests/indicators/m-r/Roc/Roc.StreamHub.Tests.cs
+++ b/tests/indicators/m-r/Roc/Roc.StreamHub.Tests.cs
@@ -38,7 +38,7 @@ public class RocHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
         sut.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
         IReadOnlyList<RocResult> expectedRevised = RevisedQuotes.ToRoc(20);
         sut.IsExactly(expectedRevised);
         sut.Should().HaveCount(quotesCount - 1);
@@ -113,7 +113,7 @@ public class RocHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // final results
         IReadOnlyList<EmaResult> sut = observer.Results;

--- a/tests/indicators/m-r/RocWb/RocWb.StreamHub.Tests.cs
+++ b/tests/indicators/m-r/RocWb/RocWb.StreamHub.Tests.cs
@@ -42,7 +42,7 @@ public class RocWbHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPr
         sut.Should().HaveCount(quotesCount);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<RocWbResult> expectedRevised = RevisedQuotes.ToRocWb(lookbackPeriods, emaPeriods, stdDevPeriods);
         sut.IsExactly(expectedRevised);
@@ -119,7 +119,7 @@ public class RocWbHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPr
         }
 
         quoteHub.Insert(Quotes[80]);  // Late arrival
-        quoteHub.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // final results
         IReadOnlyList<EmaResult> sut = observer.Results;

--- a/tests/indicators/m-r/RollingPivots/RollingPivots.StreamHub.Tests.cs
+++ b/tests/indicators/m-r/RollingPivots/RollingPivots.StreamHub.Tests.cs
@@ -45,7 +45,7 @@ public class RollingPivots : StreamHubTestBase, ITestQuoteObserver
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // time-series, for comparison
         IReadOnlyList<RollingPivotsResult> expected = RevisedQuotes.ToRollingPivots(20, 0, PivotPointType.Standard);

--- a/tests/indicators/m-r/Rsi/Rsi.StreamHub.Tests.cs
+++ b/tests/indicators/m-r/Rsi/Rsi.StreamHub.Tests.cs
@@ -40,7 +40,7 @@ public class RsiHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
         sut.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<RsiResult> expectedRevised = RevisedQuotes.ToRsi(lookbackPeriods);
         sut.IsExactly(expectedRevised);
@@ -116,7 +116,7 @@ public class RsiHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // final results
         IReadOnlyList<EmaResult> sut = observer.Results;

--- a/tests/indicators/s-z/Slope/Slope.StreamHub.Tests.cs
+++ b/tests/indicators/s-z/Slope/Slope.StreamHub.Tests.cs
@@ -40,7 +40,7 @@ public class SlopeHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPr
         sut.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
         IReadOnlyList<SlopeResult> expectedRevised = RevisedQuotes.ToSlope(lookbackPeriods);
         sut.IsExactly(expectedRevised);
         sut.Should().HaveCount(quotesCount - 1);
@@ -118,7 +118,7 @@ public class SlopeHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPr
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // final results
         IReadOnlyList<SmaResult> sut = observer.Results;

--- a/tests/indicators/s-z/Sma/Sma.StreamHub.Tests.cs
+++ b/tests/indicators/s-z/Sma/Sma.StreamHub.Tests.cs
@@ -38,7 +38,7 @@ public class SmaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
         sut.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
         IReadOnlyList<SmaResult> expectedRevised = RevisedQuotes.ToSma(5);
         sut.IsExactly(expectedRevised);
         sut.Should().HaveCount(quotesCount - 1);
@@ -112,7 +112,7 @@ public class SmaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // final results
         IReadOnlyList<EmaResult> sut = observer.Results;

--- a/tests/indicators/s-z/SmaAnalysis/SmaAnalysis.StreamHub.Tests.cs
+++ b/tests/indicators/s-z/SmaAnalysis/SmaAnalysis.StreamHub.Tests.cs
@@ -38,7 +38,7 @@ public class SmaAnalysisHubTests : StreamHubTestBase, ITestChainObserver, ITestC
         sut.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<SmaAnalysisResult> expectedRevised = RevisedQuotes.ToSmaAnalysis(5);
         sut.IsExactly(expectedRevised);
@@ -120,7 +120,7 @@ public class SmaAnalysisHubTests : StreamHubTestBase, ITestChainObserver, ITestC
         }
 
         quoteHub.Insert(Quotes[80]);  // Late arrival
-        quoteHub.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // final results
         IReadOnlyList<EmaResult> sut = observer.Results;

--- a/tests/indicators/s-z/Smi/Smi.StreamHub.Tests.cs
+++ b/tests/indicators/s-z/Smi/Smi.StreamHub.Tests.cs
@@ -14,14 +14,14 @@ public class SmiHubTest : StreamHubTestBase, ITestQuoteObserver, ITestChainProvi
     [TestMethod]
     public void QuoteObserver_WithWarmupLateArrivalAndRemoval_MatchesSeriesExactly()
     {
-        List<Quote> quotesList = Quotes.ToList();
+        List<Quote> quotes = Quotes.ToList();
         int length = Quotes.Count;
 
         // setup quote provider hub
         QuoteHub quoteHub = new();
 
         // prefill quotes at provider
-        quoteHub.Add(quotesList.Take(20));
+        quoteHub.Add(quotes.Take(20));
 
         // initialize observer
         SmiHub observer = quoteHub.ToSmiHub(
@@ -36,7 +36,7 @@ public class SmiHubTest : StreamHubTestBase, ITestQuoteObserver, ITestChainProvi
             // skip one (add later)
             if (i == 80) { continue; }
 
-            Quote q = quotesList[i];
+            Quote q = quotes[i];
             quoteHub.Add(q);
 
             // resend duplicate quotes
@@ -44,11 +44,11 @@ public class SmiHubTest : StreamHubTestBase, ITestQuoteObserver, ITestChainProvi
         }
 
         // late arrival, should equal series
-        quoteHub.Insert(quotesList[80]);
+        quoteHub.Insert(quotes[80]);
         actuals.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(quotesList[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<SmiResult> expectedRevised = RevisedQuotes.ToSmi(
             lookbackPeriods, firstSmoothPeriods, secondSmoothPeriods, signalPeriods);
@@ -89,7 +89,7 @@ public class SmiHubTest : StreamHubTestBase, ITestQuoteObserver, ITestChainProvi
         }
 
         quoteHub.Insert(Quotes[80]);  // Late arrival
-        quoteHub.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // results from stream
         IReadOnlyList<EmaResult> sut = observer.Results;

--- a/tests/indicators/s-z/Smma/Smma.StreamHub.Tests.cs
+++ b/tests/indicators/s-z/Smma/Smma.StreamHub.Tests.cs
@@ -38,7 +38,7 @@ public class SmmaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPro
         sut.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<SmmaResult> expectedRevised = RevisedQuotes.ToSmma(20);
         sut.IsExactly(expectedRevised);
@@ -98,9 +98,9 @@ public class SmmaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPro
         const int smmaPeriods = 20;
         const int smaPeriods = 10;
 
-        List<Quote> quotesList = Quotes.ToList();
+        List<Quote> quotes = Quotes.ToList();
 
-        int length = quotesList.Count;
+        int length = quotes.Count;
 
         // setup quote provider hub
         QuoteHub quoteHub = new();
@@ -119,7 +119,7 @@ public class SmmaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPro
                 continue;
             }
 
-            Quote q = quotesList[i];
+            Quote q = quotes[i];
             quoteHub.Add(q);
 
             // resend duplicate quotes
@@ -130,24 +130,24 @@ public class SmmaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPro
         }
 
         // late arrival
-        quoteHub.Insert(quotesList[80]);
+        quoteHub.Insert(quotes[80]);
 
         // delete
-        quoteHub.Remove(quotesList[400]);
-        quotesList.RemoveAt(400);
+        quoteHub.RemoveAt(removeAtIndex);
+        quotes.RemoveAt(removeAtIndex);
 
         // final results
-        IReadOnlyList<SmaResult> streamList
+        IReadOnlyList<SmaResult> sut
             = observer.Results;
 
         // time-series, for comparison
-        IReadOnlyList<SmaResult> seriesList
-           = quotesList.ToSmma(smmaPeriods)
+        IReadOnlyList<SmaResult> expected
+           = quotes.ToSmma(smmaPeriods)
             .ToSma(smaPeriods);
 
         // assert, should equal series
-        streamList.Should().HaveCount(length - 1);
-        streamList.IsExactly(seriesList);
+        sut.Should().HaveCount(length - 1);
+        sut.IsExactly(expected);
 
         // cleanup
         observer.Unsubscribe();

--- a/tests/indicators/s-z/StarcBands/StarcBands.StreamHub.Tests.cs
+++ b/tests/indicators/s-z/StarcBands/StarcBands.StreamHub.Tests.cs
@@ -38,7 +38,7 @@ public class StarcBandsHubTests : StreamHubTestBase, ITestQuoteObserver
         sut.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<StarcBandsResult> expectedRevised = RevisedQuotes.ToStarcBands(5, 2, 10);
         sut.IsExactly(expectedRevised);

--- a/tests/indicators/s-z/Stc/Stc.StreamHub.Tests.cs
+++ b/tests/indicators/s-z/Stc/Stc.StreamHub.Tests.cs
@@ -43,7 +43,7 @@ public class StcHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
         actuals.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<StcResult> expectedRevised = RevisedQuotes.ToStc(cyclePeriods, fastPeriods, slowPeriods);
 
@@ -120,7 +120,7 @@ public class StcHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // final results
         IReadOnlyList<SmaResult> actuals = observer.Results;

--- a/tests/indicators/s-z/StdDev/StdDev.StreamHub.Tests.cs
+++ b/tests/indicators/s-z/StdDev/StdDev.StreamHub.Tests.cs
@@ -41,7 +41,7 @@ public class StdDevHubTests : StreamHubTestBase, ITestChainObserver, ITestChainP
         actuals.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<StdDevResult> expectedRevised = RevisedQuotes.ToStdDev(lookbackPeriods);
 
@@ -120,7 +120,7 @@ public class StdDevHubTests : StreamHubTestBase, ITestChainObserver, ITestChainP
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // final results
         IReadOnlyList<SmaResult> actuals

--- a/tests/indicators/s-z/Stoch/Stoch.StreamHub.Tests.cs
+++ b/tests/indicators/s-z/Stoch/Stoch.StreamHub.Tests.cs
@@ -44,7 +44,7 @@ public class StochHubTests : StreamHubTestBase, ITestQuoteObserver
         actuals.IsExactly(expected);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<StochResult> expectedRevised = RevisedQuotes.ToStoch(lookbackPeriods, signalPeriods, smoothPeriods);
 

--- a/tests/indicators/s-z/StochRsi/StochRsi.StreamHub.Tests.cs
+++ b/tests/indicators/s-z/StochRsi/StochRsi.StreamHub.Tests.cs
@@ -46,7 +46,7 @@ public class StochRsiHubTests : StreamHubTestBase, ITestChainObserver, ITestChai
         sut.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<StochRsiResult> expectedRevised = RevisedQuotes.ToStochRsi(14, 14, 3, 1);
         sut.IsExactly(expectedRevised);
@@ -130,7 +130,7 @@ public class StochRsiHubTests : StreamHubTestBase, ITestChainObserver, ITestChai
         }
 
         quoteHub.Insert(Quotes[80]);  // Late arrival
-        quoteHub.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // final results
         IReadOnlyList<EmaResult> sut = observer.Results;

--- a/tests/indicators/s-z/SuperTrend/SuperTrend.StreamHub.Tests.cs
+++ b/tests/indicators/s-z/SuperTrend/SuperTrend.StreamHub.Tests.cs
@@ -43,7 +43,7 @@ public class SuperTrendHubTests : StreamHubTestBase, ITestQuoteObserver
         actuals.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<SuperTrendResult> expectedRevised = RevisedQuotes.ToSuperTrend(lookbackPeriods, multiplier);
 

--- a/tests/indicators/s-z/T3/T3.StreamHub.Tests.cs
+++ b/tests/indicators/s-z/T3/T3.StreamHub.Tests.cs
@@ -41,7 +41,7 @@ public class T3HubTests : StreamHubTestBase, ITestChainObserver, ITestChainProvi
         sut.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
         IReadOnlyList<T3Result> expectedRevised = RevisedQuotes.ToT3(lookbackPeriods, volumeFactor);
         sut.IsExactly(expectedRevised);
         sut.Should().HaveCount(quotesCount - 1);
@@ -118,7 +118,7 @@ public class T3HubTests : StreamHubTestBase, ITestChainObserver, ITestChainProvi
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // final results
         IReadOnlyList<SmaResult> sut = observer.Results;

--- a/tests/indicators/s-z/Tema/Tema.StreamHub.Tests.cs
+++ b/tests/indicators/s-z/Tema/Tema.StreamHub.Tests.cs
@@ -40,7 +40,7 @@ public class TemaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPro
         sut.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
         IReadOnlyList<TemaResult> expectedRevised = RevisedQuotes.ToTema(lookbackPeriods);
         sut.IsExactly(expectedRevised);
         sut.Should().HaveCount(quotesCount - 1);
@@ -115,7 +115,7 @@ public class TemaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPro
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // final results
         IReadOnlyList<SmaResult> sut = observer.Results;

--- a/tests/indicators/s-z/Tr/Tr.StreamHub.Tests.cs
+++ b/tests/indicators/s-z/Tr/Tr.StreamHub.Tests.cs
@@ -38,7 +38,7 @@ public class TrHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainProvi
         sut.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<TrResult> expectedRevised = RevisedQuotes.ToTr();
         sut.IsExactly(expectedRevised);
@@ -76,7 +76,7 @@ public class TrHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainProvi
         }
 
         quoteHub.Insert(Quotes[80]);  // Late arrival
-        quoteHub.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // final results
         IReadOnlyList<SmaResult> sut = observer.Results;

--- a/tests/indicators/s-z/Trix/Trix.StreamHub.Tests.cs
+++ b/tests/indicators/s-z/Trix/Trix.StreamHub.Tests.cs
@@ -38,7 +38,7 @@ public class TrixHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPro
         sut.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<TrixResult> expectedRevised = RevisedQuotes.ToTrix(14);
         sut.IsExactly(expectedRevised);
@@ -118,7 +118,7 @@ public class TrixHubTests : StreamHubTestBase, ITestChainObserver, ITestChainPro
         }
 
         quoteHub.Insert(Quotes[80]);  // Late arrival
-        quoteHub.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // final results
         IReadOnlyList<EmaResult> sut = emaOfTrix.Results;

--- a/tests/indicators/s-z/Tsi/Tsi.StreamHub.Tests.cs
+++ b/tests/indicators/s-z/Tsi/Tsi.StreamHub.Tests.cs
@@ -66,7 +66,7 @@ public class TsiHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
         sut.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<TsiResult> expectedRevised = RevisedQuotes.ToTsi(lookbackPeriods, smoothPeriods, signalPeriods);
         sut.IsExactly(expectedRevised);
@@ -120,8 +120,8 @@ public class TsiHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
     {
         const int smaPeriods = 10;
 
-        List<Quote> quotesList = Quotes.ToList();
-        int length = quotesList.Count;
+        List<Quote> quotes = Quotes.ToList();
+        int length = quotes.Count;
 
         // setup quote provider hub
         QuoteHub quoteHub = new();
@@ -140,7 +140,7 @@ public class TsiHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
                 continue;
             }
 
-            Quote q = quotesList[i];
+            Quote q = quotes[i];
             quoteHub.Add(q);
 
             // resend duplicate quotes
@@ -151,17 +151,17 @@ public class TsiHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
         }
 
         // late arrival
-        quoteHub.Insert(quotesList[80]);
+        quoteHub.Insert(quotes[80]);
 
         // delete
-        quoteHub.Remove(quotesList[removeAtIndex]);
-        quotesList.RemoveAt(removeAtIndex);
+        quoteHub.RemoveAt(removeAtIndex);
+        quotes.RemoveAt(removeAtIndex);
 
         // final results
         IReadOnlyList<SmaResult> streamList = observer.Results;
 
         // time-series, for comparison
-        IReadOnlyList<SmaResult> seriesList = quotesList
+        IReadOnlyList<SmaResult> seriesList = quotes
             .ToTsi(lookbackPeriods, smoothPeriods, signalPeriods)
             .ToSma(smaPeriods);
 

--- a/tests/indicators/s-z/UlcerIndex/UlcerIndex.StreamHub.Tests.cs
+++ b/tests/indicators/s-z/UlcerIndex/UlcerIndex.StreamHub.Tests.cs
@@ -41,7 +41,7 @@ public class UlcerIndexHubTests : StreamHubTestBase, ITestChainObserver, ITestCh
         actuals.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<UlcerIndexResult> expectedRevised = RevisedQuotes.ToUlcerIndex(lookbackPeriods);
 
@@ -120,7 +120,7 @@ public class UlcerIndexHubTests : StreamHubTestBase, ITestChainObserver, ITestCh
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // final results
         IReadOnlyList<SmaResult> actuals

--- a/tests/indicators/s-z/Ultimate/Ultimate.StreamHub.Tests.cs
+++ b/tests/indicators/s-z/Ultimate/Ultimate.StreamHub.Tests.cs
@@ -45,7 +45,7 @@ public class UltimateHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChai
         sut.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<UltimateResult> expectedRevised = RevisedQuotes.ToUltimate(7, 14, 28);
         sut.IsExactly(expectedRevised);
@@ -83,7 +83,7 @@ public class UltimateHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChai
         }
 
         quoteHub.Insert(Quotes[80]);  // Late arrival
-        quoteHub.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // final results
         IReadOnlyList<SmaResult> sut = observer.Results;

--- a/tests/indicators/s-z/VolatilityStop/VolatilityStop.StreamHub.Tests.cs
+++ b/tests/indicators/s-z/VolatilityStop/VolatilityStop.StreamHub.Tests.cs
@@ -41,7 +41,7 @@ public class VolatilityStopHubTests : StreamHubTestBase, ITestQuoteObserver
         sut.IsExactly(expectedOriginal);
 
         // delete (test Remove functionality), should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<VolatilityStopResult> expectedRevised = RevisedQuotes.ToVolatilityStop();
         sut.IsExactly(expectedRevised);

--- a/tests/indicators/s-z/Vortex/Vortex.StreamHub.Tests.cs
+++ b/tests/indicators/s-z/Vortex/Vortex.StreamHub.Tests.cs
@@ -41,7 +41,7 @@ public class VortexHubTests : StreamHubTestBase, ITestQuoteObserver
         actuals.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<VortexResult> expectedRevised = RevisedQuotes.ToVortex(lookbackPeriods);
 

--- a/tests/indicators/s-z/Vwap/Vwap.StreamHub.Tests.cs
+++ b/tests/indicators/s-z/Vwap/Vwap.StreamHub.Tests.cs
@@ -38,7 +38,7 @@ public class VwapHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainPro
         sut.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<VwapResult> expectedRevised = RevisedQuotes.ToVwap();
         sut.IsExactly(expectedRevised);
@@ -52,11 +52,11 @@ public class VwapHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainPro
     [TestMethod]
     public void QuoteObserver_WithWarmupLateArrivalAndRemoval_MatchesSeriesExactlyWithStartDate()
     {
-        List<Quote> quotesList = Quotes.ToList();
-        int length = quotesList.Count;
+        List<Quote> quotes = Quotes.ToList();
+        int length = quotes.Count;
 
         // Use a start date somewhere in the middle
-        DateTime startDate = quotesList[100].Timestamp;
+        DateTime startDate = quotes[100].Timestamp;
 
         // setup quote provider hub
         QuoteHub quoteHub = new();
@@ -64,7 +64,7 @@ public class VwapHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainPro
         // prefill quotes at provider
         for (int i = 0; i < 20; i++)
         {
-            quoteHub.Add(quotesList[i]);
+            quoteHub.Add(quotes[i]);
         }
 
         // initialize observer with start date
@@ -79,7 +79,7 @@ public class VwapHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainPro
                 continue;
             }
 
-            Quote q = quotesList[i];
+            Quote q = quotes[i];
             quoteHub.Add(q);
 
             // resend duplicate quotes
@@ -90,14 +90,14 @@ public class VwapHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainPro
         }
 
         // late arrival
-        quoteHub.Insert(quotesList[80]);
+        quoteHub.Insert(quotes[80]);
 
         // removal
-        quoteHub.Remove(quotesList[400]);
-        quotesList.RemoveAt(400);
+        quoteHub.RemoveAt(removeAtIndex);
+        quotes.RemoveAt(removeAtIndex);
 
         // final results
-        IReadOnlyList<VwapResult> seriesList = quotesList.ToVwap(startDate);
+        IReadOnlyList<VwapResult> seriesList = quotes.ToVwap(startDate);
 
         observer.Results.Should().HaveCount(length - 1);
         observer.Results.IsExactly(seriesList);
@@ -133,7 +133,7 @@ public class VwapHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainPro
         }
 
         quoteHub.Insert(Quotes[80]);  // Late arrival
-        quoteHub.Remove(Quotes[removeAtIndex]);  // Remove
+        quoteHub.RemoveAt(removeAtIndex);  // Remove
 
         // final results
         IReadOnlyList<SmaResult> sut = observer.Results;

--- a/tests/indicators/s-z/Vwma/Vwma.StreamHub.Tests.cs
+++ b/tests/indicators/s-z/Vwma/Vwma.StreamHub.Tests.cs
@@ -41,7 +41,7 @@ public class VwmaHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainPro
         actuals.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<VwmaResult> expectedRevised = RevisedQuotes.ToVwma(lookbackPeriods);
 
@@ -85,7 +85,7 @@ public class VwmaHubTests : StreamHubTestBase, ITestQuoteObserver, ITestChainPro
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // final results
         IReadOnlyList<SmaResult> actuals

--- a/tests/indicators/s-z/WilliamsR/WilliamsR.StreamHub.Tests.cs
+++ b/tests/indicators/s-z/WilliamsR/WilliamsR.StreamHub.Tests.cs
@@ -50,7 +50,7 @@ public class WilliamsRHubTests : StreamHubTestBase, ITestQuoteObserver
         actuals.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         IReadOnlyList<WilliamsResult> expectedRevised = RevisedQuotes.ToWilliamsR(lookbackPeriods);
 

--- a/tests/indicators/s-z/Wma/Wma.StreamHub.Tests.cs
+++ b/tests/indicators/s-z/Wma/Wma.StreamHub.Tests.cs
@@ -40,7 +40,7 @@ public class WmaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
         sut.IsExactly(expectedOriginal);
 
         // delete, should equal series (revised)
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
         IReadOnlyList<WmaResult> expectedRevised = RevisedQuotes.ToWma(LookbackPeriods);
         sut.IsExactly(expectedRevised);
         sut.Should().HaveCount(quotesCount - 1);
@@ -112,7 +112,7 @@ public class WmaHubTests : StreamHubTestBase, ITestChainObserver, ITestChainProv
         quoteHub.Insert(Quotes[80]);
 
         // delete
-        quoteHub.Remove(Quotes[removeAtIndex]);
+        quoteHub.RemoveAt(removeAtIndex);
 
         // final results
         IReadOnlyList<EmaResult> sut = observer.Results;


### PR DESCRIPTION
Fixes variants in `IStreamHub` to better enable collections of hubs.

- adds `out TOut` for `IStreamHub`
- adds `HubCollection` as general utility
- adds `IReusable` where _loosely feasible_ (not all)

```csharp
  HubCollection hubs = [
      quotes.ToQuoteHub(),
      quotes.ToEmaHub(14),
      quotes.ToRsiHub(14),
      quotes.ToDonchianHub(20),
      quotes.ToObvHub()
  ];
  
  IStreamObservable<ISeries>[] observableHubs = [
      quotes.ToEmaHub(14),
      quotes.ToRsiHub(14),
      quotes.ToDonchianHub(20),
      quotes.ToObvHub()
  ];
  
  IStreamObservable<IReusable>[] reusableHubs = [
      quotes.ToEmaHub(14),
      quotes.ToRsiHub(14)
  ];
  
  IStreamHub<IQuote, IReusable>[] fullQuoteHubs = [
      quotes.ToEmaHub(14),
      quotes.ToRsiHub(14),
      quotes.ToObvHub()
  ];
```

This picks up some of the contributions by @JGronholz from:
- #1878 