### PR TITLE
fix: StochRsiHub provider notification order

### DIFF
--- a/src/a-d/Chandelier/Chandelier.StreamHub.cs
+++ b/src/a-d/Chandelier/Chandelier.StreamHub.cs
@@ -14,7 +14,7 @@ public class ChandelierHub
         IQuoteProvider<IQuote> provider,
         int lookbackPeriods,
         double multiplier,
-        Direction type) : base(provider)
+        Direction type) : base(provider.ToAtrHub(lookbackPeriods))
     {
         Chandelier.Validate(lookbackPeriods, multiplier);
 
@@ -27,7 +27,7 @@ public class ChandelierHub
             $"CHEXIT({lookbackPeriods},{multiplier},{typeName})");
 
         // Initialize internal ATR hub to maintain streaming state
-        atrHub = provider.ToAtrHub(lookbackPeriods);
+        atrHub = (AtrHub)Provider;
 
         // Initialize rolling windows for O(1) amortized max/min tracking
         _highWindow = new RollingWindowMax<double>(lookbackPeriods);

--- a/src/a-d/Chandelier/Chandelier.StreamHub.cs
+++ b/src/a-d/Chandelier/Chandelier.StreamHub.cs
@@ -6,7 +6,6 @@ namespace Skender.Stock.Indicators;
 public class ChandelierHub
     : ChainHub<AtrResult, ChandelierResult>, IChandelier
 {
-    private readonly AtrHub atrHub;
     private readonly IReadOnlyList<IQuote> quoteCache;
     private readonly RollingWindowMax<double> _highWindow;
     private readonly RollingWindowMin<double> _lowWindow;
@@ -27,9 +26,6 @@ public class ChandelierHub
         string typeName = type.ToString().ToUpperInvariant();
         Name = FormattableString.Invariant(
             $"CHEXIT({lookbackPeriods},{multiplier},{typeName})");
-
-        // Store reference to ATR hub (which is now our provider)
-        atrHub = (AtrHub)Provider;
 
         // Store reference to the underlying quote cache for High/Low access
         quoteCache = quoteProvider.Quotes;

--- a/src/a-d/ConnorsRsi/ConnorsRsi.StreamHub.cs
+++ b/src/a-d/ConnorsRsi/ConnorsRsi.StreamHub.cs
@@ -28,7 +28,7 @@ public class ConnorsRsiHub
         Name = $"CRSI({rsiPeriods},{streakPeriods},{rankPeriods})";
 
         // Create internal hub for price RSI
-        rsiHub = provider.ToRsiHub(rsiPeriods);
+        rsiHub = (RsiHub)Provider;
 
         // Initialize state
         streakBuffer = [];
@@ -390,5 +390,5 @@ public static partial class ConnorsRsi
         int rsiPeriods = 3,
         int streakPeriods = 2,
         int rankPeriods = 100)
-        => new(chainProvider, rsiPeriods, streakPeriods, rankPeriods);
+        => new(chainProvider.ToRsiHub(rsiPeriods), rsiPeriods, streakPeriods, rankPeriods);
 }

--- a/src/a-d/ConnorsRsi/ConnorsRsi.StreamHub.cs
+++ b/src/a-d/ConnorsRsi/ConnorsRsi.StreamHub.cs
@@ -4,9 +4,8 @@ namespace Skender.Stock.Indicators;
 /// Streaming hub for Connors RSI indicator in a streaming context.
 /// </summary>
 public class ConnorsRsiHub
-    : ChainHub<IReusable, ConnorsRsiResult>, IConnorsRsi
+    : ChainHub<RsiResult, ConnorsRsiResult>, IConnorsRsi
 {
-    private readonly RsiHub rsiHub;
     private readonly List<double> streakBuffer;
     private readonly Queue<double> gainBuffer;
     private double streak;
@@ -15,7 +14,7 @@ public class ConnorsRsiHub
     private double streakAvgLoss;
 
     internal ConnorsRsiHub(
-        IChainProvider<IReusable> provider,
+        IChainProvider<RsiResult> provider,
         int rsiPeriods,
         int streakPeriods,
         int rankPeriods) : base(provider)
@@ -26,9 +25,6 @@ public class ConnorsRsiHub
         RankPeriods = rankPeriods;
 
         Name = $"CRSI({rsiPeriods},{streakPeriods},{rankPeriods})";
-
-        // Create internal hub for price RSI
-        rsiHub = (RsiHub)Provider;
 
         // Initialize state
         streakBuffer = [];
@@ -51,14 +47,14 @@ public class ConnorsRsiHub
     public int RankPeriods { get; init; }
     /// <inheritdoc/>
     protected override (ConnorsRsiResult result, int index)
-        ToIndicator(IReusable item, int? indexHint)
+        ToIndicator(RsiResult item, int? indexHint)
     {
         ArgumentNullException.ThrowIfNull(item);
 
         int i = indexHint ?? ProviderCache.IndexOf(item, true);
 
         // Get RSI from embedded hub
-        double? rsi = rsiHub.Cache[i].Rsi;
+        double? rsi = item.Rsi;
 
         // Calculate streak
         double currentValue = item.Value;
@@ -263,7 +259,7 @@ public class ConnorsRsiHub
         // Replay values to restore state
         for (int i = 0; i <= targetIndex; i++)
         {
-            IReusable item = ProviderCache[i];
+            RsiResult item = ProviderCache[i];
             double value = item.Value;
 
             // Restore streak

--- a/src/s-z/StochRsi/StochRsi.StreamHub.cs
+++ b/src/s-z/StochRsi/StochRsi.StreamHub.cs
@@ -7,11 +7,6 @@ public sealed class StochRsiHub
     : ChainHub<IReusable, StochRsiResult>
 {
     /// <summary>
-    /// Internal RSI hub for incremental RSI calculation
-    /// </summary>
-    private readonly RsiHub rsiHub;
-
-    /// <summary>
     /// Rolling windows for O(1) RSI max/min tracking
     /// </summary>
     private readonly RollingWindowMax<double> _rsiMaxWindow;
@@ -41,9 +36,6 @@ public sealed class StochRsiHub
         SmoothPeriods = smoothPeriods;
 
         Name = $"STOCH-RSI({rsiPeriods},{stochPeriods},{signalPeriods},{smoothPeriods})";
-
-        // Store reference to RSI hub (which is now our provider)
-        rsiHub = (RsiHub)Provider;
 
         // Rolling windows for O(1) RSI max/min tracking
         _rsiMaxWindow = new RollingWindowMax<double>(stochPeriods);

--- a/src/s-z/StochRsi/StochRsi.StreamHub.cs
+++ b/src/s-z/StochRsi/StochRsi.StreamHub.cs
@@ -31,7 +31,7 @@ public sealed class StochRsiHub
         int rsiPeriods = 14,
         int stochPeriods = 14,
         int signalPeriods = 3,
-        int smoothPeriods = 1) : base(provider.ToRsiHub(rsiPeriods))
+        int smoothPeriods = 1) : base(provider)
     {
         StochRsi.Validate(rsiPeriods, stochPeriods, signalPeriods, smoothPeriods);
 
@@ -236,5 +236,5 @@ public static partial class StochRsi
         int stochPeriods = 14,
         int signalPeriods = 3,
         int smoothPeriods = 1)
-        => new(chainProvider, rsiPeriods, stochPeriods, signalPeriods, smoothPeriods);
+        => new(chainProvider.ToRsiHub(rsiPeriods), rsiPeriods, stochPeriods, signalPeriods, smoothPeriods);
 }

--- a/tests/indicators/a-d/Chandelier/Chandelier.StreamHub.Tests.cs
+++ b/tests/indicators/a-d/Chandelier/Chandelier.StreamHub.Tests.cs
@@ -95,7 +95,8 @@ public class Chandelier : StreamHubTestBase, ITestQuoteObserver
     [TestMethod]
     public override void ToStringOverride_ReturnsExpectedName()
     {
-        ChandelierHub hub = new(new QuoteHub(), 22, 3, Direction.Long);
+        QuoteHub quoteHub = new();
+        ChandelierHub hub = new(quoteHub.ToAtrHub(22), quoteHub, 22, 3, Direction.Long);
         hub.ToString().Should().Be("CHEXIT(22,3,LONG)");
     }
 }


### PR DESCRIPTION
Initial problem:
IndexOutOfRangeException at `rsiHub.Cache[i];`

Investigating led me here:
provider > rsiHub
provider > stochRsiHub
Q: When provider triggers rebuild, who goes first?
A: RsiHub needs to always go first.

So, we just make rsiHub the stochHub's provider:
provider > rsiHub > stochRsiHub

Changes:
- Constructor chains through RsiHub (base(provider.ToRsiHub()) not base(provider))
- ToIndicator casts item to RsiResult and uses it directly
- RollbackState replays from ProviderCache (RsiResults) without triggering rsiHub rebuild
- Eliminates infinite recursion and synchronization issues
- Results match Series implementation exactly