### PR TITLE
test: compound hub failure mode (race)

### DIFF
--- a/docs/hub-with-hub-analysis.md
+++ b/docs/hub-with-hub-analysis.md
@@ -1,0 +1,205 @@
+# Hub-with-Hub Pattern Analysis
+
+This document analyzes all StreamHub implementations that use internal hubs, examining their subscription patterns and potential race conditions.
+
+## Overview
+
+The StochRsiHub race condition (documented in this PR) revealed an architectural pattern that affects multiple indicators. This analysis examines all hubs-with-hubs to identify similar issues.
+
+## StochRsiHub - BROKEN (v3)
+
+**Pattern:** StochRsiHub contains internal RsiHub
+
+**v3 Implementation (BROKEN):**
+
+```csharp
+internal StochRsiHub(IChainProvider<IReusable> provider, ...) 
+    : base(provider)  // ❌ BROKEN: subscribes to same provider as rsiHub
+{
+    rsiHub = provider.ToRsiHub(rsiPeriods);  // Both subscribe to same provider
+}
+```
+
+**Failure Mode:**
+
+- During rebuild (late arrival, removal), `ToIndicator()` accesses `rsiHub.Cache[i]`
+- Race condition: If StochRsiHub processes update before rsiHub, `Cache[i]` doesn't exist
+- Result: `ArgumentOutOfRangeException` at line 81: `rsiHub.Cache[i]`
+
+**Correct Architecture (post-fix):**
+
+```csharp
+internal StochRsiHub(IChainProvider<IReusable> provider, ...) 
+    : base(provider.ToRsiHub(rsiPeriods))  // ✅ CORRECT: chains through RsiHub
+{
+    rsiHub = (RsiHub)ProviderCache;  // Reference to our provider
+}
+```
+
+Data flow: `provider → RsiHub → StochRsiHub` (proper chaining eliminates race condition)
+
+## ConnorsRsiHub - BROKEN (v3)
+
+**Pattern:** ConnorsRsiHub contains internal RsiHub
+
+**v3 Implementation (BROKEN):**
+
+```csharp
+internal ConnorsRsiHub(IChainProvider<IReusable> provider, ...) 
+    : base(provider)  // ❌ BROKEN: same pattern as StochRsiHub
+{
+    rsiHub = provider.ToRsiHub(rsiPeriods);  // Both subscribe to same provider
+}
+```
+
+**Failure Mode:**
+
+- Identical race condition to StochRsiHub
+- Line 61: `double? rsi = rsiHub.Cache[i].Rsi;` can throw `ArgumentOutOfRangeException`
+- Occurs during rebuild operations when ConnorsRsiHub processes before rsiHub
+
+**Correct Architecture (post-fix):**
+
+```csharp
+internal ConnorsRsiHub(IChainProvider<IReusable> provider, ...) 
+    : base(provider.ToRsiHub(rsiPeriods))  // ✅ CORRECT
+{
+    rsiHub = (RsiHub)ProviderCache;
+}
+```
+
+## ChandelierHub - BROKEN (v3)
+
+**Pattern:** ChandelierHub contains internal AtrHub
+
+**v3 Implementation (BROKEN):**
+
+```csharp
+internal ChandelierHub(IQuoteProvider<IQuote> provider, ...) 
+    : base(provider)  // ❌ BROKEN: same pattern
+{
+    atrHub = provider.ToAtrHub(lookbackPeriods);  // Both subscribe to same provider
+}
+```
+
+**Failure Mode:**
+
+- Line 76: `double? atr = atrHub.Cache[i].Atr;` can throw `ArgumentOutOfRangeException`
+- ChandelierHub even has defensive bounds checking at lines 68-74, suggesting awareness of the issue
+- Current code has a comment "System invariant" claiming atrHub processes first, but this is not guaranteed
+
+**Correct Architecture (post-fix):**
+
+```csharp
+internal ChandelierHub(IQuoteProvider<IQuote> provider, ...) 
+    : base(provider.ToAtrHub(lookbackPeriods))  // ✅ CORRECT
+{
+    atrHub = (AtrHub)ProviderCache;
+}
+```
+
+## GatorHub - CORRECT (v3)
+
+**Pattern:** GatorHub subscribes to AlligatorHub
+
+**v3 Implementation (CORRECT):**
+
+```csharp
+internal GatorHub(AlligatorHub alligatorHub)
+    : base(alligatorHub)  // ✅ CORRECT: subscribes directly to AlligatorHub
+{
+    // No internal hub created - properly chains
+}
+```
+
+**Why This Works:**
+
+- Gator doesn't create an internal AlligatorHub
+- It receives AlligatorHub as parameter and subscribes to it
+- No race condition possible - proper provider chain from the start
+
+**Extension Method Pattern:**
+
+```csharp
+public static GatorHub ToGatorHub(this IChainProvider<IReusable> chainProvider)
+{
+    AlligatorHub alligatorHub = chainProvider.ToAlligatorHub();  // Create hub
+    return new GatorHub(alligatorHub);  // Pass as provider
+}
+```
+
+This is the CORRECT pattern - create the inner hub in the extension method, pass it as the provider to the outer hub's constructor.
+
+## PvoHub - CORRECT (v3)
+
+**Pattern:** PvoHub uses provider transformation in extension method
+
+**v3 Implementation (CORRECT):**
+
+```csharp
+public static PvoHub ToPvoHub(this IQuoteProvider<IQuote> quoteProvider, ...)
+    => quoteProvider
+        .ToQuotePartHub(CandlePart.Volume)  // ✅ Transform provider first
+        .ToPvoHub(fastPeriods, slowPeriods, signalPeriods);  // Then create hub
+```
+
+**Why This Works:**
+
+- PvoHub itself doesn't create any internal hubs
+- Extension method transforms the provider chain before creating PvoHub
+- Data flows: `QuoteHub → QuotePartHub → PvoHub`
+- No race condition - proper chaining
+
+## Summary
+
+| Hub | Internal Hub | v3 Status | Issue |
+|-----|--------------|-----------|-------|
+| **StochRsiHub** | RsiHub | ❌ BROKEN | Race condition: `rsiHub.Cache[i]` |
+| **ConnorsRsiHub** | RsiHub | ❌ BROKEN | Race condition: `rsiHub.Cache[i]` |
+| **ChandelierHub** | AtrHub | ❌ BROKEN | Race condition: `atrHub.Cache[i]` |
+| **GatorHub** | AlligatorHub | ✅ CORRECT | Chains properly |
+| **PvoHub** | QuotePartHub | ✅ CORRECT | Transforms provider |
+
+## Architectural Patterns
+
+### Anti-Pattern (BROKEN)
+
+```csharp
+internal OuterHub(IProvider provider) : base(provider)
+{
+    innerHub = provider.ToInnerHub();  // ❌ Both subscribe to same provider
+}
+```
+
+### Correct Pattern 1 - Pass Hub as Provider
+
+```csharp
+internal OuterHub(InnerHub innerHub) : base(innerHub)  // ✅ Subscribe to inner hub
+{
+    // innerHub is our provider, no duplicate subscription
+}
+
+// Extension method creates and chains:
+public static OuterHub ToOuterHub(this IProvider provider)
+{
+    InnerHub inner = provider.ToInnerHub();
+    return new OuterHub(inner);
+}
+```
+
+### Correct Pattern 2 - Chain in Base Constructor
+
+```csharp
+internal OuterHub(IProvider provider) 
+    : base(provider.ToInnerHub())  // ✅ Chain through inner hub
+{
+    innerHub = (InnerHub)ProviderCache;  // Reference to our provider
+}
+```
+
+## Recommendation
+
+All three broken hubs (StochRsiHub, ConnorsRsiHub, ChandelierHub) should be fixed using **Correct Pattern 2** to eliminate race conditions and ensure deterministic notification ordering.
+
+---
+Last updated: 2026-01-15

--- a/tests/indicators/s-z/StochRsi/StochRsi.StreamHub.RaceCondition.Tests.cs
+++ b/tests/indicators/s-z/StochRsi/StochRsi.StreamHub.RaceCondition.Tests.cs
@@ -1,0 +1,125 @@
+namespace StreamHubs;
+
+using TestData = Test.Data.Data;
+
+/// <summary>
+/// Tests demonstrating the pre-fix race condition failure mode in StochRsiHub.
+/// 
+/// ARCHITECTURAL FLAW (v3 broken implementation):
+/// Both StochRsiHub and its internal rsiHub subscribed to the same provider:
+///   : base(provider)  // StochRsiHub subscribes to provider
+///   rsiHub = provider.ToRsiHub(rsiPeriods);  // rsiHub ALSO subscribes to provider
+///
+/// FAILURE MODE:
+/// During rebuild operations (late arrival, removal), ToIndicator() accesses rsiHub.Cache[i]
+/// before the internal rsiHub has processed the update and populated that cache entry.
+/// No ordering guarantee exists → ArgumentOutOfRangeException when Cache[i] doesn't exist.
+///
+/// CORRECT ARCHITECTURE (post-fix):
+///   : base(provider.ToRsiHub(rsiPeriods))  // StochRsiHub subscribes to RsiHub
+///   rsiHub = (RsiHub)ProviderCache;  // Reference to our provider (which is RsiHub)
+/// Data flow: provider → RsiHub → StochRsiHub (proper chaining eliminates race condition)
+/// </summary>
+[TestClass]
+public class StochRsiHubRaceConditionTests
+{
+    private static readonly IReadOnlyList<Quote> Quotes = TestData.GetDefault();
+
+    /// <summary>
+    /// Demonstrates ArgumentOutOfRangeException during late arrival scenario.
+    /// The broken implementation fails because rsiHub.Cache[i] doesn't exist yet.
+    /// </summary>
+    [TestMethod]
+    public void BrokenImplementation_LateArrival_ThrowsIndexOutOfRangeException()
+    {
+        // Setup: QuoteHub with initial quotes
+        QuoteHub quoteHub = new();
+
+        quoteHub.Add(Quotes.Take(20));
+
+        // Create StochRsiHub (broken: both hubs subscribe to same provider)
+        StochRsiHub observer = quoteHub.ToStochRsiHub(14, 14, 3, 1);
+
+        // Add more quotes normally
+        for (int i = 20; i < 80; i++)
+        {
+            quoteHub.Add(Quotes[i]);
+        }
+
+        // Skip quote 80
+        for (int i = 81; i < Quotes.Count; i++)
+        {
+            quoteHub.Add(Quotes[i]);
+        }
+
+        // Late arrival triggers rebuild: THIS THROWS ArgumentOutOfRangeException
+        // During rebuild, StochRsiHub.ToIndicator() tries to access rsiHub.Cache[i]
+        // but rsiHub hasn't processed that index yet → Cache[i] doesn't exist
+        Action act = () => quoteHub.Insert(Quotes[80]);
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithMessage("*Index was out of range*");
+
+        observer.Unsubscribe();
+        quoteHub.EndTransmission();
+    }
+
+    /// <summary>
+    /// Demonstrates ArgumentOutOfRangeException during removal scenario.
+    /// The broken implementation fails during rebuild after removing a quote.
+    /// </summary>
+    [TestMethod]
+    public void BrokenImplementation_Removal_ThrowsIndexOutOfRangeException()
+    {
+        // Setup: QuoteHub with all quotes
+        QuoteHub quoteHub = new();
+        quoteHub.Add(Quotes);
+
+        // Create StochRsiHub (broken: both hubs subscribe to same provider)
+        StochRsiHub observer = quoteHub.ToStochRsiHub(14, 14, 3, 1);
+
+        // Remove a quote triggers rebuild: THIS THROWS ArgumentOutOfRangeException
+        // StochRsiHub rebuilds and tries to access rsiHub.Cache[i] before
+        // rsiHub has rebuilt its cache → ArgumentOutOfRangeException
+        Action act = () => quoteHub.RemoveAt(250);
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithMessage("*Index was out of range*");
+
+        observer.Unsubscribe();
+        quoteHub.EndTransmission();
+    }
+
+    /// <summary>
+    /// Documents the race condition: no ordering guarantee between hubs.
+    /// When both subscribe to same provider, notification order is undefined.
+    /// </summary>
+    [TestMethod]
+    public void BrokenImplementation_ExplainsRaceCondition()
+    {
+        // The fundamental issue with the broken implementation:
+        //
+        // QuoteHub notifies all subscribers when a quote is added/inserted/removed.
+        // With broken architecture:
+        //   - StochRsiHub subscribes to QuoteHub
+        //   - Internal rsiHub ALSO subscribes to QuoteHub
+        //
+        // During rebuild (triggered by Insert or RemoveAt):
+        //   1. QuoteHub notifies subscribers in UNDEFINED order
+        //   2. If StochRsiHub processes update BEFORE rsiHub:
+        //      - StochRsiHub.ToIndicator(item, i) executes
+        //      - Tries to access rsiHub.Cache[i]
+        //      - But rsiHub hasn't processed this update yet!
+        //      - rsiHub.Cache.Count is still < i
+        //      - ArgumentOutOfRangeException thrown
+        //
+        // The fix chains the hubs properly:
+        //   - StochRsiHub subscribes to RsiHub (not QuoteHub)
+        //   - RsiHub subscribes to QuoteHub
+        //   - Data flows: QuoteHub → RsiHub → StochRsiHub
+        //   - When StochRsiHub receives update, RsiHub has already processed it
+        //   - rsiHub.Cache[i] is guaranteed to exist
+
+        Assert.IsTrue(true, "This test documents the race condition architecture");
+    }
+}


### PR DESCRIPTION
As requested, this "demonstrates" a failure-mode of incorrectly-chained hubs-within-hubs.

Many compound hubs were already correctly chained!

The issue with StochRsiHub was that the RsiHub hadn't created a result yet (race condition).
The exception was ArgumentOutOfRange (index).
Copilot "fixed" it by adding bounds-checking.
Copilot may have encountered this issue with ChandelierHub and "fixed" it the same way.

The real solution was to correctly chain the hubs.
ChandelierHub was correctly chained, but may have (unneccessary?) bounds-checking.

This PR revealed a better way than cramming everything into ctor:
```
 : base(provider.ToRsiHub(rsiPeriods)) //rsiHub is the provider for StochRsiHub
```

which is to have the static hub-creator methods create the upstream chain, then instantiate the hub.
```
StochRsiHub ToStochRsiHub(this provider, rsiPeriods, XYZ) 
{ 
   var rsiHub = provider.ToRsiHub(rsiPeriods);
   return new(rsiHub, XYZ); //rsiHub is the provider for StochRsiHub
}
```

```
var rsiHub = provider.ToRsiHub(rsiPeriods);
```
used to be in the body of StochRsiHub ctor (after it's provider was already assigned).
RsiHub should be StochRsiHub's provider, not provider.