### PR TITLE
feat: Add AsStaticSeries method to StreamHub

### DIFF
--- a/src/_common/QuotePart/QuotePart.StreamHub.cs
+++ b/src/_common/QuotePart/QuotePart.StreamHub.cs
@@ -16,6 +16,10 @@ public class QuotePartHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<TimeValue> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToQuotePart(CandlePartSelection);
     /// <inheritdoc/>
     public CandlePart CandlePartSelection { get; init; }
 

--- a/src/_common/Quotes/Quote.StreamHub.cs
+++ b/src/_common/Quotes/Quote.StreamHub.cs
@@ -47,6 +47,10 @@ public class QuoteHub
     }
 
     /// <inheritdoc/>
+    public override IReadOnlyList<IQuote> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input;
+
+    /// <inheritdoc/>
     protected override (IQuote result, int index)
         ToIndicator(IQuote item, int? indexHint)
     {

--- a/src/_common/StreamHub/IStreamHub.cs
+++ b/src/_common/StreamHub/IStreamHub.cs
@@ -161,6 +161,13 @@ public interface IStreamHub<in TIn, out TOut> : IStreamObserver<TIn>, IStreamObs
     void Rebuild(int fromIndex);
 
     /// <summary>
+    /// Converts input to results using the static series algorithm.
+    /// </summary>
+    /// <param name="input">Input data</param>
+    /// <returns>List of output results</returns>
+    IReadOnlyList<TOut> AsStaticSeries(IReadOnlyList<TIn> input);
+
+    /// <summary>
     /// Returns a short text label for the hub
     /// with parameter values, e.g. "EMA(10)"
     /// </summary>

--- a/src/_common/StreamHub/StreamHub.cs
+++ b/src/_common/StreamHub/StreamHub.cs
@@ -240,6 +240,9 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamHub<TIn, TOut>
     /// <inheritdoc/>
     public override string ToString() => Name;
 
+    /// <inheritdoc/>
+    public abstract IReadOnlyList<TOut> AsStaticSeries(IReadOnlyList<TIn> input);
+
     /// <summary>
     /// Converts incremental value into an indicator candidate and cache position.
     /// </summary>

--- a/src/a-d/Adl/Adl.StreamHub.cs
+++ b/src/a-d/Adl/Adl.StreamHub.cs
@@ -13,6 +13,10 @@ public class AdlHub : ChainHub<IQuote, AdlResult>
     }
 
     /// <inheritdoc/>
+    public override IReadOnlyList<AdlResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToAdl();
+
+    /// <inheritdoc/>
     protected override (AdlResult result, int index)
         ToIndicator(IQuote item, int? indexHint)
     {

--- a/src/a-d/Adx/Adx.StreamHub.cs
+++ b/src/a-d/Adx/Adx.StreamHub.cs
@@ -30,6 +30,10 @@ public class AdxHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<AdxResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToAdx(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
 

--- a/src/a-d/Alligator/Alligator.StreamHub.cs
+++ b/src/a-d/Alligator/Alligator.StreamHub.cs
@@ -30,6 +30,10 @@ public class AlligatorHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<AlligatorResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToAlligator(JawPeriods, JawOffset, TeethPeriods, TeethOffset, LipsPeriods, LipsOffset);
     /// <inheritdoc/>
     public int JawPeriods { get; init; }
 

--- a/src/a-d/Alma/Alma.StreamHub.cs
+++ b/src/a-d/Alma/Alma.StreamHub.cs
@@ -40,6 +40,10 @@ public class AlmaHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<AlmaResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToAlma(LookbackPeriods, Offset, Sigma);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
 

--- a/src/a-d/Aroon/Aroon.StreamHub.cs
+++ b/src/a-d/Aroon/Aroon.StreamHub.cs
@@ -17,6 +17,10 @@ public class AroonHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<AroonResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToAroon(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
     /// <inheritdoc/>

--- a/src/a-d/Atr/Atr.StreamHub.cs
+++ b/src/a-d/Atr/Atr.StreamHub.cs
@@ -17,6 +17,10 @@ public class AtrHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<AtrResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToAtr(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
 

--- a/src/a-d/AtrStop/AtrStop.StreamHub.cs
+++ b/src/a-d/AtrStop/AtrStop.StreamHub.cs
@@ -22,6 +22,10 @@ public class AtrStopHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<AtrStopResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToAtrStop(LookbackPeriods, Multiplier, EndType);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
 

--- a/src/a-d/Awesome/Awesome.StreamHub.cs
+++ b/src/a-d/Awesome/Awesome.StreamHub.cs
@@ -19,6 +19,10 @@ public class AwesomeHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<AwesomeResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToAwesome(FastPeriods, SlowPeriods);
     /// <inheritdoc/>
     public int FastPeriods { get; init; }
 

--- a/src/a-d/BollingerBands/BollingerBands.StreamHub.cs
+++ b/src/a-d/BollingerBands/BollingerBands.StreamHub.cs
@@ -19,6 +19,10 @@ public class BollingerBandsHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<BollingerBandsResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToBollingerBands(LookbackPeriods, StandardDeviations);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
 

--- a/src/a-d/Bop/Bop.StreamHub.cs
+++ b/src/a-d/Bop/Bop.StreamHub.cs
@@ -17,6 +17,10 @@ public class BopHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<BopResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToBop(SmoothPeriods);
     /// <inheritdoc/>
     public int SmoothPeriods { get; init; }
     /// <inheritdoc/>

--- a/src/a-d/Cci/Cci.StreamHub.cs
+++ b/src/a-d/Cci/Cci.StreamHub.cs
@@ -20,6 +20,10 @@ public class CciHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<CciResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToCci(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
     /// <inheritdoc/>

--- a/src/a-d/ChaikinOsc/ChaikinOsc.StreamHub.cs
+++ b/src/a-d/ChaikinOsc/ChaikinOsc.StreamHub.cs
@@ -23,6 +23,10 @@ public class ChaikinOscHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<ChaikinOscResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToChaikinOsc(FastPeriods, SlowPeriods);
     /// <inheritdoc/>
     public int FastPeriods { get; init; }
 

--- a/src/a-d/Chandelier/Chandelier.StreamHub.cs
+++ b/src/a-d/Chandelier/Chandelier.StreamHub.cs
@@ -36,6 +36,10 @@ public class ChandelierHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<ChandelierResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToChandelier(LookbackPeriods, Multiplier, Type);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
 

--- a/src/a-d/Chop/Chop.StreamHub.cs
+++ b/src/a-d/Chop/Chop.StreamHub.cs
@@ -26,6 +26,10 @@ public class ChopHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<ChopResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToChop(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
     /// <inheritdoc/>

--- a/src/a-d/Cmf/Cmf.StreamHub.cs
+++ b/src/a-d/Cmf/Cmf.StreamHub.cs
@@ -18,6 +18,10 @@ public class CmfHub : ChainHub<IQuote, CmfResult>, ICmf
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<CmfResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToCmf(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
 

--- a/src/a-d/Cmo/Cmo.StreamHub.cs
+++ b/src/a-d/Cmo/Cmo.StreamHub.cs
@@ -20,6 +20,10 @@ public class CmoHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<CmoResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToCmo(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
     /// <inheritdoc/>

--- a/src/a-d/ConnorsRsi/ConnorsRsi.StreamHub.cs
+++ b/src/a-d/ConnorsRsi/ConnorsRsi.StreamHub.cs
@@ -41,6 +41,10 @@ public class ConnorsRsiHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<ConnorsRsiResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToConnorsRsi(RsiPeriods, StreakPeriods, RankPeriods);
     /// <inheritdoc/>
     public int RsiPeriods { get; init; }
 

--- a/src/a-d/Dema/Dema.StreamHub.cs
+++ b/src/a-d/Dema/Dema.StreamHub.cs
@@ -21,6 +21,10 @@ public class DemaHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<DemaResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToDema(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
 

--- a/src/a-d/Doji/Doji.StreamHub.cs
+++ b/src/a-d/Doji/Doji.StreamHub.cs
@@ -20,6 +20,10 @@ public class DojiHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<CandleResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToDoji(MaxPriceChangePercent);
     /// <inheritdoc/>
     public double MaxPriceChangePercent { get; init; }
     /// <inheritdoc/>

--- a/src/a-d/Donchian/Donchian.StreamHub.cs
+++ b/src/a-d/Donchian/Donchian.StreamHub.cs
@@ -40,6 +40,10 @@ public class DonchianHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<DonchianResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToDonchian(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
     /// <inheritdoc/>

--- a/src/a-d/Dpo/Dpo.StreamHub.cs
+++ b/src/a-d/Dpo/Dpo.StreamHub.cs
@@ -25,6 +25,10 @@ public class DpoHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<DpoResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToDpo(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
 

--- a/src/a-d/Dynamic/Dynamic.StreamHub.cs
+++ b/src/a-d/Dynamic/Dynamic.StreamHub.cs
@@ -19,6 +19,10 @@ public class DynamicHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<DynamicResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToDynamic(LookbackPeriods, KFactor);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
 

--- a/src/e-k/ElderRay/ElderRay.StreamHub.cs
+++ b/src/e-k/ElderRay/ElderRay.StreamHub.cs
@@ -19,6 +19,10 @@ public class ElderRayHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<ElderRayResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToElderRay(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
 

--- a/src/e-k/Ema/Ema.StreamHub.cs
+++ b/src/e-k/Ema/Ema.StreamHub.cs
@@ -23,6 +23,11 @@ public class EmaHub
 
     /// <inheritdoc/>
     public double K { get; private init; }
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<EmaResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToEma(LookbackPeriods);
+
     /// <inheritdoc/>
     protected override (EmaResult result, int index)
         ToIndicator(IReusable item, int? indexHint)

--- a/src/e-k/Epma/Epma.StreamHub.cs
+++ b/src/e-k/Epma/Epma.StreamHub.cs
@@ -17,6 +17,10 @@ public class EpmaHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<EpmaResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToEpma(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
 

--- a/src/e-k/Fcb/Fcb.StreamHub.cs
+++ b/src/e-k/Fcb/Fcb.StreamHub.cs
@@ -17,6 +17,10 @@ public class FcbHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<FcbResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToFcb(WindowSpan);
     /// <inheritdoc/>
     public int WindowSpan { get; init; }
 

--- a/src/e-k/FisherTransform/FisherTransform.StreamHub.cs
+++ b/src/e-k/FisherTransform/FisherTransform.StreamHub.cs
@@ -32,6 +32,10 @@ public class FisherTransformHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<FisherTransformResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToFisherTransform(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
     /// <inheritdoc/>

--- a/src/e-k/ForceIndex/ForceIndex.StreamHub.cs
+++ b/src/e-k/ForceIndex/ForceIndex.StreamHub.cs
@@ -21,6 +21,10 @@ public class ForceIndexHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<ForceIndexResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => ((IReadOnlyList<IQuote>)input).ToForceIndex(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
 

--- a/src/e-k/Fractal/Fractal.StreamHub.cs
+++ b/src/e-k/Fractal/Fractal.StreamHub.cs
@@ -38,6 +38,10 @@ public class FractalHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<FractalResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToFractal(LeftSpan, RightSpan, EndType);
     /// <inheritdoc/>
     public int LeftSpan { get; init; }
 

--- a/src/e-k/Gator/Gator.StreamHub.cs
+++ b/src/e-k/Gator/Gator.StreamHub.cs
@@ -15,6 +15,10 @@ public class GatorHub
     }
 
     /// <inheritdoc/>
+    public override IReadOnlyList<GatorResult> AsStaticSeries(IReadOnlyList<AlligatorResult> input)
+        => input.ToGator();
+
+    /// <inheritdoc/>
     protected override (GatorResult result, int index)
         ToIndicator(AlligatorResult item, int? indexHint)
     {

--- a/src/e-k/HeikinAshi/HeikinAshi.StreamHub.cs
+++ b/src/e-k/HeikinAshi/HeikinAshi.StreamHub.cs
@@ -15,6 +15,11 @@ public class HeikinAshiHub
         Name = "HEIKINASHI";
         Reinitialize();
     }
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<HeikinAshiResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToHeikinAshi();
+
     /// <inheritdoc/>
     protected override (HeikinAshiResult result, int index)
         ToIndicator(IQuote item, int? indexHint)

--- a/src/e-k/Hma/Hma.StreamHub.cs
+++ b/src/e-k/Hma/Hma.StreamHub.cs
@@ -37,6 +37,10 @@ public class HmaHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<HmaResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToHma(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
     /// <inheritdoc/>

--- a/src/e-k/HtTrendline/HtTrendline.StreamHub.cs
+++ b/src/e-k/HtTrendline/HtTrendline.StreamHub.cs
@@ -30,6 +30,11 @@ public class HtTrendlineHub
         Name = "HTL()";
         Reinitialize();
     }
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<HtlResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToHtTrendline();
+
     /// <inheritdoc/>
     protected override (HtlResult result, int index)
         ToIndicator(IReusable item, int? indexHint)

--- a/src/e-k/Hurst/Hurst.StreamHub.cs
+++ b/src/e-k/Hurst/Hurst.StreamHub.cs
@@ -20,6 +20,10 @@ public class HurstHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<HurstResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToHurst(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
     /// <inheritdoc/>

--- a/src/e-k/Ichimoku/Ichimoku.StreamHub.cs
+++ b/src/e-k/Ichimoku/Ichimoku.StreamHub.cs
@@ -44,6 +44,10 @@ public class IchimokuHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<IchimokuResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToIchimoku(TenkanPeriods, KijunPeriods, SenkouBPeriods, SenkouOffset, ChikouOffset);
     /// <inheritdoc/>
     public int TenkanPeriods { get; init; }
 

--- a/src/e-k/Kama/Kama.StreamHub.cs
+++ b/src/e-k/Kama/Kama.StreamHub.cs
@@ -28,6 +28,10 @@ public class KamaHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<KamaResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToKama(ErPeriods, FastPeriods, SlowPeriods);
     /// <inheritdoc/>
     public int ErPeriods { get; init; }
 

--- a/src/e-k/Keltner/Keltner.StreamHub.cs
+++ b/src/e-k/Keltner/Keltner.StreamHub.cs
@@ -27,6 +27,10 @@ public class KeltnerHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<KeltnerResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToKeltner(EmaPeriods, Multiplier, AtrPeriods);
     /// <inheritdoc/>
     public int EmaPeriods { get; init; }
 

--- a/src/e-k/Kvo/Kvo.StreamHub.cs
+++ b/src/e-k/Kvo/Kvo.StreamHub.cs
@@ -71,6 +71,10 @@ public class KvoHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<KvoResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToKvo(FastPeriods, SlowPeriods, SignalPeriods);
     /// <inheritdoc/>
     public int FastPeriods { get; init; }
 

--- a/src/m-r/MaEnvelopes/MaEnvelopes.StreamHub.cs
+++ b/src/m-r/MaEnvelopes/MaEnvelopes.StreamHub.cs
@@ -128,6 +128,10 @@ public class MaEnvelopesHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<MaEnvelopeResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToMaEnvelopes(LookbackPeriods, PercentOffset, MovingAverageType);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
 

--- a/src/m-r/Macd/Macd.StreamHub.cs
+++ b/src/m-r/Macd/Macd.StreamHub.cs
@@ -26,6 +26,10 @@ public class MacdHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<MacdResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToMacd(FastPeriods, SlowPeriods, SignalPeriods);
     /// <inheritdoc/>
     public int FastPeriods { get; init; }
 

--- a/src/m-r/Mama/Mama.StreamHub.cs
+++ b/src/m-r/Mama/Mama.StreamHub.cs
@@ -38,6 +38,10 @@ public class MamaHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<MamaResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToMama(FastLimit, SlowLimit);
     /// <inheritdoc/>
     public double FastLimit { get; init; }
 

--- a/src/m-r/Marubozu/Marubozu.StreamHub.cs
+++ b/src/m-r/Marubozu/Marubozu.StreamHub.cs
@@ -20,6 +20,10 @@ public class MarubozuHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<CandleResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToMarubozu(MinBodyPercent);
     /// <inheritdoc/>
     public double MinBodyPercent { get; init; }
     /// <inheritdoc/>

--- a/src/m-r/Mfi/Mfi.StreamHub.cs
+++ b/src/m-r/Mfi/Mfi.StreamHub.cs
@@ -22,6 +22,10 @@ public class MfiHub : ChainHub<IQuote, MfiResult>, IMfi
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<MfiResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToMfi(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
     /// <inheritdoc/>

--- a/src/m-r/Obv/Obv.StreamHub.cs
+++ b/src/m-r/Obv/Obv.StreamHub.cs
@@ -13,6 +13,10 @@ public class ObvHub : ChainHub<IQuote, ObvResult>
     }
 
     /// <inheritdoc/>
+    public override IReadOnlyList<ObvResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToObv();
+
+    /// <inheritdoc/>
     protected override (ObvResult result, int index)
         ToIndicator(IQuote item, int? indexHint)
     {

--- a/src/m-r/ParabolicSar/ParabolicSar.StreamHub.cs
+++ b/src/m-r/ParabolicSar/ParabolicSar.StreamHub.cs
@@ -43,6 +43,10 @@ public class ParabolicSarHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<ParabolicSarResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToParabolicSar(AccelerationStep, MaxAccelerationFactor, InitialFactor);
     /// <inheritdoc/>
     public double AccelerationStep { get; init; }
 

--- a/src/m-r/PivotPoints/PivotPoints.StreamHub.cs
+++ b/src/m-r/PivotPoints/PivotPoints.StreamHub.cs
@@ -36,6 +36,10 @@ public class PivotPointsHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<PivotPointsResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToPivotPoints(WindowSize, PointType);
     /// <inheritdoc/>
     public PeriodSize WindowSize { get; init; }
 

--- a/src/m-r/Pivots/Pivots.StreamHub.cs
+++ b/src/m-r/Pivots/Pivots.StreamHub.cs
@@ -24,6 +24,10 @@ public class PivotsHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<PivotsResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToPivots(LeftSpan, RightSpan, MaxTrendPeriods, EndType);
     /// <inheritdoc/>
     public int LeftSpan { get; init; }
 

--- a/src/m-r/Pmo/Pmo.StreamHub.cs
+++ b/src/m-r/Pmo/Pmo.StreamHub.cs
@@ -33,6 +33,10 @@ public class PmoHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<PmoResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToPmo(TimePeriods, SmoothPeriods, SignalPeriods);
     /// <inheritdoc/>
     public int TimePeriods { get; init; }
 

--- a/src/m-r/Pvo/Pvo.StreamHub.cs
+++ b/src/m-r/Pvo/Pvo.StreamHub.cs
@@ -29,6 +29,10 @@ public class PvoHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<PvoResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => ((IReadOnlyList<IQuote>)input).ToPvo(FastPeriods, SlowPeriods, SignalPeriods);
     /// <inheritdoc/>
     public int FastPeriods { get; init; }
 

--- a/src/m-r/Renko/Renko.StreamHub.cs
+++ b/src/m-r/Renko/Renko.StreamHub.cs
@@ -31,6 +31,10 @@ public class RenkoHub
     /// </summary>
     public override BinarySettings Properties { get; init; } = new(0b00000010);  // custom
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<RenkoResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToRenko(BrickSize, EndType);
     /// <inheritdoc/>
     public decimal BrickSize { get; }
 

--- a/src/m-r/Roc/Roc.StreamHub.cs
+++ b/src/m-r/Roc/Roc.StreamHub.cs
@@ -17,6 +17,10 @@ public class RocHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<RocResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToRoc(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
     /// <inheritdoc/>

--- a/src/m-r/RocWb/RocWb.StreamHub.cs
+++ b/src/m-r/RocWb/RocWb.StreamHub.cs
@@ -29,6 +29,10 @@ public class RocWbHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<RocWbResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToRocWb(LookbackPeriods, EmaPeriods, StdDevPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
 

--- a/src/m-r/RollingPivots/RollingPivots.StreamHub.cs
+++ b/src/m-r/RollingPivots/RollingPivots.StreamHub.cs
@@ -50,6 +50,10 @@ public class RollingPivotsHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<RollingPivotsResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToRollingPivots(WindowPeriods, OffsetPeriods, PointType);
     /// <inheritdoc/>
     public int WindowPeriods { get; init; }
 

--- a/src/m-r/Rsi/Rsi.StreamHub.cs
+++ b/src/m-r/Rsi/Rsi.StreamHub.cs
@@ -29,6 +29,10 @@ public class RsiHub
     public int LookbackPeriods { get; init; }
 
     /// <inheritdoc/>
+    public override IReadOnlyList<RsiResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToRsi(LookbackPeriods);
+
+    /// <inheritdoc/>
     /// <remarks>
     /// O(1) complexity per quote using Wilder's smoothing for incremental updates.
     /// The initial SMA calculation at lookback period is O(k) where k = lookbackPeriods.

--- a/src/s-z/Slope/Slope.StreamHub.cs
+++ b/src/s-z/Slope/Slope.StreamHub.cs
@@ -44,6 +44,10 @@ public class SlopeHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<SlopeResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToSlope(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
     /// <inheritdoc/>

--- a/src/s-z/Sma/Sma.StreamHub.cs
+++ b/src/s-z/Sma/Sma.StreamHub.cs
@@ -18,6 +18,10 @@ public class SmaHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<SmaResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToSma(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
     /// <inheritdoc/>

--- a/src/s-z/SmaAnalysis/SmaAnalysis.StreamHub.cs
+++ b/src/s-z/SmaAnalysis/SmaAnalysis.StreamHub.cs
@@ -17,6 +17,10 @@ public class SmaAnalysisHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<SmaAnalysisResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToSmaAnalysis(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
     /// <inheritdoc/>

--- a/src/s-z/Smi/Smi.StreamHub.cs
+++ b/src/s-z/Smi/Smi.StreamHub.cs
@@ -65,6 +65,11 @@ public sealed class SmiHub
 
     /// <inheritdoc/>
     public double KS { get; private init; }
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<SmiResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToSmi(LookbackPeriods, FirstSmoothPeriods, SecondSmoothPeriods, SignalPeriods);
+
     /// <inheritdoc/>
     protected override (SmiResult result, int index)
         ToIndicator(IQuote item, int? indexHint)

--- a/src/s-z/Smma/Smma.StreamHub.cs
+++ b/src/s-z/Smma/Smma.StreamHub.cs
@@ -17,6 +17,10 @@ public class SmmaHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<SmmaResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToSmma(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
     /// <inheritdoc/>

--- a/src/s-z/StarcBands/StarcBands.StreamHub.cs
+++ b/src/s-z/StarcBands/StarcBands.StreamHub.cs
@@ -25,6 +25,10 @@ public class StarcBandsHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<StarcBandsResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToStarcBands(SmaPeriods, Multiplier, AtrPeriods);
     /// <inheritdoc/>
     public int SmaPeriods { get; init; }
 

--- a/src/s-z/Stc/Stc.StreamHub.cs
+++ b/src/s-z/Stc/Stc.StreamHub.cs
@@ -52,6 +52,10 @@ public class StcHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<StcResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToStc(CyclePeriods, FastPeriods, SlowPeriods);
     /// <inheritdoc/>
     public int CyclePeriods { get; init; }
 

--- a/src/s-z/StdDev/StdDev.StreamHub.cs
+++ b/src/s-z/StdDev/StdDev.StreamHub.cs
@@ -17,6 +17,10 @@ public class StdDevHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<StdDevResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToStdDev(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
     /// <inheritdoc/>

--- a/src/s-z/Stoch/Stoch.StreamHub.cs
+++ b/src/s-z/Stoch/Stoch.StreamHub.cs
@@ -76,6 +76,10 @@ public class StochHub
 
     /// <inheritdoc />
     public MaType MovingAverageType { get; init; }
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<StochResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToStoch(LookbackPeriods, SignalPeriods, SmoothPeriods, KFactor, DFactor, MovingAverageType);
     /// <inheritdoc/>
     protected override (StochResult result, int index)
         ToIndicator(IQuote item, int? indexHint)

--- a/src/s-z/StochRsi/StochRsi.StreamHub.cs
+++ b/src/s-z/StochRsi/StochRsi.StreamHub.cs
@@ -67,6 +67,11 @@ public sealed class StochRsiHub
 
     /// <inheritdoc/>
     public int SmoothPeriods { get; init; }
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<StochRsiResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToStochRsi(RsiPeriods, StochPeriods, SignalPeriods, SmoothPeriods);
+
     /// <inheritdoc/>
     protected override (StochRsiResult result, int index)
         ToIndicator(IReusable item, int? indexHint)

--- a/src/s-z/SuperTrend/SuperTrend.StreamHub.cs
+++ b/src/s-z/SuperTrend/SuperTrend.StreamHub.cs
@@ -20,6 +20,10 @@ public class SuperTrendHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<SuperTrendResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToSuperTrend(LookbackPeriods, Multiplier);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
 

--- a/src/s-z/T3/T3.StreamHub.cs
+++ b/src/s-z/T3/T3.StreamHub.cs
@@ -34,6 +34,10 @@ public class T3Hub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<T3Result> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToT3(LookbackPeriods, VolumeFactor);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
 

--- a/src/s-z/Tema/Tema.StreamHub.cs
+++ b/src/s-z/Tema/Tema.StreamHub.cs
@@ -22,6 +22,10 @@ public class TemaHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<TemaResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToTema(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
 

--- a/src/s-z/Tr/Tr.StreamHub.cs
+++ b/src/s-z/Tr/Tr.StreamHub.cs
@@ -12,6 +12,10 @@ public class TrHub
     }
 
     /// <inheritdoc/>
+    public override IReadOnlyList<TrResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToTr();
+
+    /// <inheritdoc/>
     protected override (TrResult result, int index)
         ToIndicator(IQuote item, int? indexHint)
     {

--- a/src/s-z/Trix/Trix.StreamHub.cs
+++ b/src/s-z/Trix/Trix.StreamHub.cs
@@ -22,6 +22,10 @@ public class TrixHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<TrixResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToTrix(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
 

--- a/src/s-z/Tsi/Tsi.StreamHub.cs
+++ b/src/s-z/Tsi/Tsi.StreamHub.cs
@@ -54,6 +54,10 @@ public class TsiHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<TsiResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToTsi(LookbackPeriods, SmoothPeriods, SignalPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
 

--- a/src/s-z/UlcerIndex/UlcerIndex.StreamHub.cs
+++ b/src/s-z/UlcerIndex/UlcerIndex.StreamHub.cs
@@ -17,6 +17,10 @@ public class UlcerIndexHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<UlcerIndexResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToUlcerIndex(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
     /// <inheritdoc/>

--- a/src/s-z/Ultimate/Ultimate.StreamHub.cs
+++ b/src/s-z/Ultimate/Ultimate.StreamHub.cs
@@ -20,6 +20,10 @@ public class UltimateHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<UltimateResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => ((IReadOnlyList<IQuote>)input).ToUltimate(ShortPeriods, MiddlePeriods, LongPeriods);
     /// <inheritdoc/>
     public int ShortPeriods { get; init; }
 

--- a/src/s-z/VolatilityStop/VolatilityStop.StreamHub.cs
+++ b/src/s-z/VolatilityStop/VolatilityStop.StreamHub.cs
@@ -20,6 +20,10 @@ public class VolatilityStopHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<VolatilityStopResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToVolatilityStop(LookbackPeriods, Multiplier);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
 

--- a/src/s-z/Vortex/Vortex.StreamHub.cs
+++ b/src/s-z/Vortex/Vortex.StreamHub.cs
@@ -29,6 +29,10 @@ public class VortexHub
 
     /// <inheritdoc />
     public int LookbackPeriods { get; init; }
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<VortexResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToVortex(LookbackPeriods);
     /// <inheritdoc/>
     protected override (VortexResult result, int index)
         ToIndicator(IQuote item, int? indexHint)

--- a/src/s-z/Vwap/Vwap.StreamHub.cs
+++ b/src/s-z/Vwap/Vwap.StreamHub.cs
@@ -20,6 +20,10 @@ public class VwapHub : ChainHub<IQuote, VwapResult>
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<VwapResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToVwap();
     /// <inheritdoc/>
     public DateTime? StartDate { get; private set; }
 

--- a/src/s-z/Vwma/Vwma.StreamHub.cs
+++ b/src/s-z/Vwma/Vwma.StreamHub.cs
@@ -17,6 +17,10 @@ public class VwmaHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<VwmaResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => ((IReadOnlyList<IQuote>)input).ToVwma(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
 

--- a/src/s-z/WilliamsR/WilliamsR.StreamHub.cs
+++ b/src/s-z/WilliamsR/WilliamsR.StreamHub.cs
@@ -30,6 +30,10 @@ public class WilliamsRHub
 
     #region properties
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<WilliamsResult> AsStaticSeries(IReadOnlyList<IQuote> input)
+        => input.ToWilliamsR(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
 

--- a/src/s-z/Wma/Wma.StreamHub.cs
+++ b/src/s-z/Wma/Wma.StreamHub.cs
@@ -17,6 +17,10 @@ public class WmaHub
         Reinitialize();
     }
 
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<WmaResult> AsStaticSeries(IReadOnlyList<IReusable> input)
+        => input.ToWma(LookbackPeriods);
     /// <inheritdoc/>
     public int LookbackPeriods { get; init; }
 


### PR DESCRIPTION
This method is a shortcut to the corresponding static method using the hub's parameters as input.

```
var rsiHub = quotes.ToRsiHub(lookBackPeriods);
var rsiHubStatic = rsiHub.AsStaticSeries(quotes);
var rsiStatic = quotes.GetRsi(lookBackPeriods);

Should().Be(rsiHub.Cache == rsiHubStatic == rsiStatic);
```

This is the same one-liner in 80+ files:
`
public override IReadOnlyList<TOut> AsStaticSeries(IReadOnlyList<TIn> input) => input.ToXXX(hubsParameters);
`

This can be used to implement #1261 
`Cache = this.AsStaticSeries(BaseProvider.Cache) //same one-liner, in 80+ places`

I'll lose the ability to integrate feedback specific to this pr/branch in about a week, and close this.