### PR TITLE
fix: Internal chaining for Gator, StochRsi compound hubs

### DIFF
--- a/.github/skills/indicator-stream/references/compound-hubs.md
+++ b/.github/skills/indicator-stream/references/compound-hubs.md
@@ -1,0 +1,222 @@
+# Compound hub pattern
+
+## Overview
+
+Compound hubs are StreamHub indicators that depend on another hub's output as their input. Examples: StochRSI (requires RSI), Gator (requires Alligator).
+
+**Problem**: Without proper construction, users could inadvertently create duplicate internal hubs, wasting computation.
+
+**Solution**: Two-constructor pattern that allows reusing an existing hub OR creating one internally.
+
+## Constructor pattern
+
+### Required constructors
+
+```csharp
+public class StochRsiHub : ChainHub<IReusable, StochRsiResult>
+{
+    // Constructor 1: Create internal hub from provider
+    internal StochRsiHub(
+        IChainProvider<IReusable> provider,
+        int rsiPeriods = 14,
+        int stochPeriods = 14,
+        int signalPeriods = 3,
+        int smoothPeriods = 1)
+        : this(
+            provider.ToRsiHub(rsiPeriods),  // Create internal hub
+            stochPeriods,
+            signalPeriods,
+            smoothPeriods)  // Delegate to constructor 2
+    { }
+
+    // Constructor 2: Accept existing hub (avoids duplicate creation)
+    internal StochRsiHub(
+        RsiHub rsiHub,
+        int stochPeriods = 14,
+        int signalPeriods = 3,
+        int smoothPeriods = 1)
+        : base(rsiHub)  // Pass hub to base (NOT original provider!)
+    {
+        ArgumentNullException.ThrowIfNull(rsiHub);
+        StochRsi.Validate(rsiHub.LookbackPeriods, stochPeriods, signalPeriods, smoothPeriods);
+
+        RsiPeriods = rsiHub.LookbackPeriods;
+        StochPeriods = stochPeriods;
+        SignalPeriods = signalPeriods;
+        SmoothPeriods = smoothPeriods;
+
+        Name = $"STOCH-RSI({RsiPeriods},{stochPeriods},{signalPeriods},{smoothPeriods})";
+
+        // Initialize local state for processing hub results
+        _rsiMaxWindow = new RollingWindowMax<double>(stochPeriods);
+        _rsiMinWindow = new RollingWindowMin<double>(stochPeriods);
+        kBuffer = new Queue<double>(smoothPeriods);
+        signalBuffer = new Queue<double>(signalPeriods);
+
+        Reinitialize();
+    }
+}
+```
+
+### Key principles
+
+1. **Delegate constructors** - Constructor 1 creates internal hub and delegates to constructor 2
+2. **Pass hub to base** - Constructor 2 passes the hub (not original provider) to base class
+3. **Validate in constructor 2** - Only the hub-accepting constructor does validation and initialization
+4. **Internal state only** - Only maintain state for processing the hub's results, not for the hub's calculations
+
+## Extension methods
+
+Provide both overloads with clear documentation:
+
+```csharp
+public static partial class StochRsi
+{
+    /// <summary>
+    /// Converts the chain provider to a Stochastic RSI hub.
+    /// </summary>
+    public static StochRsiHub ToStochRsiHub(
+        this IChainProvider<IReusable> chainProvider,
+        int rsiPeriods = 14,
+        int stochPeriods = 14,
+        int signalPeriods = 3,
+        int smoothPeriods = 1)
+        => new(chainProvider, rsiPeriods, stochPeriods, signalPeriods, smoothPeriods);
+
+    /// <summary>
+    /// Creates a new Stochastic RSI hub, using RSI values from an existing RSI hub.
+    /// </summary>
+    /// <remarks>
+    /// This extension overrides and enables a chain that specifically
+    /// reuses the existing <see cref="RsiHub"/> as its internal construction.
+    /// <para>IMPORTANT: This is not a normal chaining approach.</para>
+    /// Do not use this interface if you want to instead want a StochRSI of an RSI hub.</remarks>
+    public static StochRsiHub ToStochRsiHub(
+        this RsiHub rsiHub,
+        int stochPeriods = 14,
+        int signalPeriods = 3,
+        int smoothPeriods = 1)
+        => new(rsiHub, stochPeriods, signalPeriods, smoothPeriods);
+}
+```
+
+**Critical documentation**: The hub-accepting extension MUST document that it's non-standard chaining to prevent confusion.
+
+## RollbackState considerations
+
+### When NOT to override
+
+Most compound hubs **do not need RollbackState override** because:
+
+1. The internal hub manages its own state and RollbackState
+2. The compound hub only processes results from the internal hub
+3. No additional stateful fields beyond result processing buffers
+
+**Example**: Gator hub has no stateful fields (simple transformation of Alligator results):
+
+```csharp
+public class GatorHub : StreamHub<AlligatorResult, GatorResult>
+{
+    // No stateful fields beyond base class
+    // No RollbackState override needed
+}
+```
+
+### When to override
+
+Override RollbackState only when maintaining **additional state** beyond the internal hub's results:
+
+**Example**: StochRSI maintains rolling windows and buffers for processing RSI values:
+
+```csharp
+private readonly RollingWindowMax<double> _rsiMaxWindow;
+private readonly RollingWindowMin<double> _rsiMinWindow;
+private readonly Queue<double> kBuffer;
+private readonly Queue<double> signalBuffer;
+
+protected override void RollbackState(DateTime timestamp)
+{
+    int targetIndex = ProviderCache.IndexGte(timestamp);
+
+    // Clear all compound state
+    _rsiMaxWindow.Clear();
+    _rsiMinWindow.Clear();
+    kBuffer.Clear();
+    signalBuffer.Clear();
+
+    if (targetIndex <= 0) return;
+
+    // Rebuild state up to targetIndex - 1 (exclusive of rollback timestamp)
+    int restoreIndex = targetIndex - 1;
+
+    for (int i = 0; i <= restoreIndex; i++)
+    {
+        double rsiValue = ProviderCache[i].Value;  // ProviderCache holds RSI results
+        if (!double.IsNaN(rsiValue))
+        {
+            _ = UpdateOscillatorState(rsiValue);  // Rebuild internal state
+        }
+    }
+}
+```
+
+**Key pattern**: Replay the compound hub's processing logic using cached results from the internal hub (`ProviderCache[i].Value`).
+
+## Anti-patterns
+
+### Creating internal hub in ToIndicator (FORBIDDEN)
+
+```csharp
+// WRONG - Creates new hub on every tick
+protected override (GatorResult result, int index)
+    ToIndicator(IQuote item, int? indexHint)
+{
+    var alligator = item.ToAlligatorHub();  // FORBIDDEN - O(n²) disaster
+    var alligatorResult = alligator.GetNext(item);
+    // ... process result
+}
+```
+
+**Correct**: Create internal hub once in constructor, reuse throughout lifetime.
+
+### Passing original provider to base (FORBIDDEN)
+
+```csharp
+// WRONG - Base doesn't receive the internal hub's results
+internal StochRsiHub(RsiHub rsiHub, int stochPeriods)
+    : base(/* original provider */)  // WRONG - loses hub connection
+{
+    // This breaks the chain - ToIndicator won't receive RSI results
+}
+```
+
+**Correct**: Pass the internal hub to base: `: base(rsiHub)`
+
+### Missing hub-accepting extension
+
+```csharp
+// INCOMPLETE - Only provides provider-based extension
+public static StochRsiHub ToStochRsiHub(
+    this IChainProvider<IReusable> chainProvider,
+    int rsiPeriods = 14,
+    int stochPeriods = 14)
+    => new(chainProvider, rsiPeriods, stochPeriods);
+
+// Missing: Extension accepting RsiHub directly
+```
+
+**Correct**: Provide both extensions (provider and hub-accepting).
+
+## Testing compound hubs
+
+Follow standard StreamHub testing requirements:
+
+1. Inherit from `StreamHubTestBase`
+2. Implement `ITestChainObserver` (most common for compound hubs)
+3. Test rollback validation if RollbackState is overridden
+4. Verify Series parity with the compound indicator
+
+**Example**: `tests/indicators/s-z/StochRsi/StochRsi.StreamHub.Tests.cs`
+
+---
+Last updated: January 19, 2026

--- a/.github/skills/indicator-stream/references/provider-selection.md
+++ b/.github/skills/indicator-stream/references/provider-selection.md
@@ -114,7 +114,7 @@ public static StochRsiHub ToStochRsiHub(
 2. **Delegate constructors** - Constructor 1 calls constructor 2 with created hub
 3. **Base receives hub** - Pass the internal hub to base class (not original provider)
 4. **Document overrides** - Clearly mark the hub-accepting extension as non-standard chaining
-5. **No RollbackState override** - Compound hubs rely on internal hub's state; only override if maintaining additional state beyond the internal hub's results
+5. **Avoid RollbackState override** - Compound hubs typically rely on their internal hub's state management; only override when maintaining additional derived state beyond what the internal hub exposes. Example: `StochRsiHub` overrides `RollbackState` to rebuild oscillator state (`_rsiMaxWindow`, `_rsiMinWindow`, `kBuffer`, `signalBuffer`) from cached RSI results. See "Compound hub state" pattern in `rollback-patterns.md` for the accepted exception and implementation pattern
 
 ## Test interface mapping
 

--- a/docs/indicators/Gator.md
+++ b/docs/indicators/Gator.md
@@ -101,3 +101,29 @@ foreach (IQuote quote in quotes)  // simulating stream
 
 IReadOnlyList<GatorResult> results = observer.Results;
 ```
+
+::: info Compound hub
+The Gator hub is based on the Alligator indicator.
+When the Gator hub is chained from an existing `AlligatorHub` instance it will reuse the existing Alligator hub values rather than creating its own internal Alligator calculations.
+**This is not a normal chaining model.**
+
+```csharp
+// creates an internal Alligator hub
+var gatorHub = quotes
+  .ToGatorHub();
+
+// this is helpful in cases where you have an indedpendent 
+// Alligator hub and do not want to create duplicate copies
+
+var alligatorHub = quotes
+  .ToAlligatorHub();
+
+// does not create a separate internal Alligator hub
+var gatorHub = alligatorHub
+  .ToGatorHub();  // does not create 
+
+// ❌ Alligator → [ Alligator ] → Gator
+// ✅ Alligator → Gator
+```
+
+:::

--- a/docs/indicators/Gator.md
+++ b/docs/indicators/Gator.md
@@ -112,15 +112,15 @@ When the Gator hub is chained from an existing `AlligatorHub` instance it will r
 var gatorHub = quotes
   .ToGatorHub();
 
-// this is helpful in cases where you have an indedpendent 
+// this is helpful in cases where you have an independent 
 // Alligator hub and do not want to create duplicate copies
 
 var alligatorHub = quotes
   .ToAlligatorHub();
 
-// does not create a separate internal Alligator hub
+// does not create 2nd internal huba separate internal Alligator hub
 var gatorHub = alligatorHub
-  .ToGatorHub();  // does not create 
+  .ToGatorHub();  // does not create 2nd internal hub
 
 // ❌ Alligator → [ Alligator ] → Gator
 // ✅ Alligator → Gator

--- a/docs/indicators/StochRsi.md
+++ b/docs/indicators/StochRsi.md
@@ -116,3 +116,29 @@ foreach (IQuote quote in quotes)  // simulating stream
 
 IReadOnlyList<StochRsiResult> results = observer.Results;
 ```
+
+::: info Compound hub
+The StochRSI hub is based on the RSI indicator.
+When the StochRSI hub is chained from an existing `RsiHub` instance it will reuse the existing RSI hub values rather than creating its own internal RSI calculations.
+**This is not a normal chaining model.**
+
+```csharp
+// creates an internal RSI hub
+var stochRsiHub = quotes
+  .ToStochRsiHub();
+
+// this is helpful in cases where you have an indedpendent 
+// RSI hub and do not want to create duplicate copies
+
+var rsiHub = quotes
+  .ToRsiHub();
+
+// does not create a separate internal RSI hub
+var stochRsiHub = rsiHub
+  .ToStochRsi();  // does not create 
+
+// ❌ RSI → [ RSI ] → StochRSI
+// ✅ RSI → StochRSI
+```
+
+:::

--- a/docs/indicators/StochRsi.md
+++ b/docs/indicators/StochRsi.md
@@ -135,7 +135,7 @@ var rsiHub = quotes
 
 // does not create 2nd internal huba separate internal RSI hub
 var stochRsiHub = rsiHub
-  .ToStochRsi();  // does not create 2nd internal hub
+  .ToStochRsiHub();  // does not create 2nd internal hub
 
 // ❌ RSI → [ RSI ] → StochRSI
 // ✅ RSI → StochRSI

--- a/docs/indicators/StochRsi.md
+++ b/docs/indicators/StochRsi.md
@@ -127,15 +127,15 @@ When the StochRSI hub is chained from an existing `RsiHub` instance it will reus
 var stochRsiHub = quotes
   .ToStochRsiHub();
 
-// this is helpful in cases where you have an indedpendent 
+// this is helpful in cases where you have an independent 
 // RSI hub and do not want to create duplicate copies
 
 var rsiHub = quotes
   .ToRsiHub();
 
-// does not create a separate internal RSI hub
+// does not create 2nd internal huba separate internal RSI hub
 var stochRsiHub = rsiHub
-  .ToStochRsi();  // does not create 
+  .ToStochRsi();  // does not create 2nd internal hub
 
 // ❌ RSI → [ RSI ] → StochRSI
 // ✅ RSI → StochRSI

--- a/src/e-k/Gator/Gator.StreamHub.cs
+++ b/src/e-k/Gator/Gator.StreamHub.cs
@@ -6,6 +6,9 @@ namespace Skender.Stock.Indicators;
 public class GatorHub
    : StreamHub<AlligatorResult, GatorResult>
 {
+    internal GatorHub(IChainProvider<IReusable> chainProvider)
+        : this(chainProvider.ToAlligatorHub()) { }
+
     internal GatorHub(AlligatorHub alligatorHub)
         : base(alligatorHub)
     {
@@ -48,23 +51,25 @@ public class GatorHub
 public static partial class Gator
 {
     /// <summary>
-    /// Converts an Alligator hub to a Gator hub.
-    /// </summary>
-    /// <param name="alligatorHub">The Alligator hub.</param>
-    /// <returns>A Gator hub.</returns>
-    public static GatorHub ToGatorHub(
-        this AlligatorHub alligatorHub)
-        => new(alligatorHub);
-
-    /// <summary>
     /// Creates a Gator hub from a chain provider.
     /// </summary>
     /// <param name="chainProvider">The chain provider.</param>
     /// <returns>A Gator hub.</returns>
     public static GatorHub ToGatorHub(
         this IChainProvider<IReusable> chainProvider)
-    {
-        AlligatorHub alligatorHub = chainProvider.ToAlligatorHub();
-        return new GatorHub(alligatorHub);
-    }
+        => new(chainProvider);
+
+    /// <summary>
+    /// Creates a new Gator hub, using values from an existing Alligator hub.
+    /// </summary>
+    /// <param name="alligatorHub">The Alligator hub.</param>
+    /// <returns>A Gator hub.</returns>
+    /// <remarks>
+    /// <para>IMPORTANT: This is not a normal chaining approach.</para>
+    /// This extension overrides and enables a chain that specifically
+    /// resuses the existing <see cref="AlligatorHub"/> in its internal construction.
+    ///</remarks>
+    public static GatorHub ToGatorHub(
+        this AlligatorHub alligatorHub)
+        => new(alligatorHub);
 }

--- a/src/e-k/Gator/Gator.StreamHub.cs
+++ b/src/e-k/Gator/Gator.StreamHub.cs
@@ -67,7 +67,7 @@ public static partial class Gator
     /// <remarks>
     /// <para>IMPORTANT: This is not a normal chaining approach.</para>
     /// This extension overrides and enables a chain that specifically
-    /// resuses the existing <see cref="AlligatorHub"/> in its internal construction.
+    /// reuses the existing <see cref="AlligatorHub"/> in its internal construction.
     ///</remarks>
     public static GatorHub ToGatorHub(
         this AlligatorHub alligatorHub)

--- a/src/e-k/Hma/Hma.StreamHub.cs
+++ b/src/e-k/Hma/Hma.StreamHub.cs
@@ -116,13 +116,9 @@ public static partial class Hma
     /// <param name="chainProvider">The chain provider.</param>
     /// <param name="lookbackPeriods">Quantity of periods in lookback window.</param>
     /// <returns>An HMA hub.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when the chain provider is null.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when the lookback periods are invalid.</exception>
     public static HmaHub ToHmaHub(
         this IChainProvider<IReusable> chainProvider,
         int lookbackPeriods)
-    {
-        ArgumentNullException.ThrowIfNull(chainProvider);
-        return new(chainProvider, lookbackPeriods);
-    }
+        => new(chainProvider, lookbackPeriods);
 }

--- a/src/s-z/StochRsi/StochRsi.StreamHub.cs
+++ b/src/s-z/StochRsi/StochRsi.StreamHub.cs
@@ -236,17 +236,6 @@ public static partial class StochRsi
         int smoothPeriods = 1)
         => new(chainProvider, rsiPeriods, stochPeriods, signalPeriods, smoothPeriods);
 
-    // TODO: Consider whether this overload (below) is necessary or if it could lead to confusion.
-    // If we keep it, it opens possibility of not redundantly creating the internal RSI hub.
-    // If we lose it, it opens possibility of chaining to do an Stoch RSI of an RSI hub.
-    // Catch 22.  See below.
-
-    // Note: for most other indicators this extension overload,
-    // even if available as an internal contructor, may not be
-    // appropriate since it will prevent normal chaining.
-    // For example, if someone truly wanted an RSI of a Stoch
-    // and we applied this overload to StochRSI, it wouldn't work.
-
     /// <summary>
     /// Creates a new Stochastic RSI hub, using RSI values from an existing RSI hub.
     /// </summary>

--- a/src/s-z/StochRsi/StochRsi.StreamHub.cs
+++ b/src/s-z/StochRsi/StochRsi.StreamHub.cs
@@ -109,11 +109,7 @@ public sealed class StochRsiHub
     /// <inheritdoc/>
     protected override void RollbackState(DateTime timestamp)
     {
-        int providerIndex = ProviderCache.IndexGte(timestamp);
-        if (providerIndex == -1)
-        {
-            providerIndex = ProviderCache.Count;
-        }
+        int targetIndex = ProviderCache.IndexGte(timestamp);
 
         // Reset state and replay historical RSI values up to the rebuild index
         _rsiMaxWindow.Clear();
@@ -121,14 +117,15 @@ public sealed class StochRsiHub
         kBuffer.Clear();
         signalBuffer.Clear();
 
-        if (providerIndex <= 0)
+        if (targetIndex <= 0)
         {
             return;
         }
 
-        int replayLimit = Math.Min(providerIndex, ProviderCache.Count);
+        // Rebuild state up to targetIndex - 1 (exclusive of rollback timestamp)
+        int restoreIndex = targetIndex - 1;
 
-        for (int i = 0; i < replayLimit; i++)
+        for (int i = 0; i <= restoreIndex; i++)
         {
             double rsiValue = ProviderCache[i].Value;
             if (!double.IsNaN(rsiValue))

--- a/src/s-z/StochRsi/StochRsi.StreamHub.cs
+++ b/src/s-z/StochRsi/StochRsi.StreamHub.cs
@@ -240,7 +240,7 @@ public static partial class StochRsi
         => new(chainProvider, rsiPeriods, stochPeriods, signalPeriods, smoothPeriods);
 
     // TODO: Consider whether this overload (below) is necessary or if it could lead to confusion.
-    // If we keep it, it opens possibility of not redudnantly creating the internal RSI hub.
+    // If we keep it, it opens possibility of not redundantly creating the internal RSI hub.
     // If we lose it, it opens possibility of chaining to do an Stoch RSI of an RSI hub.
     // Catch 22.  See below.
 
@@ -255,8 +255,8 @@ public static partial class StochRsi
     /// </summary>
     /// <remarks>
     /// This extension overrides and enables a chain that specifically
-    /// resuses the existing <see cref="RsiHub"/> as its internal construction.
-    /// /// <para>IMPORTANT: This is not a normal chaining approach.</para>
+    /// reuses the existing <see cref="RsiHub"/> as its internal construction.
+    /// <para>IMPORTANT: This is not a normal chaining approach.</para>
     /// Do not use this interface if you want to instead want a StochRSI of an RSI hub.</remarks>
     /// <param name="rsiHub">The existing RSI hub provider.</param>
     /// <param name="stochPeriods">The number of periods for the Stochastic calculation.</param>

--- a/tests/indicators/e-k/Gator/Gator.StreamHub.Tests.cs
+++ b/tests/indicators/e-k/Gator/Gator.StreamHub.Tests.cs
@@ -121,6 +121,22 @@ public class GatorHubTests : StreamHubTestBase, ITestChainObserver
     }
 
     [TestMethod]
+    public void Provider_IsAlligatorHub()
+    {
+        QuoteHub quoteHub = new();
+        GatorHub observer = quoteHub.ToGatorHub();
+
+        System.Reflection.PropertyInfo property = typeof(StreamHub<AlligatorResult, GatorResult>)
+            .GetProperty("Provider", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+
+        object provider = property.GetValue(observer)!;
+        provider.Should().BeOfType<AlligatorHub>();
+
+        observer.Unsubscribe();
+        quoteHub.EndTransmission();
+    }
+
+    [TestMethod]
     public void Reset()
     {
         List<Quote> quotesList = Quotes.ToList();
@@ -178,7 +194,7 @@ public class GatorHubTests : StreamHubTestBase, ITestChainObserver
         AlligatorHub alligatorHub = quoteHub.ToAlligatorHub();
 
         // test null alligatorHub parameter (throws NullReferenceException from base constructor)
-        Action act1 = () => _ = new GatorHub(null!);
+        Action act1 = () => _ = new GatorHub(alligatorHub: null!);
         act1.Should().Throw<NullReferenceException>("AlligatorHub cannot be null");
 
         // test null item in ToIndicator (via reflection to access protected method)

--- a/tests/indicators/s-z/StochRsi/StochRsi.StreamHub.Tests.cs
+++ b/tests/indicators/s-z/StochRsi/StochRsi.StreamHub.Tests.cs
@@ -102,6 +102,26 @@ public class StochRsiHubTests : StreamHubTestBase, ITestChainObserver, ITestChai
     }
 
     [TestMethod]
+    public void Provider_IsRsiHub()
+    {
+        QuoteHub quoteHub = new();
+        StochRsiHub observer = quoteHub.ToStochRsiHub(14, 14, 3, 1);
+
+        System.Reflection.PropertyInfo property = typeof(StochRsiHub)
+            .GetProperty(
+                "Provider",
+                System.Reflection.BindingFlags.NonPublic
+                | System.Reflection.BindingFlags.Instance
+                | System.Reflection.BindingFlags.FlattenHierarchy)!;
+
+        object provider = property.GetValue(observer)!;
+        provider.Should().BeOfType<RsiHub>();
+
+        observer.Unsubscribe();
+        quoteHub.EndTransmission();
+    }
+
+    [TestMethod]
     public void ChainProvider_MatchesSeriesExactly()
     {
         const int rsiPeriods = 14;


### PR DESCRIPTION
Compound stream hubs are incorrectly using internal hubs, causing incorrectly sequenced internal chaining behavior, which is also notably less efficient than our standard chaining model

In the cases where indicators are really indicators of indicators, we should also accommodate natural chaining re-use.  For example, when a Gator is chained to Alligator hub, it should not try to create Alligator again but rather just reuse it.  Same applies for StochRsi.

Partially fixes (for Gator and StochRsi only, not all impacted hubs):

- #1911 