### PR TITLE
fix: Rebuild streaming aggregates for late ticks

### DIFF
--- a/src/_common/Quotes/Quote.AggregatorHub.cs
+++ b/src/_common/Quotes/Quote.AggregatorHub.cs
@@ -86,29 +86,7 @@ public class QuoteAggregatorHub
         // Handle late arrival for past bar
         if (isPastBar)
         {
-            // Find the existing bar in cache
-            int existingIndex = Cache.IndexGte(barTimestamp);
-            if (existingIndex >= 0 && existingIndex < Cache.Count && Cache[existingIndex].Timestamp == barTimestamp)
-            {
-                // Update existing past bar
-                IQuote existingBar = Cache[existingIndex];
-                Quote updatedBar = new(
-                    Timestamp: barTimestamp,
-                    Open: existingBar.Open,  // Keep original open
-                    High: Math.Max(existingBar.High, item.High),
-                    Low: Math.Min(existingBar.Low, item.Low),
-                    Close: item.Close,  // Update close
-                    Volume: existingBar.Volume + item.Volume);
-
-                Cache[existingIndex] = updatedBar;
-
-                // Trigger rebuild from this timestamp
-                if (notify)
-                {
-                    NotifyObserversOnRebuild(barTimestamp);
-                }
-            }
-
+            Rebuild(barTimestamp);
             return;
         }
 
@@ -227,6 +205,13 @@ public class QuoteAggregatorHub
     /// <inheritdoc/>
     public override string ToString()
         => $"QUOTE-AGG<{AggregationPeriod}>: {Cache.Count} items";
+
+    /// <inheritdoc/>
+    protected override void RollbackState(DateTime timestamp)
+    {
+        _currentBar = null;
+        _currentBarTimestamp = default;
+    }
 }
 
 public static partial class Quotes

--- a/tests/indicators/_common/Quotes/Tick.AggregatorHub.Tests.cs
+++ b/tests/indicators/_common/Quotes/Tick.AggregatorHub.Tests.cs
@@ -276,7 +276,7 @@ public class TickAggregatorHubTests : StreamHubTestBase, ITestQuoteObserver, ITe
     }
 
     [TestMethod]
-    public void DuplicateExecutionId_IsIgnored()
+    public void DuplicateExecutionId_CorrectionRebuildsBar()
     {
         TickHub provider = new();
         TickAggregatorHub aggregator = provider.ToTickAggregatorHub(PeriodSize.OneMinute);
@@ -286,26 +286,22 @@ public class TickAggregatorHubTests : StreamHubTestBase, ITestQuoteObserver, ITe
             DateTime.Parse("2023-11-09 10:00:00", invariantCulture),
             100m, 10m, "EXEC-001"));
 
-        // Add duplicate with same execution ID
+        // Add correction with same execution ID and timestamp
         provider.Add(new Tick(
-            DateTime.Parse("2023-11-09 10:00:10", invariantCulture),
+            DateTime.Parse("2023-11-09 10:00:00", invariantCulture),
             200m, 20m, "EXEC-001"));
-
-        // Add different tick with unique execution ID
-        provider.Add(new Tick(
-            DateTime.Parse("2023-11-09 10:00:20", invariantCulture),
-            101m, 11m, "EXEC-002"));
 
         IReadOnlyList<IQuote> results = aggregator.Results;
 
         results.Should().HaveCount(1);
 
-        // TODO: is this right? What if the second "EXEC-001" is a correction (likely)?
-
-        // Should only incorporate first and third ticks (not the duplicate)
+        // Should reflect corrected tick
         IQuote bar = results[0];
-        bar.High.Should().Be(101m); // Max of 100 and 101, not 200
-        bar.Volume.Should().Be(21m); // Sum of 10 and 11, not 30
+        bar.Open.Should().Be(200m);
+        bar.High.Should().Be(200m);
+        bar.Low.Should().Be(200m);
+        bar.Close.Should().Be(200m);
+        bar.Volume.Should().Be(20m);
 
         aggregator.Unsubscribe();
         provider.EndTransmission();


### PR DESCRIPTION
### Motivation

- Ensure streaming aggregators handle late-arriving quotes/ticks deterministically by rebuilding from the provider cache rather than performing ad-hoc in-place updates. 
- Reset aggregator internal state when a rebuild occurs so subsequent bars are computed correctly. 
- Treat ticks with execution-id corrections as corrections (rebuild) rather than silently ignoring duplicates. 

### Description

- Modified `QuoteAggregatorHub.OnAdd` to call `Rebuild(barTimestamp)` for late (past) bars instead of attempting local in-place updates. 
- Modified `TickAggregatorHub.OnAdd` to call `Rebuild(barTimestamp)` for late (past) bars and removed the previous `executionId` de-duplication cache, allowing corrections to rebuild the aggregation. 
- Added `RollbackState` overrides in both hubs to reset `_currentBar` and `_currentBarTimestamp` during rebuilds so internal aggregator state is consistent after a rebuild. 
- Updated tests: renamed/rewrote the prior duplicate-execution-id test to `DuplicateExecutionId_CorrectionRebuildsBar` and adjusted assertions to validate correction behavior (aggregator reflects corrected tick). 
- Commit message: `fix: rebuild streaming aggregates on late ticks` (changes staged and committed). 

### Testing

- Ran `npx markdownlint-cli2` (markdown lint) and it completed with no errors. 
- Attempted `dotnet format`, `dotnet build`, and `dotnet test` but `dotnet` was not available in the execution environment so those automated .NET checks could not be executed. 
- No unit/regression test runs were completed in this environment; the updated tests are in `tests/indicators/_common/Quotes/Tick.AggregatorHub.Tests.cs` and should be executed in CI or a developer environment with the .NET SDK using `dotnet test`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979a2ad6fcc8326a24efa8bc00c0f0a)