### PR TITLE
test(streamhub): Add WithCachePruning test to TickHub

### DIFF
--- a/tests/indicators/_common/Quotes/Tick.StreamHub.Tests.cs
+++ b/tests/indicators/_common/Quotes/Tick.StreamHub.Tests.cs
@@ -333,6 +333,53 @@ public class TickStreamHubTests : StreamHubTestBase, ITestTickObserver
         provider.EndTransmission();
     }
 
+    [TestMethod]
+    public void WithCachePruning_MatchesSeriesExactly()
+    {
+        const int maxCacheSize = 50;
+        const int totalTicks = 100;
+
+        // build tick data: 100 sequential ticks at 1-minute intervals
+        DateTime start = new(2023, 11, 9, 10, 0, 0);
+        List<Tick> allTicks = Enumerable
+            .Range(0, totalTicks)
+            .Select(i => new Tick(
+                start.AddMinutes(i),
+                100m + i,
+                10m + i,
+                $"EXEC-{i:000}"))
+            .ToList();
+
+        // Setup TickHub with cache limit
+        TickHub hub = new(maxCacheSize);
+
+        // Stream more ticks than cache can hold
+        foreach (Tick tick in allTicks)
+        {
+            hub.Add(tick);
+        }
+
+        // Verify cache was pruned to maxCacheSize
+        hub.Cache.Should().HaveCount(maxCacheSize);
+
+        // Verify correct ticks remain (the most recent ones)
+        IReadOnlyList<ITick> cachedTicks = hub.Cache;
+        IReadOnlyList<Tick> expectedTicks = allTicks
+            .TakeLast(maxCacheSize)
+            .ToList();
+
+        cachedTicks.Should().HaveCount(expectedTicks.Count);
+
+        for (int i = 0; i < expectedTicks.Count; i++)
+        {
+            cachedTicks[i].Timestamp.Should().Be(expectedTicks[i].Timestamp);
+            cachedTicks[i].Price.Should().Be(expectedTicks[i].Price);
+            cachedTicks[i].Volume.Should().Be(expectedTicks[i].Volume);
+        }
+
+        hub.EndTransmission();
+    }
+
     /// <summary>
     /// Test observer helper class for tracking tick notifications.
     /// </summary>


### PR DESCRIPTION
## Summary

Adds the standardized `WithCachePruning_MatchesSeriesExactly` test to `TickStreamHubTests`, completing coverage for all StreamHub implementations.

Closes #1936

## Changes

- Added `WithCachePruning_MatchesSeriesExactly` to `tests/indicators/_common/Quotes/Tick.StreamHub.Tests.cs`
- Test streams 100 ticks through a `TickHub` with `maxCacheSize=50`, then verifies the cache was pruned to 50 entries retaining the most recent ticks

## Context

Of the ~82 `*.StreamHub.Tests.cs` files, 80 already had this standardized test. The only indicator-specific hub missing it was `TickStreamHubTests`. The `Convergence.StreamHub.Tests.cs` file tests convergence/precision behavior for specific indicators and is intentionally out of scope for this pattern.

## Testing

```
dotnet test tests/indicators/ --filter "TickStreamHubTests"
```

Build verified locally with 0 compiler errors.