### PR TITLE
revert: undo direct-push f92a0fd6 (governance violation §1.7)

### DIFF
--- a/docs/indicators/Alligator.md
+++ b/docs/indicators/Alligator.md
@@ -83,21 +83,7 @@ See [Chaining indicators](/guide/batch#chaining-indicators) for more.
 
 ## Streaming
 
-Use the buffer-style `List<T>` when you need incremental calculations without a hub:
-
-```csharp
-AlligatorList alligatorList = new(jawPeriods, jawOffset, teethPeriods, teethOffset, lipsPeriods, lipsOffset);
-
-foreach (IQuote quote in quotes)  // simulating stream
-{
-  alligatorList.Add(quote);
-}
-
-// based on `ICollection<AlligatorResult>`
-IReadOnlyList<AlligatorResult> results = alligatorList;
-```
-
-Subscribe to a `QuoteHub` for advanced streaming scenarios:
+Subscribe to a `QuoteHub` for streaming scenarios:
 
 ```csharp
 QuoteHub quoteHub = new();

--- a/docs/indicators/AtrStop.md
+++ b/docs/indicators/AtrStop.md
@@ -80,21 +80,7 @@ See [Chaining indicators](/guide/batch#chaining-indicators) for more.
 
 ## Streaming
 
-Use the buffer-style `List<T>` when you need incremental calculations without a hub:
-
-```csharp
-AtrStopList atrStopList = new(lookbackPeriods, multiplier: 3.0, endType: EndType.Close);
-
-foreach (IQuote quote in quotes)  // simulating stream
-{
-  atrStopList.Add(quote);
-}
-
-// based on `ICollection<AtrStopResult>`
-IReadOnlyList<AtrStopResult> results = atrStopList;
-```
-
-Subscribe to a `QuoteHub` for advanced streaming scenarios:
+Subscribe to a `QuoteHub` for streaming scenarios:
 
 ```csharp
 QuoteHub quoteHub = new();

--- a/docs/indicators/Tsi.md
+++ b/docs/indicators/Tsi.md
@@ -65,32 +65,20 @@ See [Utilities and helpers](/utilities/results/) for more information.
 
 ## Streaming
 
-Use the buffer-style `List<T>` when you need incremental calculations without a hub:
+This indicator can be used with the buffer style for incremental streaming scenarios.  See [Streaming guide](/guide/stream) for more information.
 
 ```csharp
-TsiList tsiList = new(lookbackPeriods, smoothPeriods, signalPeriods);
+// buffer-style streaming
+TsiList buffer = new(lookbackPeriods, smoothPeriods, signalPeriods);
 
 foreach (IQuote quote in quotes)  // simulating stream
 {
-  tsiList.Add(quote);
+    buffer.Add(quote);
+    TsiResult result = buffer[^1];
 }
 
-// based on `ICollection<TsiResult>`
-IReadOnlyList<TsiResult> results = tsiList;
-```
-
-Subscribe to a `QuoteHub` for advanced streaming scenarios:
-
-```csharp
-QuoteHub quoteHub = new();
-TsiHub observer = quoteHub.ToTsiHub(lookbackPeriods, smoothPeriods, signalPeriods);
-
-foreach (IQuote quote in quotes)  // simulating stream
-{
-  quoteHub.Add(quote);
-}
-
-IReadOnlyList<TsiResult> results = observer.Results;
+// or initialize with historical quotes
+TsiList buffer = quotes.ToTsiList(lookbackPeriods, smoothPeriods, signalPeriods);
 ```
 
 See [Buffer lists](/guide/buffer) and [Stream hubs](/guide/stream) for full usage guides.


### PR DESCRIPTION
## Summary

Reverts commit `f92a0fd6d8228dd0ad9b0d028f00cb6384e99f5e` which was pushed directly to the default branch (`v3`) without a pull request, in violation of governance policy §1.7.

**Scope of original commit:** Docs-only additions to `Alligator.md`, `AtrStop.md`, `Tsi.md` (BufferList/StreamHub examples).

**Why revert via PR?** Direct pushes to the default branch are prohibited. This revert restores the branch to its proper pre-violation state. The same changes will be re-landed through a proper PR.

## Related
- Governance violation issue: FAC-763
- Follow-up re-land PR: to be opened immediately after this merges

## Checklist
- [x] Revert is clean (no unintended changes)
- [x] Board approval granted before opening this PR (approval 07637fb6)