### PR TITLE
docs: add missing BufferList/StreamHub coverage to Alligator, AtrStop, Tsi

### DIFF
--- a/docs/indicators/Alligator.md
+++ b/docs/indicators/Alligator.md
@@ -83,7 +83,21 @@ See [Chaining indicators](/guide/batch#chaining-indicators) for more.
 
 ## Streaming
 
-Subscribe to a `QuoteHub` for streaming scenarios:
+Use the buffer-style `List<T>` when you need incremental calculations without a hub:
+
+```csharp
+AlligatorList alligatorList = new(jawPeriods, jawOffset, teethPeriods, teethOffset, lipsPeriods, lipsOffset);
+
+foreach (IQuote quote in quotes)  // simulating stream
+{
+  alligatorList.Add(quote);
+}
+
+// based on `ICollection<AlligatorResult>`
+IReadOnlyList<AlligatorResult> results = alligatorList;
+```
+
+Subscribe to a `QuoteHub` for advanced streaming scenarios:
 
 ```csharp
 QuoteHub quoteHub = new();

--- a/docs/indicators/AtrStop.md
+++ b/docs/indicators/AtrStop.md
@@ -80,7 +80,21 @@ See [Chaining indicators](/guide/batch#chaining-indicators) for more.
 
 ## Streaming
 
-Subscribe to a `QuoteHub` for streaming scenarios:
+Use the buffer-style `List<T>` when you need incremental calculations without a hub:
+
+```csharp
+AtrStopList atrStopList = new(lookbackPeriods, multiplier: 3.0, endType: EndType.Close);
+
+foreach (IQuote quote in quotes)  // simulating stream
+{
+  atrStopList.Add(quote);
+}
+
+// based on `ICollection<AtrStopResult>`
+IReadOnlyList<AtrStopResult> results = atrStopList;
+```
+
+Subscribe to a `QuoteHub` for advanced streaming scenarios:
 
 ```csharp
 QuoteHub quoteHub = new();

--- a/docs/indicators/Tsi.md
+++ b/docs/indicators/Tsi.md
@@ -65,20 +65,32 @@ See [Utilities and helpers](/utilities/results/) for more information.
 
 ## Streaming
 
-This indicator can be used with the buffer style for incremental streaming scenarios.  See [Streaming guide](/guide/stream) for more information.
+Use the buffer-style `List<T>` when you need incremental calculations without a hub:
 
 ```csharp
-// buffer-style streaming
-TsiList buffer = new(lookbackPeriods, smoothPeriods, signalPeriods);
+TsiList tsiList = new(lookbackPeriods, smoothPeriods, signalPeriods);
 
 foreach (IQuote quote in quotes)  // simulating stream
 {
-    buffer.Add(quote);
-    TsiResult result = buffer[^1];
+  tsiList.Add(quote);
 }
 
-// or initialize with historical quotes
-TsiList buffer = quotes.ToTsiList(lookbackPeriods, smoothPeriods, signalPeriods);
+// based on `ICollection<TsiResult>`
+IReadOnlyList<TsiResult> results = tsiList;
+```
+
+Subscribe to a `QuoteHub` for advanced streaming scenarios:
+
+```csharp
+QuoteHub quoteHub = new();
+TsiHub observer = quoteHub.ToTsiHub(lookbackPeriods, smoothPeriods, signalPeriods);
+
+foreach (IQuote quote in quotes)  // simulating stream
+{
+  quoteHub.Add(quote);
+}
+
+IReadOnlyList<TsiResult> results = observer.Results;
 ```
 
 See [Buffer lists](/guide/buffer) and [Stream hubs](/guide/stream) for full usage guides.


### PR DESCRIPTION
## Summary

Re-lands the docs changes from commit `f92a0fd6` via a proper PR, as required by governance policy §1.7.

This branch is built cleanly on top of `v3` after the revert PR (#2003) was merged.

**Changes:**
- `Alligator.md`: add `AlligatorList` buffer-style example (was hub-only)
- `AtrStop.md`: add `AtrStopList` buffer-style example (was hub-only)
- `Tsi.md`: add `TsiHub` streaming example; normalize buffer section to standard template

These changes complete the 3-style coverage gate for FAC-714 VitePress docs completeness pass.

## Related
- Governance violation issue: FAC-763
- Revert PR (merged): #2003
- Supersedes: #2004 (stale branch — closed)
- Part of: FAC-714