### PR TITLE
feat: Hurst exponent upgrade

### DIFF
--- a/src/e-k/Hurst/Hurst.Series.cs
+++ b/src/e-k/Hurst/Hurst.Series.cs
@@ -102,8 +102,9 @@ public static partial class Indicator
                 // chunk mean diff
                 double sumY = 0;
                 double sumSq = 0;
-                double maxY = values[startIndex] - chunkMean;
-                double minY = values[startIndex] - chunkMean;
+                double maxY = double.MinValue;
+                double minY = double.MaxValue;
+
                 for (int i = startIndex; i < startIndex + chunkSize; i++)
                 {
                     double y = values[i] - chunkMean;

--- a/src/e-k/Hurst/Hurst.Series.cs
+++ b/src/e-k/Hurst/Hurst.Series.cs
@@ -35,7 +35,7 @@ public static partial class Indicator
                     (DateTime _, double c) = tpList[p];
 
                     // return values
-                    values[x] = l != 0 ? (c / l) - 1 : double.NaN;
+                    values[x] = l != 0 ? Math.Log(c / l) : double.NaN;
 
                     l = c;
                     x++;


### PR DESCRIPTION
Changes to do:
- [x] Use log returns.
- [ ] Add [Anis-Lloyd corrected R/S Hurst](https://en.wikipedia.org/wiki/Hurst_exponent#Rescaled_range_(R/S)_analysis)
- [x] Simplify cumulative range initialization semantics
- [ ] Update manual calculation spreadsheet
- [ ] Updates tests from calculation proofs
- [ ] Do sanity check in formula authenticity (math)

<details><summary>Why log returns?</summary>
Because Hurst estimation assumes:
- additive increments
- scale consistency

Log returns behave much better statistically.

Arithmetic returns can:
- inflate persistence during strong trends
- distort volatility normalization
- introduce asymmetry in high-momentum periods
</details>

Consider other lower priority improvements:
- [ ] Add DFA-based alternative implementation
- [ ] Add confidence intervals
- [ ] Add bias warnings in docs
- [ ] Allow custom chunk schedules