### PR TITLE
feat: Hurst exponent upgrade

### DIFF
--- a/.github/workflows/test-website-links.yml
+++ b/.github/workflows/test-website-links.yml
@@ -42,7 +42,11 @@ jobs:
         run: sed -i 's/data-src/src/g' pages/home.md
 
       - name: Use 'localhost'
-        run: grep -rl 'https://dotnet.stockindicators.dev' . | xargs --no-run-if-empty sed -i 's|https://dotnet.stockindicators.dev|http://127.0.0.1:4000|g'
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          find: "https://dotnet.stockindicators.dev"
+          replace: "http://127.0.0.1:4000"
+          regex: false
 
       - name: Build site
         env:

--- a/.github/workflows/test-website-links.yml
+++ b/.github/workflows/test-website-links.yml
@@ -39,18 +39,10 @@ jobs:
         run: gem install html-proofer
 
       - name: Replace "data-src"
-        uses: jacobtomlinson/gha-find-replace@v3
-        with:
-          find: "data-src"
-          replace: "src"
-          regex: false
+        run: sed -i 's/data-src/src/g' pages/home.md
 
       - name: Use 'localhost'
-        uses: jacobtomlinson/gha-find-replace@v3
-        with:
-          find: "https://dotnet.stockindicators.dev"
-          replace: "http://127.0.0.1:4000"
-          regex: false
+        run: grep -rl 'https://dotnet.stockindicators.dev' . | xargs --no-run-if-empty sed -i 's|https://dotnet.stockindicators.dev|http://127.0.0.1:4000|g'
 
       - name: Build site
         env:

--- a/docs/_indicators/Hurst.md
+++ b/docs/_indicators/Hurst.md
@@ -45,7 +45,9 @@ IEnumerable<HurstResult>
 
 **`Date`** _`DateTime`_ - Date from evaluated `TQuote`
 
-**`HurstExponent`** _`double`_ - Hurst Exponent (`H`)
+**`HurstExponent`** _`double`_ - Hurst Exponent (`H`) from raw rescaled range (R/S) analysis
+
+**`HurstExponentAL`** _`double`_ - [Anis-Lloyd corrected](https://en.wikipedia.org/wiki/Hurst_exponent#Rescaled_range_(R/S)_analysis) Hurst Exponent (`H`). Removes finite-sample bias from the raw R/S estimate. Like `HurstExponent`, values near 0.5 represent a random walk, greater than 0.5 depict trending, and less than 0.5 indicate mean-reverting behavior. This corrected value is generally preferred for smaller lookback periods.
 
 ### Utilities
 

--- a/docs/_indicators/Hurst.md
+++ b/docs/_indicators/Hurst.md
@@ -22,7 +22,7 @@ IEnumerable<HurstResult> results =
 
 ## Parameters
 
-**`lookbackPeriods`** _`int`_ - Number of periods (`N`) in the Hurst Analysis.  Must be greater than 20.  Default is 100.
+**`lookbackPeriods`** _`int`_ - Number of periods (`N`) in the Hurst Analysis.  Must be at least 20.  Default is 100.
 
 ### Historical quotes requirements
 
@@ -77,3 +77,9 @@ var results = quotes
     .GetHurst(..)
     .GetSlope(..);
 ```
+
+## References
+
+- Inputs are log returns `ln(c_t / c_{t-1})`, which provide additive, scale-consistent increments.
+- `HurstExponent` (raw `H`) is the slope of `log(R/S)` against `log(n)` across chunk sizes, following the rescaled-range analysis of Hurst (1951) and Mandelbrot & Wallis (1969).
+- `HurstExponentAL` applies the Anis & Lloyd (1976) finite-sample expectation `E[R/S]_n = Γ((n-1)/2) / (√π · Γ(n/2)) · Σ_{r=1}^{n-1} √((n-r)/r)`, then corrects each observed R/S as `R/S − E[R/S]_n + √(π·n/2)` before regressing. The expected value uses an exact `LogGamma` evaluation for `n ≤ 340` and Peters' (1994) Stirling approximation `√(2 / (π·(n-1)))` for larger `n`.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -21,7 +21,7 @@ For more information on how to use this library overall, see the [Guide and Pro 
 ## Getting started with our sample projects
 
 We use an external API quote source for our **streaming** and **quote API** examples.  If you intend to run those locally, you'll need to
-[get a free Alpaca API key and secret](https://alpaca.markets/docs/market-data/getting-started/),
+[get a free Alpaca API key and secret](https://docs.alpaca.markets/us/docs/getting-started-with-alpaca-market-data),
 then set your local environment variables.
 
 Run the following command line items to set, after replacing the `MY-ALPACA-KEY` and `MY-ALPACA-SECRET` values; then restart your IDE.

--- a/src/_common/Math/Numerix.cs
+++ b/src/_common/Math/Numerix.cs
@@ -88,6 +88,49 @@ public static class Numerix
         return slope;
     }
 
+    // LOG GAMMA (Lanczos approximation)
+    // Accurate for x > 0; valid range documented below.
+    // Uses reflection formula for 0 < x < 0.5, Lanczos for x >= 0.5.
+    internal static double LogGamma(double x)
+    {
+        if (x <= 0)
+        {
+            return double.NaN;
+        }
+
+        double[] c = [
+            0.99999999999980993,
+            676.5203681218851,
+            -1259.1392167224028,
+            771.32342877765313,
+            -176.61502916214059,
+            12.507343278686905,
+            -0.13857109526572012,
+            9.9843695780195716e-6,
+            1.5056327351493116e-7
+        ];
+
+        if (x < 0.5)
+        {
+            // reflection formula: Γ(x)Γ(1-x) = π/sin(πx)
+            double sinPiX = Math.Sin(Math.PI * x);
+            return sinPiX > 0
+                ? Math.Log(Math.PI / sinPiX) - LogGamma(1.0 - x)
+                : double.NaN;
+        }
+
+        x -= 1.0;
+        double a = c[0];
+        double t = x + 7.5; // g + 0.5, where g = 7
+
+        for (int i = 1; i <= 8; i++)
+        {
+            a += c[i] / (x + i);
+        }
+
+        return 0.5 * Math.Log(2 * Math.PI) + (x + 0.5) * Math.Log(t) - t + Math.Log(a);
+    }
+
     // DATE ROUNDING
     internal static DateTime RoundDown(this DateTime dateTime, TimeSpan interval)
         => interval == TimeSpan.Zero

--- a/src/e-k/Hurst/Hurst.Models.cs
+++ b/src/e-k/Hurst/Hurst.Models.cs
@@ -10,5 +10,7 @@ public sealed class HurstResult : ResultBase, IReusableResult
 
     public double? HurstExponent { get; set; }
 
+    public double? HurstExponentAL { get; set; }
+
     double? IReusableResult.Value => HurstExponent;
 }

--- a/src/e-k/Hurst/Hurst.Series.cs
+++ b/src/e-k/Hurst/Hurst.Series.cs
@@ -42,14 +42,16 @@ public static partial class Indicator
                 }
 
                 // calculate hurst exponent
-                r.HurstExponent = CalcHurstWindow(values).NaN2Null();
+                (double h, double hAl) = CalcHurstWindow(values);
+                r.HurstExponent = h.NaN2Null();
+                r.HurstExponentAL = hAl.NaN2Null();
             }
         }
 
         return results;
     }
 
-    private static double CalcHurstWindow(double[] values)
+    private static (double H, double HAL) CalcHurstWindow(double[] values)
     {
         int totalSize = values.Length;
         int maxChunks = 0;
@@ -73,6 +75,7 @@ public static partial class Indicator
 
         // initialize result sets
         double[] logRs = new double[setQty];
+        double[] logRsAL = new double[setQty];
         double[] logSize = new double[setQty];
         int setNum = 0;
 
@@ -126,17 +129,67 @@ public static partial class Indicator
                 startIndex += chunkSize;
             }
 
+            // average R/S for this chunk size
+            double avgRs = sumChunkRs / chunkQty;
+
+            // Anis-Lloyd finite-sample expected R/S
+            double eRs = HurstExpectedRS(chunkSize);
+
+            // asymptotic expected R/S: √(π×n/2)
+            double eRsAsymptotic = Math.Sqrt(Math.PI * chunkSize / 2.0);
+
+            // Anis-Lloyd corrected R/S:
+            // subtract finite-sample bias, add back asymptotic expectation
+            // RS_corrected = RS_observed − E[R/S]_AL + √(π×n/2)
+            double rsAL = avgRs - eRs + eRsAsymptotic;
+
             // set results
             logSize[setNum] = Math.Log10(chunkSize);
-            logRs[setNum] = Math.Log10(sumChunkRs / chunkQty);
+            logRs[setNum] = Math.Log10(avgRs);
+
+            // fall back to uncorrected value if corrected R/S is non-positive
+            // (rare edge case: only occurs when avgRs is near zero, e.g. bad data)
+            logRsAL[setNum] = rsAL > 0
+                ? Math.Log10(rsAL)
+                : logRs[setNum];
 
             // increment set
             setNum++;
         }
 
-        // hurst exponent
-        // TODO: apply Anis-Lloyd corrected R/S Hurst?
-        return Numerix.Slope(logSize, logRs);
+        // hurst exponents: raw and Anis-Lloyd corrected
+        return (
+            Numerix.Slope(logSize, logRs),
+            Numerix.Slope(logSize, logRsAL));
+    }
+
+    // Anis-Lloyd expected R/S for a random series of length n
+    // Reference: Anis and Lloyd (1976), Peters (1994)
+    private static double HurstExpectedRS(int n)
+    {
+        // inner sum: Σ_{j=1}^{n-1} √((n-j)/j)
+        double innerSum = 0;
+        for (int j = 1; j < n; j++)
+        {
+            innerSum += Math.Sqrt((double)(n - j) / j);
+        }
+
+        double gammaFactor;
+        if (n <= 340)
+        {
+            // exact: Γ((n-1)/2) / (√π × Γ(n/2))
+            gammaFactor = Math.Exp(
+                Numerix.LogGamma((n - 1.0) / 2.0)
+                - 0.5 * Math.Log(Math.PI)
+                - Numerix.LogGamma(n / 2.0));
+        }
+        else
+        {
+            // Stirling approximation: √(2 / (π × n))
+            gammaFactor = Math.Sqrt(2.0 / (Math.PI * n));
+        }
+
+        return (n - 0.5) / n * gammaFactor * innerSum;
     }
 
     // parameter validation

--- a/src/e-k/Hurst/Hurst.Series.cs
+++ b/src/e-k/Hurst/Hurst.Series.cs
@@ -147,11 +147,11 @@ public static partial class Indicator
             logSize[setNum] = Math.Log10(chunkSize);
             logRs[setNum] = Math.Log10(avgRs);
 
-            // fall back to uncorrected value if corrected R/S is non-positive
+            // use NaN if corrected R/S is non-positive
             // (rare edge case: only occurs when avgRs is near zero, e.g. bad data)
             logRsAL[setNum] = rsAL > 0
                 ? Math.Log10(rsAL)
-                : logRs[setNum];
+                : double.NaN;
 
             // increment set
             setNum++;

--- a/src/e-k/Hurst/Hurst.Series.cs
+++ b/src/e-k/Hurst/Hurst.Series.cs
@@ -35,7 +35,7 @@ public static partial class Indicator
                     (DateTime _, double c) = tpList[p];
 
                     // return values
-                    values[x] = l != 0 ? (c / l) - 1 : double.NaN;
+                    values[x] = l != 0 ? Math.Log(c / l) : double.NaN;
 
                     l = c;
                     x++;
@@ -102,8 +102,9 @@ public static partial class Indicator
                 // chunk mean diff
                 double sumY = 0;
                 double sumSq = 0;
-                double maxY = values[startIndex] - chunkMean;
-                double minY = values[startIndex] - chunkMean;
+                double maxY = double.MinValue;
+                double minY = double.MaxValue;
+
                 for (int i = startIndex; i < startIndex + chunkSize; i++)
                 {
                     double y = values[i] - chunkMean;

--- a/src/e-k/Hurst/Hurst.Series.cs
+++ b/src/e-k/Hurst/Hurst.Series.cs
@@ -14,6 +14,11 @@ public static partial class Indicator
         int length = tpList.Count;
         List<HurstResult> results = new(length);
 
+        // precompute Anis-Lloyd bias corrections per chunk size:
+        // these depend only on lookbackPeriods, not on the data, so
+        // they are constant across every result index.
+        double[] alCorrections = PrecomputeAlCorrections(lookbackPeriods);
+
         // roll through quotes
         for (int i = 0; i < length; i++)
         {
@@ -34,15 +39,16 @@ public static partial class Indicator
                 {
                     (DateTime _, double c) = tpList[p];
 
-                    // return values
-                    values[x] = l != 0 ? Math.Log(c / l) : double.NaN;
+                    // log returns require strictly positive prices on both
+                    // ends; non-positive inputs propagate as NaN
+                    values[x] = (l > 0 && c > 0) ? Math.Log(c / l) : double.NaN;
 
                     l = c;
                     x++;
                 }
 
                 // calculate hurst exponent
-                (double h, double hAl) = CalcHurstWindow(values);
+                (double h, double hAl) = CalcHurstWindow(values, alCorrections);
                 r.HurstExponent = h.NaN2Null();
                 r.HurstExponentAL = hAl.NaN2Null();
             }
@@ -51,7 +57,9 @@ public static partial class Indicator
         return results;
     }
 
-    private static (double H, double HAL) CalcHurstWindow(double[] values)
+    private static (double H, double HAL) CalcHurstWindow(
+        double[] values,
+        double[] alCorrections)
     {
         int totalSize = values.Length;
         int maxChunks = 0;
@@ -132,23 +140,19 @@ public static partial class Indicator
             // average R/S for this chunk size
             double avgRs = sumChunkRs / chunkQty;
 
-            // Anis-Lloyd finite-sample expected R/S
-            double eRs = HurstExpectedRS(chunkSize);
-
-            // asymptotic expected R/S: √(π×n/2)
-            double eRsAsymptotic = Math.Sqrt(Math.PI * chunkSize / 2.0);
-
             // Anis-Lloyd corrected R/S:
-            // subtract finite-sample bias, add back asymptotic expectation
-            // RS_corrected = RS_observed − E[R/S]_AL + √(π×n/2)
-            double rsAL = avgRs - eRs + eRsAsymptotic;
+            // RS_corrected = avgRs - E[R/S]_AL + √(π·n/2)
+            // The bias-correction term (√(π·n/2) - E[R/S]_AL) is precomputed
+            // per chunk size since it depends only on n.
+            double rsAL = avgRs + alCorrections[setNum];
 
             // set results
             logSize[setNum] = Math.Log10(chunkSize);
             logRs[setNum] = Math.Log10(avgRs);
 
-            // use NaN if corrected R/S is non-positive
-            // (rare edge case: only occurs when avgRs is near zero, e.g. bad data)
+            // NaN-guards: rsAL is non-negative for any finite avgRs (the
+            // bias-correction term is positive across all chunk sizes used),
+            // so this branch fires only when avgRs is NaN.
             logRsAL[setNum] = rsAL > 0
                 ? Math.Log10(rsAL)
                 : double.NaN;
@@ -163,6 +167,39 @@ public static partial class Indicator
             Numerix.Slope(logSize, logRsAL));
     }
 
+    // Precomputes the Anis-Lloyd bias-correction term (√(π·n/2) - E[R/S]_AL)
+    // for each chunk size derived from totalSize. The chunk sizes and the
+    // correction depend only on lookbackPeriods, not on the data, so we do
+    // this once per indicator call rather than per result index.
+    private static double[] PrecomputeAlCorrections(int totalSize)
+    {
+        int setQty = 0;
+        int maxChunks = 0;
+        for (int chunkQty = 1; chunkQty <= 32; chunkQty *= 2)
+        {
+            if (totalSize / chunkQty >= 8)
+            {
+                maxChunks = chunkQty;
+                setQty++;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        double[] corrections = new double[setQty];
+        int setIdx = 0;
+        for (int chunkQty = 1; chunkQty <= maxChunks; chunkQty *= 2)
+        {
+            int chunkSize = totalSize / chunkQty;
+            double eRsAsymptotic = Math.Sqrt(Math.PI * chunkSize / 2.0);
+            corrections[setIdx++] = eRsAsymptotic - HurstExpectedRS(chunkSize);
+        }
+
+        return corrections;
+    }
+
     // Anis-Lloyd expected R/S for a random series of length n
     // Reference: Anis and Lloyd (1976), Peters (1994)
     private static double HurstExpectedRS(int n)
@@ -175,6 +212,10 @@ public static partial class Indicator
         }
 
         double gammaFactor;
+
+        // Branch threshold n=340: below this, LogGamma is fast and exact;
+        // above, the Stirling approximation introduces <0.05% error and
+        // avoids LogGamma overflow risk for very large n.
         if (n <= 340)
         {
             // exact: Γ((n-1)/2) / (√π × Γ(n/2))
@@ -185,11 +226,13 @@ public static partial class Indicator
         }
         else
         {
-            // Stirling approximation: √(2 / (π × n))
-            gammaFactor = Math.Sqrt(2.0 / (Math.PI * n));
+            // Stirling Variant A (Peters 1994): √(2 / (π × (n-1)))
+            // More accurate than (n-0.5)/n · √(2/(π·n)) — 5× lower error
+            // vs exact Γ((n-1)/2)/(√π·Γ(n/2)) across all n > 340.
+            gammaFactor = Math.Sqrt(2.0 / (Math.PI * (n - 1.0)));
         }
 
-        return (n - 0.5) / n * gammaFactor * innerSum;
+        return gammaFactor * innerSum;
     }
 
     // parameter validation

--- a/tests/indicators/e-k/Hurst/Hurst.Tests.cs
+++ b/tests/indicators/e-k/Hurst/Hurst.Tests.cs
@@ -18,7 +18,8 @@ public class HurstTests : TestBase
 
         // sample value
         HurstResult r15820 = results[15820];
-        Assert.AreEqual(0.483563, r15820.HurstExponent.Round(6));
+        Assert.AreEqual(0.479755, r15820.HurstExponent.Round(6));
+        Assert.AreEqual(0.470697, r15820.HurstExponentAL.Round(6));
     }
 
     [TestMethod]
@@ -31,6 +32,11 @@ public class HurstTests : TestBase
 
         Assert.HasCount(502, results);
         Assert.AreEqual(402, results.Count(static x => x.HurstExponent != null));
+
+        // sample value: last result
+        HurstResult last = results[501];
+        Assert.AreEqual(0.564643, last.HurstExponent.Round(6));
+        Assert.AreEqual(0.485145, last.HurstExponentAL.Round(6));
     }
 
     [TestMethod]
@@ -42,6 +48,7 @@ public class HurstTests : TestBase
 
         Assert.HasCount(200, r);
         Assert.IsEmpty(r.Where(static x => x.HurstExponent is double v && double.IsNaN(v)));
+        Assert.IsEmpty(r.Where(static x => x.HurstExponentAL is double v && double.IsNaN(v)));
     }
 
     [TestMethod]
@@ -77,6 +84,7 @@ public class HurstTests : TestBase
 
         Assert.HasCount(502, r);
         Assert.IsEmpty(r.Where(static x => x.HurstExponent is double v && double.IsNaN(v)));
+        Assert.IsEmpty(r.Where(static x => x.HurstExponentAL is double v && double.IsNaN(v)));
     }
 
     [TestMethod]
@@ -106,7 +114,8 @@ public class HurstTests : TestBase
         Assert.HasCount(1, results);
 
         HurstResult last = results.LastOrDefault();
-        Assert.AreEqual(0.483563, last.HurstExponent.Round(6));
+        Assert.AreEqual(0.479755, last.HurstExponent.Round(6));
+        Assert.AreEqual(0.470697, last.HurstExponentAL.Round(6));
     }
 
     // bad lookback period

--- a/tests/indicators/e-k/Hurst/Hurst.Tests.cs
+++ b/tests/indicators/e-k/Hurst/Hurst.Tests.cs
@@ -32,6 +32,7 @@ public class HurstTests : TestBase
 
         Assert.HasCount(502, results);
         Assert.AreEqual(402, results.Count(static x => x.HurstExponent != null));
+        Assert.AreEqual(402, results.Count(static x => x.HurstExponentAL != null));
 
         // sample value: last result
         HurstResult last = results[501];

--- a/tests/indicators/e-k/Hurst/Hurst.Tests.cs
+++ b/tests/indicators/e-k/Hurst/Hurst.Tests.cs
@@ -19,7 +19,27 @@ public class HurstTests : TestBase
         // sample value
         HurstResult r15820 = results[15820];
         Assert.AreEqual(0.479755, r15820.HurstExponent.Round(6));
-        Assert.AreEqual(0.470697, r15820.HurstExponentAL.Round(6));
+        Assert.AreEqual(0.471156, r15820.HurstExponentAL.Round(6));
+    }
+
+    [TestMethod]
+    public void StirlingBoundary()
+    {
+        // lookbackPeriods=500 produces chunk sizes [500, 250, 125, 62, 31, 15]
+        // which straddle the n=340 Stirling/exact-gamma branch boundary.
+        // First chunk uses the Stirling Variant A path; the rest use the
+        // exact LogGamma path.
+        List<HurstResult> results = quotes
+            .GetHurst(500)
+            .ToList();
+
+        Assert.HasCount(502, results);
+        Assert.AreEqual(2, results.Count(static x => x.HurstExponent != null));
+        Assert.AreEqual(2, results.Count(static x => x.HurstExponentAL != null));
+
+        HurstResult last = results[501];
+        Assert.AreEqual(0.568000, last.HurstExponent.Round(6));
+        Assert.AreEqual(0.516229, last.HurstExponentAL.Round(6));
     }
 
     [TestMethod]
@@ -37,7 +57,7 @@ public class HurstTests : TestBase
         // sample value: last result
         HurstResult last = results[501];
         Assert.AreEqual(0.564643, last.HurstExponent.Round(6));
-        Assert.AreEqual(0.485145, last.HurstExponentAL.Round(6));
+        Assert.AreEqual(0.497004, last.HurstExponentAL.Round(6));
     }
 
     [TestMethod]
@@ -116,7 +136,7 @@ public class HurstTests : TestBase
 
         HurstResult last = results.LastOrDefault();
         Assert.AreEqual(0.479755, last.HurstExponent.Round(6));
-        Assert.AreEqual(0.470697, last.HurstExponentAL.Round(6));
+        Assert.AreEqual(0.471156, last.HurstExponentAL.Round(6));
     }
 
     // bad lookback period


### PR DESCRIPTION
Changes:
- [x] Use log returns `ln(c_t / c_{t-1})` for additive, scale-consistent increments.
- [x] Add [Anis-Lloyd corrected R/S Hurst](https://en.wikipedia.org/wiki/Hurst_exponent#Rescaled_range_(R/S)_analysis) (`HurstExponentAL`).
- [x] Simplify cumulative range initialization semantics.
- [x] Update tests from calculation proofs.
- [x] Sanity-check formula authenticity (see below).
- [x] Update manual calculation spreadsheet.

## Formulas used

- **Raw `HurstExponent`** — rescaled-range (R/S) analysis of Hurst (1951) and Mandelbrot & Wallis (1969). Slope of `log(R/S)` against `log(n)` across chunk sizes.
- **`HurstExponentAL`** — Anis & Lloyd (1976) finite-sample expectation, applied as a bias correction:

  `E[R/S]_n = Γ((n-1)/2) / (√π · Γ(n/2)) · Σ_{r=1}^{n-1} √((n-r)/r)`

  Each observed R/S is corrected as `R/S − E[R/S]_n + √(π·n/2)` before regressing.
- **Gamma evaluation** — exact `LogGamma` for `n ≤ 340`; Peters (1994) Stirling approximation `√(2/(π·(n-1)))` for larger `n`. This Stirling form ("Variant A") is ~5× more accurate than the `(n-0.5)/n · √(2/(π·n))` form ("Variant B") against the exact gamma ratio across the chunk sizes used (494–15,820), and also improves continuity at the n=340 branch boundary.

<details><summary>Why log returns?</summary>
Because Hurst estimation assumes:
- additive increments
- scale consistency

Log returns behave much better statistically.

Arithmetic returns can:
- inflate persistence during strong trends
- distort volatility normalization
- introduce asymmetry in high-momentum periods
</details>

Consider other lower priority improvements:
- [ ] Add DFA-based alternative implementation
- [ ] Add confidence intervals
- [ ] Add bias warnings in docs
- [ ] Allow custom chunk schedules