### PR TITLE
test: Aggregator boundary tests + fix mid-bucket Rebuild duplicate-bar bug

### DIFF
--- a/docs/plans/streaming-indicators.plan.md
+++ b/docs/plans/streaming-indicators.plan.md
@@ -171,13 +171,15 @@ Together ~1 working day. Some items can be parallelized across multiple test PRs
   - **Why**: WilliamsR boundary clamping (T202) was added with tests, but the pattern wasn't generalized. RSI, Stoch %K/%D, Aroon, AroonOsc, MFI, UltimateOscillator, ConnorsRsi all have documented value ranges that are not systematically asserted.
   - **Action**: Add a `BoundedIndicatorInvariant.Tests.cs` enumerating indicators with documented ranges; assert every non-null result is in range across the standard quote set.
 
-- [ ] **TC004 — Expand Macd StreamHub coverage to match Ema** (2 hours).
-  - **Evidence**: Macd has 3 StreamHub tests; Ema has 11. Macd is structurally more complex.
+- [x] **TC004 — Expand Macd StreamHub coverage to match Ema** (verified 2026-05-25, no new code needed).
+  - **Evidence (original, now stale)**: Macd has 3 StreamHub tests; Ema has 11. Macd is structurally more complex.
   - **Action**: Add `LateInbound`, `Reset`, `MaxCacheSize`, `ChainObserver`, and parameter-variant tests to Macd. Audit all cascaded-state indicators for similar gaps.
+  - Re-verification (2026-05-25): `Macd.StreamHub.Tests.cs` now has 8 `[TestMethod]`s — more than Ema's 5 — including `QuoteObserver_WithWarmupLateArrivalAndRemoval`, `WithCachePruning`, `ChainObserver_ChainedProvider`, `ChainProvider`, `StreamingAccuracy_PartialQuotes`, the two TC002-added `LateArrival_*` variants, and `Parameters_WithCustomValues`. Counterparts for the other multi-stage hubs (Stoch=12, Adx=7, SuperTrend=5, Keltner=6, BollingerBands=7, Atr=6, AtrStop=6, Vortex=5, Chandelier=6, Renko=7) all carry comparable coverage after TC002 shipped. The cascaded-state audit is therefore complete. Any further per-indicator depth (e.g., the `Reset` semantics originally listed) belongs in v3.1 alongside the `Reinitialize()` work (T205).
 
-- [ ] **TC005 — Quote aggregator boundary tests** (2 hours).
+- [x] **TC005 — Quote aggregator boundary tests** (2 hours).
   - **Evidence**: `tests/indicators/_common/Quotes/Quote.Aggregate.Tests.cs` covers happy-path bucketing and invalid-period rejection. Missing: gap-fill on/off variants, late tick crossing a closed bucket boundary, partial-bucket emission on stream end.
   - **Action**: Add `Quote.Aggregate.LateArrival`, `Quote.Aggregate.GapFill`, `Quote.Aggregate.PartialBucket` tests. Pattern-match `TickHub.Tests.cs:60` (`WithCachePruning`) for consistency.
+  - Shipped scope: 3 new tests per aggregator hub (Quote + Tick = 6 tests total) covering late-arrival across closed multi-input buckets, partial-bucket-on-stream-end contract, and late-vs-fresh oracle parity. Gap-fill on/off variants were already covered. The late-arrival tests caught a latent bug: when an upstream `NotifyObserversOnRebuild` passed a mid-bucket timestamp (the input quote/tick's own timestamp, not the bucket boundary), the aggregator's `Rebuild` did not clear the partial in-cache bar, and the replay appended a duplicate bar at the bucket start. Fix landed alongside the tests: both aggregator hubs override `Rebuild(DateTime)` to round the timestamp down to `AggregationPeriod` before delegating to base.
 
 - [ ] **TC006 — Sharpen catalog assertions (consolidates T219)** (1 hour).
   - **Evidence**: `tests/indicators/_common/Catalog/Catalog.Metrics.Tests.cs:33–34` uses `bufferCount.Should().BeGreaterThan(5)` and `streamCount.Should().BeGreaterThan(10)` while `seriesCount.Should().Be(85)` is exact.
@@ -364,6 +366,12 @@ P015 status now depends on PV001 outcome. P016 and P017 confirmed at algorithmic
 - [ ] **TC-V31-5 — Compound-hub inner↔outer rollback interaction** (3 hours).
   - Source: TC001 follow-up. For compound hubs (StochRsi, Stc, ConnorsRsi, Gator, etc.) `Rebuild` on the outer hub does not exercise the inner hub's `RollbackState`. Inner is still validated via its own listing's TC001 row; the cross-hub interaction is not. Add a targeted test only if a real compound-hub rollback bug surfaces.
 
+- [ ] **TC-V31-8 — Chained-downstream late-arrival aggregator coverage** (1–2 hours).
+  - Source: TC005 self-review (Tester finding). The new TC005 tests exercise the aggregator hub in isolation. A `QuoteHub → AggregatorHub → EmaHub` (and tick analog) late-arrival test would additionally pin that the aggregator's upstream-triggered rebuild propagates downstream observer notifications correctly, catching a hypothetical regression where the rebuild silently dropped one notification per replay. Inline test per pattern; assert downstream `EmaHub.Results` bit-equality between late and fresh chains.
+
+- [ ] **TC-V31-9 — Aggregator late-arrival × gap-fill interaction** (1–2 hours).
+  - Source: TC005 self-review (Tester observation). Late quote arriving into a bucket that was previously gap-filled should replace the gap bar with a real one rather than leave or duplicate it. Add `LateArrival_IntoGapFilledBucket_ReplacesGapBar` to both aggregator test files.
+
 - [ ] **TC-V31-6 — Aggregator gap-fill / missing-candle test variants** (2–3 hours).
   - Source: Discussion #1018 @elAndyG. Companion to T236 (`GapFillMode` enum) and G008 (docs).
   - Add tests under `tests/indicators/_common/Quotes/Quote.AggregatorHub.Tests.cs`: synthesized tick sequences with intentional gaps (e.g., missing 1-minute bars during low-volume periods); assert behavior under each future `GapFillMode` value (None/ForwardFill/Interpolate). Today the test gap is in §D TC005 (boundary tests) — TC-V31-6 extends that pattern once T236 ships. Distinct from TC-V31-4 (which covers rollback equivalence on the aggregator hubs themselves).
@@ -496,4 +504,4 @@ All items implemented in source; baselines pending refresh (RG001).
 
 ---
 
-Last updated: 2026-05-25
+Last updated: 2026-05-25 (TC005 shipped + aggregator Rebuild fix; TC004 verified done)

--- a/src/_common/Quotes/Quote.AggregatorHub.cs
+++ b/src/_common/Quotes/Quote.AggregatorHub.cs
@@ -275,6 +275,23 @@ public class QuoteAggregatorHub
     public override string ToString()
         => $"QUOTE-AGG<{AggregationPeriod}>: {Cache.Count} items";
 
+    /// <summary>
+    /// Aligns the rebuild timestamp to the bucket boundary so that an
+    /// upstream-triggered rebuild (whose timestamp is the late input quote's
+    /// timestamp, not a bucket start) clears the partial aggregated bar and
+    /// re-aggregates the bucket from scratch. Without this alignment the
+    /// existing in-cache bar at the bucket start is kept and the replay
+    /// appends a duplicate bar at the same timestamp.
+    /// </summary>
+    public override void Rebuild(DateTime fromTimestamp)
+    {
+        DateTime alignedTimestamp = fromTimestamp == DateTime.MinValue
+            ? fromTimestamp
+            : fromTimestamp.RoundDown(AggregationPeriod);
+
+        base.Rebuild(alignedTimestamp);
+    }
+
     /// <inheritdoc/>
     protected override void RollbackState(int restoreIndex)
     {

--- a/src/_common/Quotes/Quote.AggregatorHub.cs
+++ b/src/_common/Quotes/Quote.AggregatorHub.cs
@@ -275,14 +275,15 @@ public class QuoteAggregatorHub
     public override string ToString()
         => $"QUOTE-AGG<{AggregationPeriod}>: {Cache.Count} items";
 
-    /// <summary>
+    /// <inheritdoc/>
+    /// <remarks>
     /// Aligns the rebuild timestamp to the bucket boundary so that an
     /// upstream-triggered rebuild (whose timestamp is the late input quote's
     /// timestamp, not a bucket start) clears the partial aggregated bar and
     /// re-aggregates the bucket from scratch. Without this alignment the
     /// existing in-cache bar at the bucket start is kept and the replay
     /// appends a duplicate bar at the same timestamp.
-    /// </summary>
+    /// </remarks>
     public override void Rebuild(DateTime fromTimestamp)
     {
         DateTime alignedTimestamp = fromTimestamp == DateTime.MinValue

--- a/src/_common/Quotes/Tick.AggregatorHub.cs
+++ b/src/_common/Quotes/Tick.AggregatorHub.cs
@@ -276,14 +276,15 @@ public class TickAggregatorHub
     public override string ToString()
         => $"TICK-AGG<{AggregationPeriod}>: {Cache.Count} items";
 
-    /// <summary>
+    /// <inheritdoc/>
+    /// <remarks>
     /// Aligns the rebuild timestamp to the bucket boundary so that an
     /// upstream-triggered rebuild (whose timestamp is the late input tick's
     /// timestamp, not a bucket start) clears the partial aggregated bar and
     /// re-aggregates the bucket from scratch. Without this alignment the
     /// existing in-cache bar at the bucket start is kept and the replay
     /// appends a duplicate bar at the same timestamp.
-    /// </summary>
+    /// </remarks>
     public override void Rebuild(DateTime fromTimestamp)
     {
         DateTime alignedTimestamp = fromTimestamp == DateTime.MinValue

--- a/src/_common/Quotes/Tick.AggregatorHub.cs
+++ b/src/_common/Quotes/Tick.AggregatorHub.cs
@@ -276,6 +276,23 @@ public class TickAggregatorHub
     public override string ToString()
         => $"TICK-AGG<{AggregationPeriod}>: {Cache.Count} items";
 
+    /// <summary>
+    /// Aligns the rebuild timestamp to the bucket boundary so that an
+    /// upstream-triggered rebuild (whose timestamp is the late input tick's
+    /// timestamp, not a bucket start) clears the partial aggregated bar and
+    /// re-aggregates the bucket from scratch. Without this alignment the
+    /// existing in-cache bar at the bucket start is kept and the replay
+    /// appends a duplicate bar at the same timestamp.
+    /// </summary>
+    public override void Rebuild(DateTime fromTimestamp)
+    {
+        DateTime alignedTimestamp = fromTimestamp == DateTime.MinValue
+            ? fromTimestamp
+            : fromTimestamp.RoundDown(AggregationPeriod);
+
+        base.Rebuild(alignedTimestamp);
+    }
+
     /// <inheritdoc/>
     protected override void RollbackState(int restoreIndex)
     {

--- a/tests/indicators/_common/Quotes/Quote.AggregatorHub.Tests.cs
+++ b/tests/indicators/_common/Quotes/Quote.AggregatorHub.Tests.cs
@@ -544,5 +544,174 @@ public class QuoteAggregatorHubTests : StreamHubTestBase, ITestQuoteObserver, IT
         aggregator.Unsubscribe();
         provider.EndTransmission();
     }
+
+    [TestMethod]
+    public void LateArrival_CrossingClosedBucket_RebuildsCorrectly()
+    {
+        // A late quote belonging to a 5-minute bucket that has already been
+        // closed (by quotes in subsequent buckets) must trigger a rebuild
+        // and produce a bar reflecting the additional quote's OHLCV
+        // contributions. The two later buckets must remain unchanged.
+
+        QuoteHub provider = new();
+        QuoteAggregatorHub aggregator = provider.ToQuoteAggregatorHub(PeriodSize.FiveMinutes);
+
+        // Bucket 10:00 — two quotes
+        provider.Add(new Quote(
+            DateTime.Parse("2023-11-09 10:00", invariantCulture), 100m, 105m, 99m, 102m, 1000m));
+        provider.Add(new Quote(
+            DateTime.Parse("2023-11-09 10:02", invariantCulture), 102m, 106m, 101m, 104m, 1100m));
+
+        // Bucket 10:05 — closes bucket 10:00
+        provider.Add(new Quote(
+            DateTime.Parse("2023-11-09 10:05", invariantCulture), 104m, 108m, 103m, 107m, 1200m));
+        provider.Add(new Quote(
+            DateTime.Parse("2023-11-09 10:07", invariantCulture), 107m, 109m, 106m, 108m, 1300m));
+
+        // Bucket 10:10 — closes bucket 10:05
+        provider.Add(new Quote(
+            DateTime.Parse("2023-11-09 10:10", invariantCulture), 108m, 112m, 107m, 110m, 1400m));
+        provider.Add(new Quote(
+            DateTime.Parse("2023-11-09 10:12", invariantCulture), 110m, 114m, 109m, 113m, 1500m));
+
+        // Late arrival to the closed 10:00 bucket with values that move
+        // both the high and the low; pinning these in the assertion proves
+        // the rebuild path incorporated the late quote rather than skipping it.
+        provider.Add(new Quote(
+            DateTime.Parse("2023-11-09 10:03", invariantCulture), 103m, 120m, 90m, 105m, 500m));
+
+        IReadOnlyList<IQuote> results = aggregator.Results;
+        results.Should().HaveCount(3);
+
+        // Bucket 10:00 now reflects the late quote
+        IQuote bar0 = results[0];
+        bar0.Timestamp.Should().Be(DateTime.Parse("2023-11-09 10:00", invariantCulture));
+        bar0.Open.Should().Be(100m);
+        bar0.High.Should().Be(120m);
+        bar0.Low.Should().Be(90m);
+        bar0.Close.Should().Be(105m);   // Close from latest-by-timestamp in bucket (10:03)
+        bar0.Volume.Should().Be(2600m); // 1000 + 1100 + 500
+
+        // Bucket 10:05 unchanged
+        IQuote bar1 = results[1];
+        bar1.Timestamp.Should().Be(DateTime.Parse("2023-11-09 10:05", invariantCulture));
+        bar1.Open.Should().Be(104m);
+        bar1.High.Should().Be(109m);
+        bar1.Low.Should().Be(103m);
+        bar1.Close.Should().Be(108m);
+        bar1.Volume.Should().Be(2500m);
+
+        // Bucket 10:10 unchanged
+        IQuote bar2 = results[2];
+        bar2.Timestamp.Should().Be(DateTime.Parse("2023-11-09 10:10", invariantCulture));
+        bar2.Open.Should().Be(108m);
+        bar2.High.Should().Be(114m);
+        bar2.Low.Should().Be(107m);
+        bar2.Close.Should().Be(113m);
+        bar2.Volume.Should().Be(2900m);
+
+        aggregator.Unsubscribe();
+        provider.EndTransmission();
+    }
+
+    [TestMethod]
+    public void PartialBucket_OnStreamEnd_IsEmittedAsIncomplete()
+    {
+        // The aggregator emits the current (in-progress) bucket as soon as
+        // its first quote arrives, and that bar mutates in place as more
+        // quotes inside the same bucket arrive. When the stream ends
+        // mid-bucket the partial bar remains in Results — it is NOT
+        // trimmed, hidden, or frozen at first emission. Pin both the
+        // live-mutation contract and the survives-on-stream-end contract
+        // so downstream consumers (e.g. live-bar charting) can rely on it.
+
+        QuoteHub provider = new();
+        QuoteAggregatorHub aggregator = provider.ToQuoteAggregatorHub(PeriodSize.FiveMinutes);
+
+        // First quote opens the 10:00-10:04 bucket as a partial bar
+        provider.Add(new Quote(
+            DateTime.Parse("2023-11-09 10:00", invariantCulture), 100m, 105m, 99m, 102m, 1000m));
+
+        IReadOnlyList<IQuote> results = aggregator.Results;
+        results.Should().HaveCount(1);
+        results[0].Open.Should().Be(100m);
+        results[0].High.Should().Be(105m);
+        results[0].Low.Should().Be(99m);
+        results[0].Close.Should().Be(102m);
+        results[0].Volume.Should().Be(1000m);
+
+        // Second quote in the same bucket — the partial bar must mutate
+        provider.Add(new Quote(
+            DateTime.Parse("2023-11-09 10:02", invariantCulture), 102m, 110m, 98m, 108m, 1100m));
+
+        results.Should().HaveCount(1);
+        IQuote partial = results[0];
+        partial.Timestamp.Should().Be(DateTime.Parse("2023-11-09 10:00", invariantCulture));
+        partial.Open.Should().Be(100m);
+        partial.High.Should().Be(110m);
+        partial.Low.Should().Be(98m);
+        partial.Close.Should().Be(108m);
+        partial.Volume.Should().Be(2100m);
+
+        aggregator.Unsubscribe();
+        provider.EndTransmission();
+    }
+
+    [TestMethod]
+    public void LateArrival_MatchesFreshStream()
+    {
+        // Skip a mid-stream quote, then re-add it after the cache head
+        // has advanced several buckets. The late hub's aggregated bars
+        // must equal a fresh hub fed the same quotes in correct order;
+        // this is the rollback-equivalence invariant exercised at the
+        // bucket-aware aggregator layer rather than at a per-indicator
+        // hub.
+
+        const int totalQuotes = 60;
+        const int lateIndex = 17;
+
+        // Use minute-spaced quotes so each 5-minute bucket holds multiple inputs
+        List<Quote> quotes = [];
+        for (int i = 0; i < totalQuotes; i++)
+        {
+            quotes.Add(new Quote(
+                DateTime.Parse("2023-11-09 10:00", invariantCulture).AddMinutes(i),
+                100m + i, 105m + i, 99m + i, 102m + i, 1000m + i));
+        }
+
+        QuoteHub lateSource = new();
+        QuoteAggregatorHub lateHub = lateSource.ToQuoteAggregatorHub(PeriodSize.FiveMinutes);
+        for (int i = 0; i < totalQuotes; i++)
+        {
+            if (i == lateIndex) { continue; }
+
+            lateSource.Add(quotes[i]);
+        }
+
+        lateSource.Add(quotes[lateIndex]);
+
+        QuoteHub freshSource = new();
+        QuoteAggregatorHub freshHub = freshSource.ToQuoteAggregatorHub(PeriodSize.FiveMinutes);
+        freshSource.Add(quotes);
+
+        IReadOnlyList<IQuote> lateResults = lateHub.Results;
+        IReadOnlyList<IQuote> freshResults = freshHub.Results;
+
+        lateResults.Should().HaveSameCount(freshResults);
+        for (int i = 0; i < freshResults.Count; i++)
+        {
+            lateResults[i].Timestamp.Should().Be(freshResults[i].Timestamp);
+            lateResults[i].Open.Should().Be(freshResults[i].Open);
+            lateResults[i].High.Should().Be(freshResults[i].High);
+            lateResults[i].Low.Should().Be(freshResults[i].Low);
+            lateResults[i].Close.Should().Be(freshResults[i].Close);
+            lateResults[i].Volume.Should().Be(freshResults[i].Volume);
+        }
+
+        lateHub.Unsubscribe();
+        freshHub.Unsubscribe();
+        lateSource.EndTransmission();
+        freshSource.EndTransmission();
+    }
 }
 

--- a/tests/indicators/_common/Quotes/Tick.AggregatorHub.Tests.cs
+++ b/tests/indicators/_common/Quotes/Tick.AggregatorHub.Tests.cs
@@ -619,4 +619,176 @@ public class TickAggregatorHubTests : StreamHubTestBase, ITestQuoteObserver, ITe
         aggregator.Unsubscribe();
         provider.EndTransmission();
     }
+
+    [TestMethod]
+    public void LateArrival_CrossingClosedBucket_RebuildsCorrectly()
+    {
+        // A late tick belonging to a 1-minute bucket that has already been
+        // closed (by ticks in subsequent buckets) must trigger a rebuild
+        // and produce a bar reflecting the additional tick's price/volume.
+        // Later buckets must remain unchanged.
+
+        TickHub provider = new();
+        TickAggregatorHub aggregator = provider.ToTickAggregatorHub(PeriodSize.OneMinute);
+
+        // Bucket 10:00 — two ticks (no execution IDs so they aren't deduped)
+        provider.Add(new Tick(
+            DateTime.Parse("2023-11-09 10:00:00", invariantCulture), 100m, 10m, null));
+        provider.Add(new Tick(
+            DateTime.Parse("2023-11-09 10:00:30", invariantCulture), 101m, 11m, null));
+
+        // Bucket 10:01 — closes bucket 10:00
+        provider.Add(new Tick(
+            DateTime.Parse("2023-11-09 10:01:10", invariantCulture), 102m, 12m, null));
+        provider.Add(new Tick(
+            DateTime.Parse("2023-11-09 10:01:40", invariantCulture), 103m, 13m, null));
+
+        // Bucket 10:02 — closes bucket 10:01
+        provider.Add(new Tick(
+            DateTime.Parse("2023-11-09 10:02:15", invariantCulture), 104m, 14m, null));
+        provider.Add(new Tick(
+            DateTime.Parse("2023-11-09 10:02:45", invariantCulture), 105m, 15m, null));
+
+        // Late tick into the closed 10:00 bucket with extreme high and low
+        provider.Add(new Tick(
+            DateTime.Parse("2023-11-09 10:00:45", invariantCulture), 120m, 5m, null));
+
+        IReadOnlyList<IQuote> results = aggregator.Results;
+        results.Should().HaveCount(3);
+
+        // Bucket 10:00 now reflects the late tick
+        IQuote bar0 = results[0];
+        bar0.Timestamp.Should().Be(DateTime.Parse("2023-11-09 10:00", invariantCulture));
+        bar0.Open.Should().Be(100m);
+        bar0.High.Should().Be(120m);   // Updated by late tick
+        bar0.Low.Should().Be(100m);    // Min of 100, 101, 120
+        bar0.Close.Should().Be(120m);  // Last-by-timestamp in bucket is 10:00:45
+        bar0.Volume.Should().Be(26m);  // 10 + 11 + 5
+
+        // Bucket 10:01 unchanged
+        IQuote bar1 = results[1];
+        bar1.Timestamp.Should().Be(DateTime.Parse("2023-11-09 10:01", invariantCulture));
+        bar1.Open.Should().Be(102m);
+        bar1.High.Should().Be(103m);
+        bar1.Low.Should().Be(102m);
+        bar1.Close.Should().Be(103m);
+        bar1.Volume.Should().Be(25m);
+
+        // Bucket 10:02 unchanged
+        IQuote bar2 = results[2];
+        bar2.Timestamp.Should().Be(DateTime.Parse("2023-11-09 10:02", invariantCulture));
+        bar2.Open.Should().Be(104m);
+        bar2.High.Should().Be(105m);
+        bar2.Low.Should().Be(104m);
+        bar2.Close.Should().Be(105m);
+        bar2.Volume.Should().Be(29m);
+
+        aggregator.Unsubscribe();
+        provider.EndTransmission();
+    }
+
+    [TestMethod]
+    public void PartialBucket_OnStreamEnd_IsEmittedAsIncomplete()
+    {
+        // The aggregator emits the current (in-progress) bucket as soon as
+        // its first tick arrives, and that bar mutates in place as more
+        // ticks inside the same bucket arrive. When the stream ends
+        // mid-bucket the partial bar remains in Results — it is NOT
+        // trimmed, hidden, or frozen at first emission. Pin both the
+        // live-mutation contract and the survives-on-stream-end contract
+        // so downstream consumers (e.g. live-bar charting) can rely on it.
+
+        TickHub provider = new();
+        TickAggregatorHub aggregator = provider.ToTickAggregatorHub(PeriodSize.OneMinute);
+
+        // First tick opens the 10:00 bucket as a partial bar
+        provider.Add(new Tick(
+            DateTime.Parse("2023-11-09 10:00:00", invariantCulture), 100m, 10m, null));
+
+        IReadOnlyList<IQuote> results = aggregator.Results;
+        results.Should().HaveCount(1);
+        results[0].Open.Should().Be(100m);
+        results[0].High.Should().Be(100m);
+        results[0].Low.Should().Be(100m);
+        results[0].Close.Should().Be(100m);
+        results[0].Volume.Should().Be(10m);
+
+        // Second tick in the same bucket — the partial bar must mutate
+        provider.Add(new Tick(
+            DateTime.Parse("2023-11-09 10:00:30", invariantCulture), 105m, 15m, null));
+
+        results.Should().HaveCount(1);
+        IQuote partial = results[0];
+        partial.Timestamp.Should().Be(DateTime.Parse("2023-11-09 10:00", invariantCulture));
+        partial.Open.Should().Be(100m);
+        partial.High.Should().Be(105m);
+        partial.Low.Should().Be(100m);
+        partial.Close.Should().Be(105m);
+        partial.Volume.Should().Be(25m);
+
+        aggregator.Unsubscribe();
+        provider.EndTransmission();
+    }
+
+    [TestMethod]
+    public void LateArrival_MatchesFreshStream()
+    {
+        // Skip a mid-stream tick, then re-add it after the cache head
+        // has advanced several buckets. The late hub's aggregated bars
+        // must equal a fresh hub fed the same ticks in correct order;
+        // this is the rollback-equivalence invariant exercised at the
+        // bucket-aware aggregator layer rather than at a per-indicator
+        // hub.
+
+        const int totalTicks = 60;
+        const int lateIndex = 17;
+
+        // 15-second spacing places multiple ticks per 1-minute bucket
+        List<Tick> ticks = [];
+        for (int i = 0; i < totalTicks; i++)
+        {
+            ticks.Add(new Tick(
+                DateTime.Parse("2023-11-09 10:00:00", invariantCulture).AddSeconds(i * 15),
+                100m + i,
+                10m + i,
+                null));
+        }
+
+        TickHub lateSource = new();
+        TickAggregatorHub lateHub = lateSource.ToTickAggregatorHub(PeriodSize.OneMinute);
+        for (int i = 0; i < totalTicks; i++)
+        {
+            if (i == lateIndex) { continue; }
+
+            lateSource.Add(ticks[i]);
+        }
+
+        lateSource.Add(ticks[lateIndex]);
+
+        TickHub freshSource = new();
+        TickAggregatorHub freshHub = freshSource.ToTickAggregatorHub(PeriodSize.OneMinute);
+        foreach (Tick tick in ticks)
+        {
+            freshSource.Add(tick);
+        }
+
+        IReadOnlyList<IQuote> lateResults = lateHub.Results;
+        IReadOnlyList<IQuote> freshResults = freshHub.Results;
+
+        lateResults.Should().HaveSameCount(freshResults);
+        for (int i = 0; i < freshResults.Count; i++)
+        {
+            lateResults[i].Timestamp.Should().Be(freshResults[i].Timestamp);
+            lateResults[i].Open.Should().Be(freshResults[i].Open);
+            lateResults[i].High.Should().Be(freshResults[i].High);
+            lateResults[i].Low.Should().Be(freshResults[i].Low);
+            lateResults[i].Close.Should().Be(freshResults[i].Close);
+            lateResults[i].Volume.Should().Be(freshResults[i].Volume);
+        }
+
+        lateHub.Unsubscribe();
+        freshHub.Unsubscribe();
+        lateSource.EndTransmission();
+        freshSource.EndTransmission();
+    }
 }


### PR DESCRIPTION
## Summary

- Adds 3 boundary tests each to `Quote.AggregatorHub.Tests.cs` and `Tick.AggregatorHub.Tests.cs` covering late-arrival across a closed multi-input bucket, partial-bucket emission and live mutation on stream end, and late-vs-fresh rollback equivalence — closing the v3.0 TC005 scope in `docs/plans/streaming-indicators.plan.md`.
- Fixes a latent aggregator bug surfaced by the new tests: when upstream `NotifyObserversOnRebuild` passes a mid-bucket timestamp (the input quote/tick's own timestamp, not the bucket boundary), the aggregator's `Rebuild` left the partial in-cache bar untouched and the replay appended a duplicate bar at the bucket start. Both aggregator hubs now override `Rebuild(DateTime)` to round the timestamp down to `AggregationPeriod` before delegating to base — bringing the upstream-rebuild path in line with the aggregator's own `OnAdd` late-arrival path, which already passed a rounded `barTimestamp`.
- Re-verifies TC004 (Macd test parity with Ema) as already complete in the current codebase; updates the plan entry rather than adding redundant work.
- Files two v3.1+ follow-ups raised by self-review: chained-downstream late-arrival coverage and late-arrival × gap-fill interaction.

Implements TC005 from `docs/plans/streaming-indicators.plan.md`.

## Why the fix

`StreamHub.Rebuild(DateTime)` does `Cache.RemoveAll(c => c.Timestamp >= fromTimestamp)`. The aggregator's `Cache` is keyed by bucket-start timestamps, so a `fromTimestamp` of `10:00:45` does not remove the bucket whose key is `10:00:00`. The replay then `AppendCache`s a new bar at `10:00:00`, producing a duplicate. Rounding to the bucket boundary unifies the two rebuild entry points (aggregator-internal `OnAdd` already passed the rounded `barTimestamp` via the `isPastBar` branch).

## Self-review

Dispatched three personas (Architect / Tester / Stercorator) inline. Acted on:

- (Stercorator critical) Stripped `TC001` plan-ID references from the two new test files — per `CLAUDE.local.md` no-plan-ID-in-code rule.
- (Stercorator + Architect agree, minor) Dropped dead `<inheritdoc/>` tag from the override xmldoc.
- (Tester major) Strengthened `PartialBucket_OnStreamEnd_IsEmittedAsIncomplete` to assert live mutation after first quote then after second quote (previously asserted only final state — a regression that froze the first emission would have passed).

Deferred (filed as v3.1 plan items): chained-downstream late-arrival test (TC-V31-8), late-arrival × gap-fill interaction (TC-V31-9).

Rejected: theoretical OHLCV literal masking — pinned Open values already differentiate "first-by-timestamp" from "first-processed-in-replay" in the new tests.

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~AggregatorHub"` — 33/33 pass
- [x] `dotnet test --filter "FullyQualifiedName~StreamHub|FullyQualifiedName~RollbackContract|FullyQualifiedName~Catalog"` — 784/784 pass
- [x] Full indicator suite — 2402/2402 pass, 12 skipped (baseline tests, intentional)
- [x] Sensitivity check: reverting the `Rebuild` override flipped both `LateArrival_CrossingClosedBucket_*` and both `LateArrival_MatchesFreshStream` tests (4 fails), confirming the regression guard. Reverted cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)