### PR TITLE
test: Pin exact catalog counts (TC006)

### DIFF
--- a/docs/plans/streaming-indicators.plan.md
+++ b/docs/plans/streaming-indicators.plan.md
@@ -181,7 +181,7 @@ Together ~1 working day. Some items can be parallelized across multiple test PRs
   - **Action**: Add `Quote.Aggregate.LateArrival`, `Quote.Aggregate.GapFill`, `Quote.Aggregate.PartialBucket` tests. Pattern-match `TickHub.Tests.cs:60` (`WithCachePruning`) for consistency.
   - Shipped scope: 3 new tests per aggregator hub (Quote + Tick = 6 tests total) covering late-arrival across closed multi-input buckets, partial-bucket-on-stream-end contract, and late-vs-fresh oracle parity. Gap-fill on/off variants were already covered. The late-arrival tests caught a latent bug: when an upstream `NotifyObserversOnRebuild` passed a mid-bucket timestamp (the input quote/tick's own timestamp, not the bucket boundary), the aggregator's `Rebuild` did not clear the partial in-cache bar, and the replay appended a duplicate bar at the bucket start. Fix landed alongside the tests: both aggregator hubs override `Rebuild(DateTime)` to round the timestamp down to `AggregationPeriod` before delegating to base.
 
-- [ ] **TC006 — Sharpen catalog assertions (consolidates T219)** (1 hour).
+- [x] **TC006 — Sharpen catalog assertions (consolidates T219)** (1 hour).
   - **Evidence**: `tests/indicators/_common/Catalog/Catalog.Metrics.Tests.cs:33–34` uses `bufferCount.Should().BeGreaterThan(5)` and `streamCount.Should().BeGreaterThan(10)` while `seriesCount.Should().Be(85)` is exact.
   - **Action**: Replace `BeGreaterThan(...)` with `Be(79)` for both Buffer and Stream; replace `totalCount.Should().BeGreaterThan(100)` with `Be(243)`.
 
@@ -504,4 +504,4 @@ All items implemented in source; baselines pending refresh (RG001).
 
 ---
 
-Last updated: 2026-05-25 (TC005 shipped + aggregator Rebuild fix; TC004 verified done)
+Last updated: 2026-05-25

--- a/docs/plans/streaming-indicators.plan.md
+++ b/docs/plans/streaming-indicators.plan.md
@@ -181,7 +181,7 @@ Together ~1 working day. Some items can be parallelized across multiple test PRs
   - **Action**: Add `Quote.Aggregate.LateArrival`, `Quote.Aggregate.GapFill`, `Quote.Aggregate.PartialBucket` tests. Pattern-match `TickHub.Tests.cs:60` (`WithCachePruning`) for consistency.
   - Shipped scope: 3 new tests per aggregator hub (Quote + Tick = 6 tests total) covering late-arrival across closed multi-input buckets, partial-bucket-on-stream-end contract, and late-vs-fresh oracle parity. Gap-fill on/off variants were already covered. The late-arrival tests caught a latent bug: when an upstream `NotifyObserversOnRebuild` passed a mid-bucket timestamp (the input quote/tick's own timestamp, not the bucket boundary), the aggregator's `Rebuild` did not clear the partial in-cache bar, and the replay appended a duplicate bar at the bucket start. Fix landed alongside the tests: both aggregator hubs override `Rebuild(DateTime)` to round the timestamp down to `AggregationPeriod` before delegating to base.
 
-- [x] **TC006 — Sharpen catalog assertions (consolidates T219)** (1 hour).
+- [x] **TC006 — Sharpen catalog assertions (consolidates T219)** (1 hour). *(PR #2023)*
   - **Evidence**: `tests/indicators/_common/Catalog/Catalog.Metrics.Tests.cs:33–34` uses `bufferCount.Should().BeGreaterThan(5)` and `streamCount.Should().BeGreaterThan(10)` while `seriesCount.Should().Be(85)` is exact.
   - **Action**: Replace `BeGreaterThan(...)` with `Be(79)` for both Buffer and Stream; replace `totalCount.Should().BeGreaterThan(100)` with `Be(243)`.
 

--- a/tests/indicators/_common/Catalog/Catalog.Metrics.Tests.cs
+++ b/tests/indicators/_common/Catalog/Catalog.Metrics.Tests.cs
@@ -2,18 +2,17 @@ namespace Catalogging;
 
 /// <summary>
 /// Catalog metrics tests:
-/// - basic catalog sanity (presence, minimum size, non-empty fields)
+/// - per-listing field presence (Uiid and Name)
 /// - exact style counts and total count matching current static catalog
 /// </summary>
 [TestClass]
 public class CatalogMetricsTests : TestBase
 {
     [TestMethod]
-    public void StaticCatalogShouldHaveCorrectCount()
+    public void StaticCatalogListingsShouldHavePopulatedFields()
     {
         IReadOnlyCollection<IndicatorListing> allListings = Catalog.Get();
         allListings.Should().NotBeEmpty();
-        allListings.Count.Should().BeGreaterThan(50);
         allListings.Should().OnlyContain(static l => !string.IsNullOrWhiteSpace(l.Uiid));
         allListings.Should().OnlyContain(static l => !string.IsNullOrWhiteSpace(l.Name));
     }
@@ -26,14 +25,13 @@ public class CatalogMetricsTests : TestBase
         int streamCount = catalog.Count(static x => x.Style == Style.Stream);
         int bufferCount = catalog.Count(static x => x.Style == Style.Buffer);
 
-        Console.WriteLine($"Actual Catalog Style Counts: Series={seriesCount}, Stream={streamCount}, Buffer={bufferCount}, Total={seriesCount + streamCount + bufferCount}");
-
-        // TODO: add final count later, not now
-        seriesCount.Should().Be(85);  // Updated for TimeValue
-        bufferCount.Should().BeGreaterThan(5);
-        streamCount.Should().BeGreaterThan(10);
+        // 6 indicators (Beta, Correlation, Prs, RenkoAtr, StdDevChannels, ZigZag) are
+        // Series-only and account for the 85 vs 79 gap.
+        seriesCount.Should().Be(85);
+        bufferCount.Should().Be(79);
+        streamCount.Should().Be(79);
 
         int totalCount = seriesCount + streamCount + bufferCount;
-        totalCount.Should().BeGreaterThan(100);
+        totalCount.Should().Be(243);
     }
 }


### PR DESCRIPTION
## Summary

Closes the last item in §D Test coverage hardening of the streaming indicators plan: tighten `CatalogShouldHaveExactStyleCounts` so a future regression in catalog registrations fails loudly instead of slipping under the prior loose bounds.

- `bufferCount.Should().BeGreaterThan(5)` → `Be(79)`
- `streamCount.Should().BeGreaterThan(10)` → `Be(79)`
- `totalCount.Should().BeGreaterThan(100)` → `Be(243)`
- `seriesCount.Should().Be(85)` retained
- Inline `Console.WriteLine` diagnostic removed (FluentAssertions failure messages carry the actuals)
- Stale `// TODO: add final count later, not now` replaced with a 2-line note pointing at the 6 Series-only indicators that explain the 85 vs 79 gap (Beta, Correlation, Prs, RenkoAtr, StdDevChannels, ZigZag)

Self-review swarm (Tester / Stercorator / Inspector) also surfaced a same-file vestigial assertion: `StaticCatalogShouldHaveCorrectCount` had a redundant `BeGreaterThan(50)` count check that the new exact totals now cover. Folded into this PR: dropped the line and renamed the test to `StaticCatalogListingsShouldHavePopulatedFields` to reflect its real purpose (per-listing `Uiid`/`Name` invariants).

The structural-invariant tests in `Catalog.Integrity.Tests.cs:67-81` (Series > Stream, Series > Buffer, total reconciles) were intentionally left alone — they assert a different property (the *relationship* between counts), not exact values.

Implements TC006 from `docs/plans/streaming-indicators.plan.md`.

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~Catalogging"` — 267 tests pass locally
- [x] `dotnet build` — full solution build clean across net8/9/10
- [x] Sensitivity-checked: actual counts confirmed as Series=85, Stream=79, Buffer=79, Total=243 via test diagnostic before tightening
- [ ] CI green on all jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)