### PR TITLE
fix: Catalog skill registration example to match real API

### DIFF
--- a/.agents/skills/indicator-catalog/SKILL.md
+++ b/.agents/skills/indicator-catalog/SKILL.md
@@ -101,7 +101,7 @@ public static partial class Ema
 
 Add entries inside the host repository's catalog populator method. The backing collection is a `private static readonly List<IndicatorListing>` declared at the top of the catalog file; the host repository determines its field name (shown below as `listings`).
 
-Indicators are grouped alphabetically by name and separated by a blank line. Each block is preceded by a short comment header — `// {Abbreviation} ({Full Name})` when an abbreviation is conventional, otherwise just `// {Full Name}`. Within a block, the preferred order for the style listings is **Buffer → Series → Stream**:
+Indicators are grouped alphabetically by indicator ID (abbreviation) and separated by a blank line. Each block is preceded by a short comment header — `// {Abbreviation} ({Full Name})` when an abbreviation is conventional, otherwise just `// {Full Name}`. Within a block, the preferred order for the style listings is **Buffer → Series → Stream**:
 
 ```csharp
 // EMA (Exponential Moving Average)

--- a/.agents/skills/indicator-catalog/SKILL.md
+++ b/.agents/skills/indicator-catalog/SKILL.md
@@ -69,7 +69,7 @@ public static partial class Ema
 
 ## Parameter patterns
 
-- `AddParameter<T>()` — int, double, bool
+- `AddParameter<T>()` — primitive value types (typically `int` or `double`)
 - `AddEnumParameter<T>()` — enum types
 - `AddDateParameter()` — DateTime
 - `AddSeriesParameter()` — `IReadOnlyList<T> where T : IReusable`
@@ -99,16 +99,28 @@ public static partial class Ema
 
 ## Registration
 
-Add to the catalog's populator method in the host repository. Indicators are grouped alphabetically by indicator name, and within each indicator block the three style listings register in **Buffer → Series → Stream** order:
+Add entries inside the host repository's catalog populator method. The backing collection is a `private static readonly List<IndicatorListing>` declared at the top of the catalog file; the host repository determines its field name (shown below as `listings`).
+
+Indicators are grouped alphabetically by name and separated by a blank line. Each block is preceded by a short comment header — `// {Abbreviation} ({Full Name})` when an abbreviation is conventional, otherwise just `// {Full Name}`. Within a block, the preferred order for the style listings is **Buffer → Series → Stream**:
 
 ```csharp
 // EMA (Exponential Moving Average)
-catalog.Add(Ema.BufferListing);
-catalog.Add(Ema.SeriesListing);
-catalog.Add(Ema.StreamListing);
+listings.Add(Ema.BufferListing);
+listings.Add(Ema.SeriesListing);
+listings.Add(Ema.StreamListing);
+
+// HMA (Hull Moving Average)
+listings.Add(Hma.BufferListing);
+listings.Add(Hma.SeriesListing);
+listings.Add(Hma.StreamListing);
 ```
 
-The backing collection is a `private static readonly List<IndicatorListing>` declared at the top of the catalog file; the host repository determines its field name. A short comment header `// {ABBR} ({Full Name})` precedes each indicator block, separated by a blank line.
+Series-only indicators (no streamable variant) register a single `SeriesListing` line in the same alphabetical position; e.g.:
+
+```csharp
+// Beta
+listings.Add(Beta.SeriesListing);
+```
 
 ## Prohibited
 

--- a/docs/plans/streaming-indicators.plan.md
+++ b/docs/plans/streaming-indicators.plan.md
@@ -506,4 +506,4 @@ All items implemented in source; baselines pending refresh (RG001).
 
 ---
 
-Last updated: 2026-05-26
+Last updated: 2026-05-25

--- a/docs/plans/streaming-indicators.plan.md
+++ b/docs/plans/streaming-indicators.plan.md
@@ -95,7 +95,7 @@ Medium-priority enhancements (composite naming E010, MaEnvelopes remaining MA ty
 
 Pure documentation fixes. Together ~4–6 hours. None require code changes.
 
-- [x] **G001 — Fix `indicator-catalog` SKILL.md to match real API** *(PR pending — branch `fix/indicator-catalog-skill`)*.
+- [x] **G001 — Fix `indicator-catalog` SKILL.md to match real API** *(PR #2025)*.
   - **Evidence**: `.agents/skills/indicator-catalog/SKILL.md:105–107` instructs `_catalog.Add(Ema.SeriesListing);` but `src/_common/Catalog/Catalog.Listings.cs:58–63` uses `_listings.Add(...)`. Grep confirms `_catalog.Add` exists in exactly one file in the repo — the SKILL.md itself.
   - **Action**: Replace `_catalog.Add` with `_listings.Add`; correct registration order to `Buffer → Series → Stream` per indicator (alphabetical grouping); add a one-line note about the ordering convention.
 

--- a/docs/plans/streaming-indicators.plan.md
+++ b/docs/plans/streaming-indicators.plan.md
@@ -95,7 +95,7 @@ Medium-priority enhancements (composite naming E010, MaEnvelopes remaining MA ty
 
 Pure documentation fixes. Together ~4–6 hours. None require code changes.
 
-- [ ] **G001 — Fix `indicator-catalog` SKILL.md to match real API** (30 min). **Severity: critical** — current example will produce non-compiling code.
+- [x] **G001 — Fix `indicator-catalog` SKILL.md to match real API** *(PR pending — branch `fix/indicator-catalog-skill`)*.
   - **Evidence**: `.agents/skills/indicator-catalog/SKILL.md:105–107` instructs `_catalog.Add(Ema.SeriesListing);` but `src/_common/Catalog/Catalog.Listings.cs:58–63` uses `_listings.Add(...)`. Grep confirms `_catalog.Add` exists in exactly one file in the repo — the SKILL.md itself.
   - **Action**: Replace `_catalog.Add` with `_listings.Add`; correct registration order to `Buffer → Series → Stream` per indicator (alphabetical grouping); add a one-line note about the ordering convention.
 
@@ -506,4 +506,4 @@ All items implemented in source; baselines pending refresh (RG001).
 
 ---
 
-Last updated: 2026-05-25
+Last updated: 2026-05-26


### PR DESCRIPTION
## Summary

- The `Registration` section of `.agents/skills/indicator-catalog/SKILL.md` previously showed `catalog.Add(Ema.SeriesListing);`. `Catalog` is a static class in the host repo, so an agent copying this verbatim into a `PopulateCatalog` method produces a non-compiling reference. Replace with a portable `listings.Add(...)` pattern and keep the existing "host repo determines its field name" caveat — the actual `_listings` field name is documented in `src/_common/AGENTS.md` per the layered guidance model (skills portable, AGENTS.md repo-specific).
- Swap the SMA second example for HMA so the demonstrated **Buffer → Series → Stream** order actually matches the host repo's registration. SMA is registered Series → Stream → Buffer at `src/_common/Catalog/Catalog.Listings.cs:352-355` and was a misleading exemplar.
- Soften the comment-header convention from a strict `// {ABBR} ({Full Name})` rule to "`// {Abbreviation} ({Full Name})` when an abbreviation is conventional; otherwise just `// {Full Name}`" — real catalog blocks split roughly 50/50 between the two forms (e.g., `// Alligator`, `// Beta`, `// Bollinger Bands`).
- Add a Series-only example block (Beta) so the existing "Series-only indicators register a single `SeriesListing` line" prose has a concrete example.
- Loosen the `AddParameter<T>` type list (`int, double, bool` → "primitive value types, typically `int` or `double`"). `AddParameter<bool>` is unused in the source; `<T>` is unconstrained.

Implements the **G001** quality-pass item in `docs/plans/streaming-indicators.plan.md`. Tick added and footer date bumped.

## Self-review swarm

Three personas reviewed the change in parallel (Stercorator, Inspector, Tester). Convergent findings acted on:

- Inspector F1 + Tester F1 (major): SMA example contradicted the stated convention → swapped for HMA.
- Stercorator F1 + Tester F2 (minor): comment-header rule overstated → softened.

Tester F4 ("decimal is used") was partially incorrect (Renko uses `<double>`, not `<decimal>`); the `bool` claim was also unsupported, so the type list was generalized instead.

Inspector F3 (use `_listings` in the example) was rejected — it conflicts with the skill portability rule at `.agents/skills/AGENTS.md:15` and the session-4 lesson that skills must not carry repo-specific field names.

## Test plan

- [x] `git diff origin/v3 -- .agents/skills/indicator-catalog/SKILL.md` — verified
- [x] Verified `Catalog.Listings.cs:217-219` registers HMA as Buffer → Series → Stream
- [x] Verified `Catalog.Listings.cs:101` registers Beta as a single `SeriesListing` line
- [x] Verified `AddParameter<bool>` and `AddParameter<decimal>` have zero occurrences in `src/`
- [ ] Docs-only change; no build/test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)