### PR TITLE
chore: Remove EnablePreviewFeatures from Indicators.csproj

### DIFF
--- a/src/Indicators.csproj
+++ b/src/Indicators.csproj
@@ -5,13 +5,6 @@
     <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
 
-    <!-- TODO: remove preview features
-         after Roslynator/.NET Roslyn agree
-         on BufferList.cs syntax -->
-    <EnablePreviewFeatures>true</EnablePreviewFeatures>
-    <GenerateRequiresPreviewFeaturesAttribute>false</GenerateRequiresPreviewFeaturesAttribute>
-    <!-- end preview features -->
-
     <AssemblyName>Skender.Stock.Indicators</AssemblyName>
     <RootNamespace>Skender.Stock.Indicators</RootNamespace>
     <NeutralLanguage>en-US</NeutralLanguage>


### PR DESCRIPTION
## Summary

- Removes `<EnablePreviewFeatures>true</EnablePreviewFeatures>` and `<GenerateRequiresPreviewFeaturesAttribute>false</GenerateRequiresPreviewFeaturesAttribute>` from `src/Indicators.csproj`.
- The `field` keyword (used only at `src/_common/BufferLists/BufferList.cs:54,56`) shipped GA in C# 14 / .NET 10. With `<LangVersion>latest</LangVersion>` and a .NET 10 SDK installed, `field` compiles cleanly without preview features regardless of target framework (`net10.0;net9.0;net8.0`).
- Eliminates preview-feature noise that would otherwise propagate to downstream consumers.

Implements `T203` from `docs/plans/streaming-indicators.plan.md` §C.

## Verification

- `dotnet build src/Indicators.csproj -c Release` — green on net10.0, net9.0, net8.0.
- `dotnet test --filter "FullyQualifiedName~BufferList"` — 553/553 passing.
- Repo grep for `[RequiresPreviewFeatures]` and other preview-only constructs returned no further usages in `src/`.
- No test or tools csproj references `EnablePreviewFeatures`, so removing it from the library produces no downstream inconsistency.

## Test plan

- [ ] CI build matrix succeeds on net8.0, net9.0, net10.0.
- [ ] Full test suite passes on `test-indicators-matrix.yml` and `test-indicators.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)