### PR TITLE
docs(aggregator): Document streaming gap-fill behavior

### DIFF
--- a/docs/plans/streaming-indicators.plan.md
+++ b/docs/plans/streaming-indicators.plan.md
@@ -123,9 +123,11 @@ Pure documentation fixes. Together ~4–6 hours. None require code changes.
   - **Evidence**: `docs/plans/streaming-indicators.plan.md` does not reference any skill or `AGENTS.md`; conversely no skill or `AGENTS.md` references this plan. This document is the design source of truth but is invisible from the contributor entry points.
   - **Action**: This file already added a "Related guidance" section at the top. Reciprocate by adding one line each to `indicator-stream/SKILL.md`, `indicator-buffer/SKILL.md`, and `indicator-catalog/SKILL.md` pointing here. Root `AGENTS.md` should mention `docs/plans/` exists.
 
-- [ ] **G008 — Document `Quote.AggregatorHub` gap-fill behavior** (30 min). **Source: Discussion #1018, @elAndyG (2023-10-10).**
-  - **Evidence**: `elAndyG` raised that premarket/low-volume periods produce missing candles (e.g., bars for 10:01, 10:02, 10:04, 10:05 with 10:03 missing) and asked how the aggregator should handle gaps — forward-fill last value, interpolate, or leave gap. Today the aggregator's behavior in this scenario is unspecified in public docs. Companion v3.1+ work tracked as T236 (`GapFillMode` enum) and TC-V31-6 (test coverage).
-  - **Action**: Document the current default behavior (no gap-fill — emits whatever ticks arrive) on the `Quote.AggregatorHub` docs page and in XML doc on the type. State explicitly that consumers needing fill semantics should pre-process input ticks; foreshadow that a `GapFillMode` enum may land in v3.1 (link T236).
+- [x] **G008 — Document `Quote.AggregatorHub` gap-fill behavior**. **Source: Discussion #1018, @elAndyG (2023-10-10).**
+  - Documented the existing `fillGaps` boolean (default `false`) on both `QuoteAggregatorHub` and `TickAggregatorHub`:
+    - Type-level xmldoc explains the default-omit vs. carry-forward synthesis behavior on both aggregator classes.
+    - Property-level xmldoc on `FillGaps` describes the semantics of the two states explicitly.
+    - `docs/utilities/quotes/resize-quote-history.md` gained a "Streaming aggregation" section covering both hubs, the `PeriodSize.Month` streaming-mode constraint, and the gap-fill behavior with a working example. The `GapFillMode` enum roadmap is mentioned as v3.1 (links T236).
 
 ### C. Pre-v3.0 cleanup pass
 

--- a/docs/utilities/quotes/resize-quote-history.md
+++ b/docs/utilities/quotes/resize-quote-history.md
@@ -122,6 +122,39 @@ var smoothedQuotes = tickData
   .Aggregate(PeriodSize.FiveMinutes);
 ```
 
+## Streaming aggregation
+
+For live feeds, use the streaming aggregator hubs to convert small bars or raw ticks into larger period bars in real time.
+
+```csharp
+// quote → quote aggregation (e.g. 1-minute bars to 5-minute bars)
+QuoteHub quoteHub = new();
+QuoteAggregatorHub fiveMinHub = quoteHub.ToQuoteAggregatorHub(
+    PeriodSize.FiveMinutes);
+
+// tick → quote aggregation (raw trades to 1-minute OHLCV)
+TickHub tickHub = new();
+TickAggregatorHub oneMinHub = tickHub.ToTickAggregatorHub(
+    PeriodSize.OneMinute);
+```
+
+Both hubs accept either a `PeriodSize` enum or a custom `TimeSpan`. `PeriodSize.Month` is not supported in streaming mode — use the `TimeSpan` overload for month-or-longer periods.
+
+### Gap-fill behavior
+
+Both `ToQuoteAggregatorHub` and `ToTickAggregatorHub` accept an optional `fillGaps` flag (default `false`):
+
+- `fillGaps: false` (default) — silent buckets are simply omitted from the output stream. If no upstream quote/tick lands inside a bucket, no bar is emitted for that period.
+- `fillGaps: true` — synthetic zero-volume bars are emitted to bridge any silent buckets between the last active bar and the next active bucket. The synthetic bar's `Open`, `High`, `Low`, and `Close` all carry forward the prior bar's `Close`.
+
+Consumers that need a different gap policy (e.g. interpolation, holding the prior `High`/`Low`, or a configurable null marker) should pre-process the upstream stream before subscribing the aggregator. A `GapFillMode` enum that exposes interpolation and other policies natively is on the v3.1 roadmap.
+
+```csharp
+// emit a synthetic bar for every silent 5-minute window
+QuoteAggregatorHub gappedHub = quoteHub
+    .ToQuoteAggregatorHub(PeriodSize.FiveMinutes, fillGaps: true);
+```
+
 ## Related utilities
 
 - [Quote utilities overview](/utilities/quotes/)

--- a/src/_common/Quotes/Quote.AggregatorHub.cs
+++ b/src/_common/Quotes/Quote.AggregatorHub.cs
@@ -3,6 +3,15 @@ namespace Skender.Stock.Indicators;
 /// <summary>
 /// Streaming hub for aggregating quotes into larger time periods.
 /// </summary>
+/// <remarks>
+/// Gap behavior: by default (<c>fillGaps: false</c>) the hub emits only
+/// the bars that incoming quotes actually populate — buckets with no
+/// upstream input are not synthesized. Set <c>fillGaps: true</c> to
+/// synthesize zero-volume bars carrying the prior bar's close as
+/// O/H/L/C through the silent period. Consumers that need a different
+/// fill policy (e.g. interpolation) should pre-process the input stream
+/// before subscribing this hub.
+/// </remarks>
 public class QuoteAggregatorHub
     : QuoteProvider<IQuote, IQuote>
 {
@@ -79,6 +88,13 @@ public class QuoteAggregatorHub
     /// <summary>
     /// Gets a value indicating whether gap filling is enabled.
     /// </summary>
+    /// <remarks>
+    /// When <c>true</c>, buckets that have no upstream input between
+    /// the last emitted bar and the next active bucket are filled with
+    /// zero-volume synthetic bars whose O/H/L/C all carry forward the
+    /// prior bar's close. When <c>false</c> (default), silent buckets
+    /// are simply omitted from the output stream.
+    /// </remarks>
     public bool FillGaps { get; }
 
     /// <summary>

--- a/src/_common/Quotes/Tick.AggregatorHub.cs
+++ b/src/_common/Quotes/Tick.AggregatorHub.cs
@@ -3,6 +3,15 @@ namespace Skender.Stock.Indicators;
 /// <summary>
 /// Streaming hub for aggregating raw tick data into OHLCV quote bars.
 /// </summary>
+/// <remarks>
+/// Gap behavior: by default (<c>fillGaps: false</c>) the hub emits only
+/// the bars that incoming ticks actually populate — buckets with no
+/// upstream activity are not synthesized. Set <c>fillGaps: true</c> to
+/// synthesize zero-volume bars carrying the prior bar's close as
+/// O/H/L/C through the silent period. Consumers that need a different
+/// fill policy (e.g. interpolation) should pre-process the input stream
+/// before subscribing this hub.
+/// </remarks>
 public class TickAggregatorHub
     : QuoteProvider<ITick, IQuote>
 {
@@ -85,6 +94,13 @@ public class TickAggregatorHub
     /// <summary>
     /// Gets a value indicating whether gap filling is enabled.
     /// </summary>
+    /// <remarks>
+    /// When <c>true</c>, buckets that have no upstream activity between
+    /// the last emitted bar and the next active bucket are filled with
+    /// zero-volume synthetic bars whose O/H/L/C all carry forward the
+    /// prior bar's close. When <c>false</c> (default), silent buckets
+    /// are simply omitted from the output stream.
+    /// </remarks>
     public bool FillGaps { get; }
 
     /// <summary>


### PR DESCRIPTION
## Summary

`QuoteAggregatorHub` and `TickAggregatorHub` already accept a `fillGaps` flag (default `false`), but the behavior was undocumented on the docs site and the xmldoc only said "Gets a value indicating whether gap filling is enabled." This makes the behavior explicit:

- **Class-level xmldoc** on both aggregator hubs explains default-omit vs. carry-forward synthesis semantics.
- **Property-level xmldoc** on `FillGaps` describes the two states explicitly.
- **Docs site** gains a "Streaming aggregation" section in `docs/utilities/quotes/resize-quote-history.md` covering both hubs, the `PeriodSize.Month` streaming-mode constraint, and gap-fill with a working code example.

Resolves a question raised in [Discussion #1018](https://github.com/DaveSkender/Stock.Indicators/discussions/1018) about how the aggregator handles premarket/low-volume silent periods. Foreshadows the v3.1 `GapFillMode` enum for consumers who need interpolation or other fill policies.

## Files

- `src/_common/Quotes/Quote.AggregatorHub.cs` — class + property xmldoc
- `src/_common/Quotes/Tick.AggregatorHub.cs` — class + property xmldoc
- `docs/utilities/quotes/resize-quote-history.md` — new streaming-aggregation section
- `docs/plans/streaming-indicators.plan.md` — G008 marked complete

## Verification

- `dotnet build src/Indicators.csproj -c Release` — green on net10.0, net9.0, net8.0; 0 warnings.
- Self-review swarm confirmed: docs claims match the actual `OnAdd` gap-fill code path (synthetic `Quote(... Close: _currentBar.Close, Volume: 0m)`); code examples use real ctor + extension method signatures.

## Test plan

- [ ] Docs site build (VitePress) succeeds with the new section.
- [ ] Markdownlint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)