### PR TITLE
docs(quote-part): Add BufferList and StreamHub sections

### DIFF
--- a/docs/plans/streaming-indicators.plan.md
+++ b/docs/plans/streaming-indicators.plan.md
@@ -9,7 +9,7 @@ This document tracks remaining work and architectural direction for the v3 strea
 - Series listings: 85 (84 indicators + `QuotePart`)
 - BufferList listings: 79 (78 indicators + `QuotePart`)
 - StreamHub listings: 79 (78 indicators + `QuotePart`)
-- Streaming docs coverage: 78 of 79 (`QuotePart` BufferList/StreamHub variants not yet documented on the utilities page — see D009)
+- Streaming docs coverage: 79 of 79 (D009 closed the `QuotePart` gap)
 - Non-streamable (Series only): Beta, Correlation, Prs, RenkoAtr, StdDevChannels, ZigZag
 
 **Related plans**: [Branching Strategy Migration](branching-strategy.plan.md) (required for v3.0 stable release), [File Reorganization](file-reorg.plan.md) (deferred to v3.1).
@@ -228,10 +228,8 @@ Pure docs work — no code changes. Together ~3–4 hours. Lands as small markdo
 
 ### G. Documentation gaps (existing)
 
-- [ ] **D009 — Document QuotePart streaming variants** (1–2 hours).
-  - **File**: `docs/utilities/quotes/use-alternate-price.md` (or new page under `docs/utilities/quotes/`).
-  - **Problem**: `QuotePart` has full StreamHub + BufferList implementations (`QuotePart.StreamHub.cs`, `QuotePart.BufferList.cs`) but the utilities page documents only the Series form. Sole gap making coverage 78/79 instead of 79/79.
-  - **Action**: Add BufferList (`.ToQuotePartList(...)`) and StreamHub (`.ToQuotePartHub(...)`) sections following the same pattern as indicator pages.
+- [x] **D009 — Document QuotePart streaming variants**.
+  - `docs/utilities/quotes/use-alternate-price.md` gained a "Streaming" section with BufferList (`ToQuotePartList`) and StreamHub (`ToQuotePartHub`) sub-sections following the indicator-page pattern. The StreamHub example also demonstrates the canonical "select then chain" composition (`partHub.ToEmaHub(20)`) that the part selector enables. Streaming docs coverage now 79 of 79.
 
 - [ ] **D010 — Document hub `Subscribe()` extensibility** (1–2 hours). **Source: Discussion #1018, @JGronholz; resolves open Issue [#1895](https://github.com/DaveSkender/Stock.Indicators/issues/1895).**
   - **Problem**: `ReusableObserver<T>` shipped via PR #1894 (MERGED), but the broader extensibility story — how external consumers wrap a hub for UI/persistence/logging via `IStreamObserver<T>` — is not documented. JGronholz spent significant time discovering this pattern by reading source; a single docs page would have removed the friction.

--- a/docs/utilities/quotes/use-alternate-price.md
+++ b/docs/utilities/quotes/use-alternate-price.md
@@ -74,6 +74,50 @@ Some indicators require the full OHLCV quote profile and cannot be used with `.U
 Attempting to use `.Use()` with incompatible indicators may produce unexpected results.
 :::
 
+## Streaming
+
+Both incremental and live streaming variants of the quote-part selector are available and produce `TimeValue` results (the same `IReusable` type the Series form emits).
+
+### BufferList
+
+Use `ToQuotePartList()` when you need incremental, single-threaded selection without a hub:
+
+```csharp
+QuotePartList parts = quotes.ToQuotePartList(CandlePart.HL2);
+
+// or, build incrementally
+QuotePartList parts = new(CandlePart.HL2);
+
+foreach (IQuote quote in quotes)
+{
+  parts.Add(quote);
+}
+
+IReadOnlyList<TimeValue> results = parts;
+```
+
+### StreamHub
+
+Subscribe to a `QuoteHub` to chain the quote-part selector into a live pipeline:
+
+```csharp
+QuoteHub quoteHub = new();
+QuotePartHub partHub = quoteHub.ToQuotePartHub(CandlePart.HLC3);
+
+// chain downstream indicators off the part selector
+EmaHub emaHub = partHub.ToEmaHub(20);
+
+foreach (IQuote quote in quotes)  // simulating stream
+{
+  quoteHub.Add(quote);
+}
+
+IReadOnlyList<TimeValue> selected = partHub.Results;
+IReadOnlyList<EmaResult> emaResults = emaHub.Results;
+```
+
+See [Buffer lists](/guide/buffer) and [Stream hubs](/guide/stream) for full usage guides.
+
 ## Related utilities
 
 - [Quote utilities overview](/utilities/quotes/)


### PR DESCRIPTION
## Summary

The Series form `.Use(CandlePart)` was the only quote-part selector documented on the utilities page, even though `QuotePartList` and `QuotePartHub` have been part of the v3 surface since shipped. This brings the docs into parity with the catalog and closes the last streaming-doc coverage gap.

## Changes

`docs/utilities/quotes/use-alternate-price.md` gains a "Streaming" section:

- **BufferList** sub-section showing `quotes.ToQuotePartList(CandlePart)` and the incremental `new()` + `Add(IQuote)` pattern.
- **StreamHub** sub-section showing `quoteHub.ToQuotePartHub(CandlePart)` and the canonical "select then chain" composition pattern via `partHub.ToEmaHub(...)`, enabled by `IChainProvider<out T>` covariance.

## Coverage

Streaming docs coverage is now **79 of 79** (matches the catalog `Stream` listing count). The plan's coverage line and D009 item are updated accordingly.

## Verification

Self-review swarm confirmed all six code examples compile against the real APIs (`QuotePartList` ctor + `Add`, `QuoteHub()` + `ToQuotePartHub` + `ToEmaHub` chain, `partHub.Results` return type). `IChainProvider<TimeValue> → IChainProvider<IReusable>` covariance check verified at `src/_common/StreamHub/IChainProvider.cs:6`.

## Test plan

- [ ] VitePress site build succeeds.
- [ ] Markdownlint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)