### PR TITLE
docs(agents): Add result-type convention and indicator boilerplate budget

### DIFF
--- a/docs/plans/streaming-indicators.plan.md
+++ b/docs/plans/streaming-indicators.plan.md
@@ -201,13 +201,11 @@ Pure docs work — no code changes. Together ~3–4 hours. Lands as small markdo
   - **Why**: `List<T>.AsReadOnly()` returns a `ReadOnlyCollection<T>` wrapping the **live** backing list. Consumers cannot mutate it but enumeration during a concurrent `Add` will throw `InvalidOperationException` (Architect F4). #1585 closed the deviant-mutation hole but not the read-during-write hole.
   - **Action**: Update XML doc on `IStreamHub.Results` and `StreamHub.cs:103` to explicitly state "live read-only view; enumerate within `.ToList()` if upstream may emit during iteration." Reserve `Snapshot()` method addition for v3.1.
 
-- [ ] **DOC-ARCH-4 — Boilerplate budget for new streamable indicators** (30 min).
-  - **Why**: Without a stated cost ("a new streamable indicator costs N files and ≤ M LOC of ceremony excluding math"), contributors cannot detect overengineering creep (Inspector F4).
-  - **Action**: Add a one-paragraph "Cost of a new streamable indicator" section to `src/AGENTS.md`. Use Ema as the baseline reference.
+- [x] **DOC-ARCH-4 — Boilerplate budget for new streamable indicators**.
+  - `src/AGENTS.md` gains a "Cost of a new streamable indicator" section with a per-file LOC table calibrated to the Ema baseline (~419 total LOC across 7 files). Calls out shared `*.Increment` kernels as the antidote when ceremony blows the budget.
 
-- [ ] **DOC-ARCH-5 — Result type convention** (30 min).
-  - **Why**: 79 result records use `public record` with `Timestamp` first and `double?` for warmup-period values, but the convention is conventional only (Inspector F8).
-  - **Action**: One paragraph in `src/AGENTS.md` codifying the convention. Cite Ema as canonical.
+- [x] **DOC-ARCH-5 — Result type convention**.
+  - `src/AGENTS.md` gains a "Result type convention" section codifying positional `public record`, `Timestamp` first, nullable warmup values, `[Serializable]`, `[JsonIgnore]` on the chainable `Value` projection, `.Null2NaN()` for predictable NaN propagation. Cites `EmaResult` as the canonical reference; notes how multi-output indicators preserve the pattern.
 
 - [ ] **DOC-ARCH-6 — No analyzer suppressions in streaming source** (15 min).
   - **Why**: Inspector F7 asks to verify and codify that simplicity claims are not artificial.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -55,6 +55,28 @@ See _common/README.md for complete policy documentation.
 - Stream and Buffer implementations must match Series results for same inputs once warmed up
 - For discrepancies, fix Stream/Buffer unless there is verified issue with Series and reference data
 
+## Result type convention
+
+Indicator result types are `public record` declarations with positional parameters, `Timestamp` first, nullable `double?` for warmup-period values, and `IReusable` implementation when the result is intended to chain into downstream indicators. The reusable value projection is a calculated `Value` property (not a constructor parameter) that calls `.Null2NaN()` so chained NaN propagation behaves predictably.
+
+Canonical reference: `src/e-k/Ema/Ema.Models.cs` (`EmaResult`). When adding a new indicator, mirror this shape — positional record, `Timestamp` first, `[Serializable]` attribute, `[JsonIgnore]` on the chainable `Value` projection, single-line xmldoc per parameter. Multi-output indicators (e.g. Bollinger Bands, MACD) follow the same skeleton with additional positional parameters; only one property maps to `Value` and that property is the one flagged `isReusable: true` in the catalog listing.
+
+## Cost of a new streamable indicator
+
+A new fully-streamable indicator costs **seven files plus a documentation page**, with ceremony excluding the math itself bounded to roughly 300–400 lines:
+
+| File | Purpose | Size guideline (Ema baseline) |
+| ---- | ------- | ------------------------------ |
+| `I{Name}.cs` | Public interface | ~15 LOC |
+| `{Name}.Models.cs` | Result `record` | ~20 LOC |
+| `{Name}.Utilities.cs` | Validation + helpers | ~80 LOC |
+| `{Name}.StaticSeries.cs` | Canonical batch implementation | ~60 LOC |
+| `{Name}.BufferList.cs` | Incremental `BufferList` form | ~120 LOC |
+| `{Name}.StreamHub.cs` | Live `StreamHub` form | ~75 LOC |
+| `{Name}.Catalog.cs` | Catalog listing builders (Common/Series/Buffer/Stream) | ~45 LOC |
+
+If a new indicator exceeds these guidelines by a wide margin without algorithmic justification, treat the excess as accidental complexity and look for a missing shared kernel (see `Ema.Increment`, `Sma.Increment`, `Tr.Increment`, `Atr.Increment` in `_common/`-adjacent siblings). Documentation under `docs/indicators/{Name}.md` and a test set under `tests/indicators/{a-d|e-k|m-r|s-z}/{Name}/*.Tests.cs` are required and have their own budgets.
+
 ## Boundaries
 
 ✅ Always use Series results as the canonical numerical reference — Stream/Buffer must match exactly


### PR DESCRIPTION
## Summary

Two new sections in `src/AGENTS.md` to make implicit conventions explicit, helping contributors and AI agents detect overengineering creep when adding a new indicator.

### Result type convention

Codifies what all 85 indicator result records already do today: positional `public record`, `Timestamp` first, nullable `double?` for warmup values, `[Serializable]`, `IReusable` with a `[JsonIgnore]` `Value` projection calling `.Null2NaN()` for predictable NaN propagation. Cites `src/e-k/Ema/Ema.Models.cs` (`EmaResult`) as the canonical reference and notes how multi-output indicators preserve the pattern.

### Cost of a new streamable indicator

Quantifies the 7-file + per-file LOC structure (~419 LOC for Ema across `IEma.cs`, `Ema.Models.cs`, `Ema.Utilities.cs`, `Ema.StaticSeries.cs`, `Ema.BufferList.cs`, `Ema.StreamHub.cs`, `Ema.Catalog.cs`). Calls out the shared `Ema.Increment` / `Sma.Increment` / `Tr.Increment` / `Atr.Increment` kernels as the antidote when ceremony blows the budget.

## Verification

Self-review swarm confirmed: every claimed LOC matches ±5 lines of actual file size; `EmaResult` description is bit-accurate; all four shared `*.Increment` kernels exist at the cited paths.

## Test plan

- [ ] Markdownlint passes.
- [ ] No code change, no test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)