### PR TITLE
docs: Retire the 'Last updated' footer convention

### DIFF
--- a/.agents/skills/markdown/SKILL.md
+++ b/.agents/skills/markdown/SKILL.md
@@ -106,9 +106,8 @@ Verify content-level requirements:
 2. **Code fences:** All blocks have language identifiers
 3. **Headers:** Sentence case, ATX style, sequential hierarchy (no skipping levels)
 4. **Lists:** Hyphen bullets only, proper indentation
-5. **End of file:** Blank line, `---` separator, "Last updated: {date}" footer (see [formatting-standards](references/formatting-standards.md) for exclusions: .github/**/*.md, README.md, AGENTS.md, .agents/**/*.md, docs/adr/*.md)
-6. **Diagrams:** Mermaid diagrams use stroke styling (not fill colors)
-7. **HTML:** Only allowed elements, all images have alt text
+5. **Diagrams:** Mermaid diagrams use stroke styling (not fill colors)
+6. **HTML:** Only allowed elements, all images have alt text
 
 See [validation checklist](references/validation-checklist.md) for complete quality checks.
 
@@ -141,7 +140,6 @@ See [setup guide](references/setup-guide.md) for step-by-step configuration.
 - [ ] All semantic issues fixed (sentence case headers, bold labels)
 - [ ] All reference syntax corrected (#file:, markdown links)
 - [ ] All content quality checks passed (links, fences, hierarchy)
-- [ ] End-of-file formatting applied where required
 - [ ] File committed to repository
 
 ## Common pitfalls

--- a/.agents/skills/markdown/references/formatting-standards.md
+++ b/.agents/skills/markdown/references/formatting-standards.md
@@ -76,25 +76,6 @@ Only these elements are allowed:
 - `<sub>`, `<sup>`, `<kbd>`, `<abbr>` (semantic formatting)
 - `<a>`, `<img>` (links and images when Markdown syntax insufficient)
 
-## End of file formatting
-
-Most files should end with:
-
-```markdown
-
----
-# Last updated: {Month Day, Year}
-
-```
-
-**Exceptions (no end-of-file elements):**
-
-- `README.md` at root
-- `AGENTS.md` (all)
-- `.agents/**/*.md`
-- `.github/**/*.md`
-- `docs/**/*.md` (VitePress documentation website)
-
 ## Common patterns to fix
 
 | Error pattern | Fix |

--- a/.agents/skills/markdown/references/validation-checklist.md
+++ b/.agents/skills/markdown/references/validation-checklist.md
@@ -32,8 +32,6 @@ Complete validation checklist for Markdown files before committing.
 - [ ] All code fences have language identifiers
 - [ ] Headers follow sequential hierarchy (no skipping levels)
 - [ ] Lists use proper indentation
-- [ ] End-of-file formatting applied (if required)
-  - Except: README.md (root), AGENTS.md (all), .agents/**/*.md, .github/**/*.md, docs/**/*.md — do NOT include 'Last updated' or other end-of-file footers for these paths
 - [ ] Mermaid diagrams use stroke styling (no fill colors)
 - [ ] HTML uses only allowed elements
 - [ ] All images have alt text

--- a/docs/plans/branching-strategy.plan.md
+++ b/docs/plans/branching-strategy.plan.md
@@ -426,6 +426,3 @@ git push origin main --force
 - **Blocking**: v3.0.0 stable release (#1585, community feedback from streaming-indicators.plan.md)
 - **Related**: Documentation site migration (#1739) - should happen AFTER branching migration
 - **Related**: File reorganization (#1810-#1813) - should happen AFTER branching migration
-
----
-Last updated: 2026-05-25

--- a/docs/plans/file-reorg.plan.md
+++ b/docs/plans/file-reorg.plan.md
@@ -825,6 +825,3 @@ After applying recommended patterns with Series suffix, ConnorsRsi would be:
 - [Framework Design Guidelines](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/)
 - [General Naming Conventions](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/general-naming-conventions)
 - [Names of Assemblies and DLLs](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/names-of-assemblies-and-dlls)
-
----
-Last updated: 2026-05-25 (status header + cross-references; content unchanged from 2025-12-28)

--- a/docs/plans/streaming-indicators.plan.md
+++ b/docs/plans/streaming-indicators.plan.md
@@ -504,7 +504,3 @@ All items implemented in source; baselines pending refresh (RG001).
 - **PRs #1981, #1991, #1992** — Website 3-pillar IA reorganization; VitePress with Vue chart components
 - **PRs #1976, #2005** — Streaming plan updates and missing BufferList/StreamHub doc sections for Alligator, AtrStop, Tsi
 - **T213** — Performance documentation consolidated into single `tools/performance/PERFORMANCE_ANALYSIS.md`
-
----
-
-Last updated: 2026-05-25

--- a/src/_common/README.md
+++ b/src/_common/README.md
@@ -155,6 +155,3 @@ For streaming and buffer indicators experiencing performance issues, consult:
 - Analysis: [tools/performance/PERFORMANCE_ANALYSIS.md](../../tools/performance/PERFORMANCE_ANALYSIS.md) - Comprehensive performance analysis and root cause analysis
 - Active plan: [docs/plans/streaming-indicators.plan.md](../../docs/plans/streaming-indicators.plan.md) - Streaming indicators plan (release gates, test hardening, performance verification)
 - Project principles: [docs/PRINCIPLES.md](../../docs/PRINCIPLES.md) - Performance First principles
-
----
-Last updated: 2026-05-24

--- a/tools/application/README.md
+++ b/tools/application/README.md
@@ -172,9 +172,3 @@ This test application should be kept in sync with the v2 package. If you discove
 2. Update this README if needed
 3. Verify the application runs cleanly
 4. Submit a pull request
-
----
-
-**Version**: Testing v2  
-**Target Framework**: .NET 9.0  
-**Last Updated**: October 2025

--- a/tools/baselining/README.md
+++ b/tools/baselining/README.md
@@ -128,6 +128,3 @@ After modifying the generator:
 2. Test with batch generation: `--all`
 3. Verify baseline files are correctly formatted
 4. Check that existing regression tests still pass
-
----
-Last updated: February 20, 2026

--- a/tools/performance/PERFORMANCE_ANALYSIS.md
+++ b/tools/performance/PERFORMANCE_ANALYSIS.md
@@ -1,6 +1,5 @@
 # Performance Analysis: Streaming Indicators
 
-**Last Updated:** January 3, 2026
 **Baseline Data:** tools/performance/baselines/
 
 ## Executive Summary
@@ -262,7 +261,3 @@ cp BenchmarkDotNet.Artifacts/results/Performance.*-report-full.json baselines/
 - GitHub Actions workflow: `.github/workflows/test-performance.yml`
 - NFR-002: Performance and memory requirements for streaming indicators
 - Streaming plan: `docs/plans/streaming-indicators.plan.md`
-
----
-
-Last updated: January 3, 2026

--- a/tools/performance/baselines/memory/README.md
+++ b/tools/performance/baselines/memory/README.md
@@ -219,7 +219,3 @@ cat baselines/memory/baseline-memory-v3.1.0.json | \
 - Streaming plan: `../../../docs/plans/streaming-indicators.plan.md`
 - NFR-002: <10KB memory overhead per StreamHub instance
 - BenchmarkDotNet Memory Diagnoser: <https://benchmarkdotnet.org/articles/configs/diagnosers.html#memory-diagnoser>
-
----
-
-Last updated: January 3, 2026

--- a/tools/performance/benchmarking.md
+++ b/tools/performance/benchmarking.md
@@ -349,7 +349,3 @@ When contributing performance improvements:
 - [BenchmarkDotNet Documentation](https://benchmarkdotnet.org/)
 - [Performance Best Practices for .NET](https://learn.microsoft.com/dotnet/core/performance/)
 - [Repository Performance Page](https://dotnet.stockindicators.dev/performance/)
-
----
-
-Last updated: January 3, 2026

--- a/tools/scripts/README.md
+++ b/tools/scripts/README.md
@@ -35,6 +35,3 @@ For detailed information about audit checks, fixing patterns, and examples, see:
 - **Streaming Plan**: `docs/plans/streaming-indicators.plan.md`
 - **StreamHub Guidelines**: `.github/instructions/indicator-stream.instructions.md`
 - **Canonical Test Pattern**: `tests/indicators/e-k/Ema/Ema.StreamHub.Tests.cs`
-
----
-Last updated: December 28, 2025


### PR DESCRIPTION
## Summary

CodeRabbit flagged PR #2030 for missing a `Last updated: {date}` end-of-file footer per the wording in `.agents/skills/markdown/SKILL.md:109`. The convention is no longer in use anywhere in the repo, and the guide's exclusions list was internally inconsistent (SKILL.md omitted `docs/**/*.md` while `formatting-standards.md` included it). This PR retires the convention everywhere — guide and stragglers.

## Changes

### Guide cleanups (3 files)

- `.agents/skills/markdown/SKILL.md` — removed the "End of file" bullet from the Step 4 content-quality checklist and the "End-of-file formatting applied where required" item from the completion criteria.
- `.agents/skills/markdown/references/validation-checklist.md` — removed the End-of-file checklist bullet (and its inconsistent exclusion sub-bullet).
- `.agents/skills/markdown/references/formatting-standards.md` — removed the entire "End of file formatting" section (rule definition + exception list).

### Footer strippings (10 files)

- `docs/plans/streaming-indicators.plan.md`
- `docs/plans/branching-strategy.plan.md`
- `docs/plans/file-reorg.plan.md`
- `src/_common/README.md`
- `tools/scripts/README.md`
- `tools/performance/PERFORMANCE_ANALYSIS.md` (both the header `**Last Updated:**` line and the trailing footer block)
- `tools/performance/benchmarking.md`
- `tools/performance/baselines/memory/README.md`
- `tools/baselining/README.md`
- `tools/application/README.md`

## What stays

- `.agents/skills/vitepress/references/theme-config.md` and `.github/workflows/deploy-website.yml:37` still mention "Last Updated" — those are the VitePress framework's `lastUpdated: true` site-config option and the git-derived per-page timestamp it produces. Framework feature, not the file-footer convention.

## Open PR rebase impact

8 in-flight PRs against `v3` (#2026–#2034) touch `docs/plans/streaming-indicators.plan.md`. Once this PR lands, each will need a trivial rebase — the conflict is a deleted footer block at the end of the file; no semantic conflict.

## Test plan

- [ ] Markdownlint passes on all 13 changed files.
- [ ] CodeRabbit on subsequent PRs no longer flags missing `Last updated` footers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)