### PR TITLE
docs(tests): Sync AGENTS.md test-layout listing with reality

### DIFF
--- a/docs/plans/streaming-indicators.plan.md
+++ b/docs/plans/streaming-indicators.plan.md
@@ -421,9 +421,8 @@ See [Issue #1259](https://github.com/DaveSkender/Stock.Indicators/issues/1259). 
 
 - [ ] **T235 (was F4 from Stercorator)** — Schedule `Obsolete.V3.Indicators.cs` and `Obsolete.V3.Other.cs` removal with CHANGELOG entry. They use `error: true` shims (compile errors with helpful messages); zero runtime utility, just better error messages during migration. Sunset in v3.1 or v3.2 with documented removal milestone.
 
-- [ ] **G007-followup — Reconcile `tests/AGENTS.md` layout** (30 min).
-  - **Evidence**: `tests/AGENTS.md:8–10` lists `indicators/`, `other/`, `performance/`. Actual `ls tests/` shows `indicators/`, `integration/`, `other/`, `performance/`, `public-api/`. Missing `integration/` and `public-api/` from the AGENTS doc.
-  - **Action**: Update to reflect real layout; clarify the relationship between `tests/performance/` and `tools/performance/` (both exist; benchmarks vs assertions).
+- [x] **G007-followup — Reconcile `tests/AGENTS.md` layout**.
+  - `tests/AGENTS.md` now lists all five subdirectories (`indicators/`, `integration/`, `other/`, `public-api/`, `performance/`) with one-line purpose statements. Distinction between `tests/performance/` (in-process assertions placeholder) and `tools/performance/` (BenchmarkDotNet harness + baselines) is called out in both the header description and the `performance/` entry.
 
 ### Infrastructure & code quality
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,12 +1,14 @@
 # Test suite
 
-This folder contains unit tests, integration tests, and performance benchmarks.
+This folder contains unit tests, public-API convergence tests, and integration tests. Performance benchmarks live separately under `tools/performance/`.
 
 ## Test organization
 
-- `indicators/` — unit tests for all indicators
-- `other/` — integration and utility tests
-- `performance/` — performance benchmarks
+- `indicators/` — unit tests for all indicators (Series + BufferList + StreamHub + Catalog + Regression)
+- `integration/` — end-to-end integration tests including `StreamHub.ThreadSafety.Sse.Tests.cs` and `Tests.Integration.csproj`; runs via `tests.integration.runsettings`
+- `other/` — utility tests and cross-cutting helpers
+- `public-api/` — public-API surface tests (`Convergence.*` ensure Series / BufferList / StreamHub agree end-to-end on the public method names; `customizable/`, `indicators/` cover consumer-facing scenarios)
+- `performance/` — placeholder for in-process performance assertions; the BenchmarkDotNet harness and baselines live under `tools/performance/`
 
 ## Commands
 


### PR DESCRIPTION
## Summary

`tests/AGENTS.md` previously listed only `indicators/`, `other/`, and `performance/`. The actual test layout has five subdirectories: `indicators/`, `integration/`, `other/`, `public-api/`, and `performance/`. The doc was also internally inconsistent — the Commands section already referenced `tests/integration/` at line 21 but the Organization section omitted it.

## Changes

`tests/AGENTS.md`:

- Lists all five subdirectories with one-line purpose statements
- Clarifies the distinction between `tests/performance/` (in-process assertions placeholder, currently empty) and `tools/performance/` (BenchmarkDotNet harness + baselines + analysis)
- Updates the header description to reflect that public-API tests are part of the suite

Plan: G007-followup marked complete with a short delivery summary.

## Test plan

- [ ] Markdownlint passes on `tests/AGENTS.md`.
- [ ] No code change, no test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)