### PR TITLE
test(cmo): Add zero-price-change coverage (T217)

### DIFF
--- a/docs/plans/streaming-indicators.plan.md
+++ b/docs/plans/streaming-indicators.plan.md
@@ -254,7 +254,7 @@ P015, P016 and P017 all confirmed at algorithmic floors per current test contrac
 ### I. Low-priority test items (existing)
 
 - [ ] **T216** — ConnorsRsi `RemoveWarmupPeriods` calculation review (2–3 hours).
-- [ ] **T217** — CMO zero price change test (1–2 hours).
+- [x] **T217** — CMO zero price change test. Closed the in-source `// TODO: test for CMO isUp works as expected when there's no price change` at `tests/indicators/a-d/Cmo/Cmo.StaticSeries.Tests.cs:6-7` with two new tests: `FlatPrices_AcrossEntireWindow_ReturnsZero` (CMO = 0 across an entirely flat 30-bar series) and `FlatThenMoving_ReturnsValuesOnceRealMovementEnters` (CMO = 0 inside the flat window, climbs to +100 once the lookback fills with up-ticks; no NaN propagation). Both pass; full CMO suite 33/33 green.
 
 ### J. Infrastructure — deferred but listed for context
 

--- a/tests/indicators/a-d/Cmo/Cmo.StaticSeries.Tests.cs
+++ b/tests/indicators/a-d/Cmo/Cmo.StaticSeries.Tests.cs
@@ -3,9 +3,6 @@ namespace StaticSeries;
 [TestClass]
 public class Cmo : StaticSeriesTestBase
 {
-    // TODO: test for CMO isUp works as expected
-    // when there’s no price change
-
     [TestMethod]
     public override void DefaultParameters_ReturnsExpectedResults()
     {
@@ -117,4 +114,73 @@ public class Cmo : StaticSeriesTestBase
             .Invoking(static () => Quotes.ToCmo(0))
             .Should()
             .ThrowExactly<ArgumentOutOfRangeException>();
+
+    [TestMethod]
+    public void FlatPrices_AcrossEntireWindow_ReturnsZero()
+    {
+        // construct a 30-bar series where every close is identical
+        // (no price change anywhere). CMO should be 0 across the
+        // entire post-warmup window since sH + sL == 0 (no movement,
+        // so neither gains nor losses accumulate).
+        DateTime t0 = new(2025, 1, 1);
+        List<Quote> flat = new(30);
+        for (int i = 0; i < 30; i++)
+        {
+            flat.Add(new Quote(
+                Timestamp: t0.AddDays(i),
+                Open: 100m,
+                High: 100m,
+                Low: 100m,
+                Close: 100m,
+                Volume: 1000m));
+        }
+
+        IReadOnlyList<CmoResult> sut = flat.ToCmo(14);
+
+        sut.Should().HaveCount(30);
+        sut[0].Cmo.Should().BeNull();           // first record always null
+        sut[13].Cmo.Should().BeNull();          // still warming up
+
+        // post-warmup: every bar within an all-flat window must report 0
+        for (int i = 14; i < 30; i++)
+        {
+            sut[i].Cmo.Should().Be(0d, $"flat window at index {i} should produce 0");
+        }
+    }
+
+    [TestMethod]
+    public void FlatThenMoving_ReturnsValuesOnceRealMovementEnters()
+    {
+        // 20 flat bars (no movement) then 14 ascending bars. The CMO
+        // should be 0 while the lookback window is fully flat, then
+        // climb toward +100 as the lookback window fills with up-ticks
+        // (sH grows, sL stays 0). Validates that an in-window zero-change
+        // tick is treated as a non-issue rather than producing NaN or null.
+        DateTime t0 = new(2025, 1, 1);
+        List<Quote> series = new(34);
+        for (int i = 0; i < 20; i++)
+        {
+            series.Add(new Quote(
+                Timestamp: t0.AddDays(i),
+                Open: 100m, High: 100m, Low: 100m, Close: 100m,
+                Volume: 1000m));
+        }
+
+        for (int i = 0; i < 14; i++)
+        {
+            decimal close = 100m + ((i + 1) * 1m);
+            series.Add(new Quote(
+                Timestamp: t0.AddDays(20 + i),
+                Open: close - 1m, High: close, Low: close - 1m, Close: close,
+                Volume: 1000m));
+        }
+
+        IReadOnlyList<CmoResult> sut = series.ToCmo(14);
+
+        sut.Should().HaveCount(34);
+        sut[19].Cmo.Should().Be(0d, "still inside the all-flat 14-bar window");
+        sut[33].Cmo.Should().Be(100d, "last bar's 14-period window is entirely up-ticks");
+        sut.Where(static x => x.Cmo is double.NaN).Should().BeEmpty(
+            "zero-change ticks must never propagate to NaN results");
+    }
 }


### PR DESCRIPTION
## Summary

Closes the in-source TODO at `tests/indicators/a-d/Cmo/Cmo.StaticSeries.Tests.cs:6-7` (\"test for CMO `isUp` works as expected when there's no price change\") with two focused tests that exercise the flat-window code paths in `src/a-d/Cmo/Cmo.StaticSeries.cs`.

## Tests added

### `FlatPrices_AcrossEntireWindow_ReturnsZero`

30-bar series with `Close=100` across every bar. Asserts:
- `Cmo` is `null` during warmup (indices 0 and 13)
- `Cmo` is `0d` post-warmup (every index 14–29)

Validates the `sH + sL == 0` branch at `Cmo.StaticSeries.cs:85-87` returns `0d` (not `null`, not `NaN`) when no movement occurs anywhere in the window.

### `FlatThenMoving_ReturnsValuesOnceRealMovementEnters`

20 flat bars (Close=100) followed by 14 ascending bars (101, 102, ..., 114). Asserts:
- `Cmo = 0d` at index 19 (last all-flat index — lookback covers bars 6–19, all flat → sH=sL=0 → 0)
- `Cmo = 100d` at index 33 (last bar — lookback covers bars 20–33, all up-ticks → sH=14, sL=0 → 100·(14-0)/14 = 100)
- No `NaN` results anywhere

Validates that in-window zero-change ticks (`isUp=null` routed to the `else` branch as `pDiff=0` added to `sL`) don't corrupt the calculation when real movement subsequently enters the lookback window.

## Verification

- Full CMO test suite: 33/33 pass (was 31; 2 new).
- Self-review swarm confirmed math: index 19 → CMO=0 ✓; index 33 → CMO=100·(14-0)/(14+0)=100 ✓; NaN safety holds because NaN can only enter via NaN source data, which the test series doesn't contain.

## Test plan

- [ ] CI green on net8.0/net9.0/net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)