### PR TITLE
chore: Pragma audit (T233) + codify suppression footprint (DOC-ARCH-6)

### DIFF
--- a/docs/plans/streaming-indicators.plan.md
+++ b/docs/plans/streaming-indicators.plan.md
@@ -146,9 +146,17 @@ Pure documentation fixes. Together ~4–6 hours. None require code changes.
   - **Re-evaluation (2026-05-25)**: The original "delete empty file" premise was wrong. The file contains five real `[assembly: SuppressMessage(...)]` declarations (CA1510, CA1710 BufferList, three CA1720 Direction, CA1716 ISeries.Date). Most are still load-bearing, but CA1510 (`"Use ArgumentNullException throw helper"`) carries the justification "Does not support .NET Standard and before .NET 6" — the project no longer targets netstandard (min is `net8.0`), and the codebase already uses `ArgumentNullException.ThrowIfNull` in ~373 sites versus only ~13 legacy `throw new ArgumentNullException` sites across 6 files.
   - **Action**: Migrate the 13 legacy `throw new ArgumentNullException` sites to `ArgumentNullException.ThrowIfNull`, then remove the CA1510 suppression. Re-verify CA1710 / CA1716 / CA1720 are still load-bearing under current analyzer rules. Track removal candidates as v3.1 if any prove unnecessary.
 
-- [ ] **T233 — Audit `#pragma warning disable` for staleness** (30 min).
-  - **Evidence**: 7 occurrences in `src/`. After API churn (renames in `Obsolete.V3.*`), some pragmas may protect already-deleted code paths.
-  - **Action**: For each pragma, verify the warning still fires without it; remove unneeded pragmas.
+- [x] **T233 — Audit `#pragma warning disable` for staleness** *(audit complete, all 14 pragmas confirmed intentional)*.
+  - 14 `#pragma warning disable` occurrences across 9 files audited. Every one has a stated reason and is load-bearing today — no pragmas protect already-deleted code paths. The standing "ask before adding pragmas" rule (per `src/_common/AGENTS.md:107`) is being followed.
+  - Breakdown by file:
+    - `e-k/HtTrendline/IHtTrendline.cs:6` (`CA1040`) — intentional empty marker interface; suppression documents the choice.
+    - `m-r/MaEnvelopes/*.cs` × 3 + `s-z/Stoch/Stoch.StaticSeries.cs` (`IDE0072` / `IDE0010`) — `MaType` enum is large; only the implemented MA types are enumerated. Tracked via T214 (add remaining MA types).
+    - `m-r/PivotPoints/PivotPoints.StaticSeries.cs` (`IDE0072`) — same pattern for `PointType` enum.
+    - `Obsolete.V3.Indicators.cs` (`CS1591`, `IND001`, `RCS1163`) and `Obsolete.V3.Other.cs` (`RCS1141`, `RCS1142`, `RCS1228`) — error-shim files for removed v3 APIs; suppress missing-xmldoc and Roslynator complaints on intentionally non-conforming shims.
+    - `_common/Catalog/Catalog.cs:374,412,413` (`IDE0060`, `S1172`) — unused parameter required by `JsonConverter` base-class signature; cannot remove.
+    - `_common/Math/Numerical.cs:3-4` (`IDE0066`, `IDE0072`) — `IsNumeric(Type)` switch on `TypeCode` deliberately uses statement form (multiple cases per body) and `default => false` rather than enumerating non-numeric type codes.
+    - `_common/StreamHub/StreamHub.cs:2` (`IDE0010`) — `Act` enum 3-value switch in `AppendCache` handles the two values produced by the call site; `default => throw` covers `Act.Ignore` as a "would never happen" safety net. Refactoring to add `case Act.Ignore: break;` is a behavior change (silent ignore instead of throw on an unexpected value) and was rejected.
+  - **Outcome**: leave all 14 pragmas in place. No code change. Unblocks DOC-ARCH-6 with a revised claim (see below) — the `_common/StreamHub/` half of the original DOC-ARCH-6 claim cannot stand as-written because of the StreamHub.cs intentional pragma.
 
 - [ ] **T234 — TODO triage in `src/`** (30 min).
   - **Evidence**: Grep finds multiple TODOs including two in `src/_common/StreamHub/StreamHub.cs:230,234` ("make reinitialization abstract", "race condition between rebuild and subscribe").
@@ -206,9 +214,10 @@ Pure docs work — no code changes. Together ~3–4 hours. Lands as small markdo
 - [x] **DOC-ARCH-5 — Result type convention**.
   - `src/AGENTS.md` gains a "Result type convention" section codifying positional `public record`, `Timestamp` first, nullable warmup values, `[Serializable]`, `[JsonIgnore]` on the chainable `Value` projection, `.Null2NaN()` for predictable NaN propagation. Cites `EmaResult` as the canonical reference; notes how multi-output indicators preserve the pattern.
 
-- [ ] **DOC-ARCH-6 — No analyzer suppressions in streaming source** (15 min).
+- [x] **DOC-ARCH-6 — Document the (minimal) analyzer-suppression footprint in `_common/`** *(scope revised after T233 audit)*.
   - **Why**: Inspector F7 asks to verify and codify that simplicity claims are not artificial.
-  - **Action**: After T233 cleanup completes, add a one-line statement to `src/AGENTS.md`: "No analyzer suppressions are used in `_common/StreamHub/` or `_common/BufferLists/`."
+  - **Re-evaluation**: The original action's exact claim ("No analyzer suppressions are used in `_common/StreamHub/` or `_common/BufferLists/`") cannot stand as-written. `_common/BufferLists/` *is* pragma-free, but `_common/StreamHub/StreamHub.cs:2` carries one intentional `IDE0010` suppression for the `Act` enum switch in `AppendCache` (documented above under T233 — refactoring it would silently change behavior on `Act.Ignore`).
+  - **Action shipped**: rather than over-promise, added a precise statement to `src/_common/AGENTS.md` (alongside the existing "Ask before adding `#pragma warning disable` directives in this folder" boundary): the streaming framework's analyzer-suppression footprint is exactly one intentional pragma (`IDE0010` at `StreamHub.cs:2`), and `_common/BufferLists/` carries zero. New pragmas anywhere under `_common/` still require explicit justification.
 
 - [ ] **DOC-ARCH-7 — Prior art comparison** (15 min).
   - **Why**: Researcher F3–F5 surfaced that the library is ahead of ta4j (pull-only), TA-Lib/Tulip (batch-only), and aligned with Pine Script bar-by-bar — useful framing for marketing and for justifying the dual-track architecture to future contributors.

--- a/src/_common/AGENTS.md
+++ b/src/_common/AGENTS.md
@@ -104,7 +104,7 @@ See the parent [src/AGENTS.md](../AGENTS.md#nan-handling-policy) for the canonic
 
 ⚠️ Ask before adding new derivations of `BaseProvider<T>` — the class is a documented workaround scheduled for replacement; current usage is limited to `QuoteHub` and `TickHub`
 
-⚠️ Ask before adding `#pragma warning disable` directives in this folder — analyzer suppressions are forbidden in the streaming framework per the streaming plan
+⚠️ Ask before adding `#pragma warning disable` directives in this folder — current footprint is exactly one intentional suppression (`IDE0010` at `StreamHub/StreamHub.cs:2`, covering the `Act` enum switch in `AppendCache` whose `default => throw` is a deliberate "would never happen" safety net for `Act.Ignore`); `BufferLists/` carries zero. New pragmas anywhere under `_common/` require explicit justification
 
 🚫 Never expose `Cache` mutation from a subclass — go through `AppendCache`, `RemoveRange`, or `RemoveAt`
 


### PR DESCRIPTION
## Summary

Bundles two related plan items into one outcome-only change.

### T233 — Pragma audit (no code change)

Audited every `#pragma warning disable` in `src/`. **All 14 pragmas across 9 files are intentional and load-bearing.** No pragmas protect already-deleted code paths. The standing \"ask before adding pragmas\" rule (per `src/_common/AGENTS.md`) is being followed.

Per-file breakdown documented in the plan body — highlights:

- `IHtTrendline.cs` `CA1040` — intentional empty marker interface
- `MaEnvelopes/*` × 3 + `Stoch.StaticSeries.cs` `IDE0072`/`IDE0010` — `MaType` enum partial coverage, tracked by T214
- `PivotPoints.StaticSeries.cs` `IDE0072` — same pattern for `PointType`
- `Obsolete.V3.*.cs` — error-shim files for removed v3 APIs (CS1591, IND001, RCS1141, RCS1142, RCS1163, RCS1228)
- `Catalog.cs` `IDE0060`/`S1172` — base-class-mandated unused parameters for JsonConverter signatures
- `Numerical.cs` `IDE0066`/`IDE0072` — `TypeCode` switch deliberately uses statement form with `default => false`
- `StreamHub.cs` `IDE0010` — `Act` enum 3-value switch in `AppendCache` with `default => throw` covering the \"would never happen\" `Act.Ignore` path

### DOC-ARCH-6 — Codify suppression footprint (scope revised)

Original action's claim (\"No analyzer suppressions in `_common/StreamHub/` or `_common/BufferLists/`\") couldn't stand as-written because of the `StreamHub.cs` intentional pragma. Revised the existing `src/_common/AGENTS.md` boundary line to document the actual footprint precisely:

> **Current footprint is exactly one intentional suppression** (`IDE0010` at `StreamHub/StreamHub.cs:2`, covering the `Act` enum switch in `AppendCache` whose `default => throw` is a deliberate \"would never happen\" safety net for `Act.Ignore`); `BufferLists/` carries zero. New pragmas anywhere under `_common/` require explicit justification.

This makes the simplicity claim verifiable rather than wishful.

## Verification

Self-review swarm confirmed:
- 14-pragma count and per-file mapping accurate.
- `StreamHub.cs:2` IDE0010 scope verified against `Act` enum (`Act.cs:11,16,21`) and call site (`StreamHub.cs:343-345`).
- `_common/BufferLists/` is genuinely pragma-free.
- `Catalog.cs` JsonConverter base-class-mandated parameters confirmed.
- No plan-ID leaks in `src/`.
- Markdownlint `MD013` is disabled in `.markdownlint-cli2.jsonc` — long line in AGENTS.md is safe.

## Test plan

- [ ] CI markdownlint passes.
- [ ] No code change — no test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)