### PR TITLE
ci: Self-cancel obsolete matrix runs (add concurrency to test-indicators-matrix)

### DIFF
--- a/.github/workflows/test-indicators-matrix.yml
+++ b/.github/workflows/test-indicators-matrix.yml
@@ -18,6 +18,11 @@ on:
 permissions:
   contents: read # Required for checkout
 
+# Cancel obsolete in-progress runs when a newer commit starts a run on the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: matrix validation


### PR DESCRIPTION
## Summary

`test-indicators-matrix.yml` triggers on `push` + `pull_request` but had **no `concurrency` block**, so pushing a new commit started a fresh matrix run while the now-obsolete run kept executing to completion. This adds the repo-canonical concurrency group so obsolete runs **self-cancel** when a newer commit starts a run on the same ref.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

This matches `ci.yml`, `test-integration.yml`, and `test-examples.yml` verbatim.

## Audit of all 16 workflows

I checked every workflow; the matrix one was the **only** commit-triggered CI gap.

| Class | Workflows | Concurrency |
|-------|-----------|-------------|
| Commit-triggered CI (`push`/`pull_request`) | ci, test-integration, test-examples, test-website-a11y, test-website-links, deploy-package-github, deploy-website, **test-indicators-matrix** | ✅ all now `cancel-in-progress: true` |
| Release publish | deploy-package-nuget | ✅ intentionally `cancel-in-progress: false` — **never interrupt a NuGet release** |
| Scheduled | lock-issues-pr | ✅ `group: lock` (no cancel — appropriate) |
| Manual dispatch only | copilot-setup-steps, regenerate-baselines, test-performance{,-comparison,-manual} | left as-is (not commit-triggered, so out of scope for "new commits cancel obsolete runs") |

## Notes

- `cancel-in-progress: true` is correct for CI checks (latest commit wins). Left the **NuGet release** publish at `false` deliberately so a release upload is never cancelled mid-flight; the GitHub-Packages CI-preview publish keeps `true` (latest-wins preview), matching the existing intent.
- Used the same `${{ github.workflow }}-${{ github.ref }}` group as every other workflow for consistency (cancels per-branch and per-PR).

Self-review: YAML validated (`yaml.safe_load`), pattern matched to the canonical block, and a full-tree consistency scan confirmed no other commit-triggered workflow is missing concurrency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
