### PR TITLE
test(stream): Cover aggregator rollback and deep-chain value-equality

### DIFF
--- a/docs/plans/streaming-indicators.plan.md
+++ b/docs/plans/streaming-indicators.plan.md
@@ -169,9 +169,9 @@ The v3 streaming engine is the headline of this release after a long development
 #### Test coverage — prove the rollback/concurrency engine before the tag
 
 - [x] **TC-V31-1 — StreamHub concurrency test suite** (4–6 hours). Parallel `Add` from N threads, interleaved late arrivals, concurrent observer subscribe/dispose. The safety net validating the documented single-writer / thread-safety contract. *(PR #2063)*
-- [ ] **TC-V31-4 — Aggregator-hub rollback-equivalence** (2 hours). `QuoteAggregatorHub`/`TickAggregatorHub` override `RollbackState` but aren't in the catalog, so TC001 doesn't exercise them; catalog-register or add two hand-built rollback-equivalence cases to `StreamHub.RollbackContract.Tests.cs`.
-- [ ] **SR020 — Deep-chain rebuild value-equality** (2 hours). `StreamHub.BoundsChecking.Tests.cs:810` asserts count/timestamp only after a chained `RemoveAt`; extend to `IsExactly` vs a Series-equivalent chain.
-- [ ] **TC-V31-8 — Chained-downstream late-arrival through an aggregator** (1–2 hours). `QuoteHub → AggregatorHub → EmaHub` (+ tick analog) late-arrival test; assert downstream `EmaHub.Results` bit-equality between late and fresh chains — catches a dropped-notification-per-replay regression.
+- [x] **TC-V31-4 — Aggregator-hub rollback-equivalence** (2 hours). `QuoteAggregatorHub`/`TickAggregatorHub` override `RollbackState` but aren't in the catalog, so TC001 doesn't exercise them; catalog-register or add two hand-built rollback-equivalence cases to `StreamHub.RollbackContract.Tests.cs`. *(PR #2064)*
+- [x] **SR020 — Deep-chain rebuild value-equality** (2 hours). `StreamHub.BoundsChecking.Tests.cs:810` asserts count/timestamp only after a chained `RemoveAt`; extend to `IsExactly` vs a Series-equivalent chain. *(PR #2064)*
+- [x] **TC-V31-8 — Chained-downstream late-arrival through an aggregator** (1–2 hours). `QuoteHub → AggregatorHub → EmaHub` (+ tick analog) late-arrival test; assert downstream `EmaHub.Results` bit-equality between late and fresh chains — catches a dropped-notification-per-replay regression. *(PR #2064)*
 - [ ] **TC-V31-7 — BufferList bounded-value parity** (1–2 hours). Add `Boundary_WithRandomQuotes_StaysWithinBounds` to each bounded `*.BufferList.Tests.cs` (RSI/Stoch/Aroon/MFI/Ultimate/ConnorsRsi/WilliamsR), matching the Series + StreamHub coverage.
 
 #### ⚠️ Pending maintainer decisions — highlighted, NOT in the next batch

--- a/tests/indicators/_common/StreamHub/StreamHub.BoundsChecking.Tests.cs
+++ b/tests/indicators/_common/StreamHub/StreamHub.BoundsChecking.Tests.cs
@@ -793,14 +793,17 @@ public class BoundsCheckingTests : TestBase
     }
 
     /// <summary>
-    /// Test Case 31: Test deeply chained StreamHubs (3 levels).
+    /// Test Case 31: A removal cascading through a deep chain must leave every
+    /// level bit-for-bit equal to the equivalent batch Series chain (not just
+    /// the right count) — the rollback engine is value-exact end to end.
     /// </summary>
     [TestMethod]
-    public void DeeplyChainedHubs_RemoveAndRebuild_ShouldNotThrow()
+    public void DeeplyChainedHubs_RemoveAndRebuild_MatchesSeries()
     {
         // Arrange
+        List<Quote> quotes = Quotes.Take(100).ToList();
         QuoteHub quoteHub = new();
-        quoteHub.Add(Quotes.Take(100));
+        quoteHub.Add(quotes);
 
         // Create a deep chain: QuoteHub -> AtrHub -> EmaHub -> SmaHub
         AtrHub atrHub = quoteHub.ToAtrHub(14);
@@ -808,12 +811,21 @@ public class BoundsCheckingTests : TestBase
         SmaHub smaHub = emaHub.ToSmaHub(5);
 
         // Act - remove a quote, triggering cascade through all levels
-        quoteHub.RemoveAt(60);
+        const int removeIndex = 60;
+        quoteHub.RemoveAt(removeIndex);
 
-        // Assert - should not throw
+        // Assert - every level matches the equivalent batch chain on the revised quotes
+        List<Quote> revised = [.. quotes];
+        revised.RemoveAt(removeIndex);
+
+        IReadOnlyList<AtrResult> expectedAtr = revised.ToAtr(14);
+        IReadOnlyList<EmaResult> expectedEma = expectedAtr.ToEma(10);
+        IReadOnlyList<SmaResult> expectedSma = expectedEma.ToSma(5);
+
         atrHub.Results.Should().HaveCount(99);
-        emaHub.Results.Should().HaveCount(99);
-        smaHub.Results.Should().HaveCount(99);
+        atrHub.Results.IsExactly(expectedAtr);
+        emaHub.Results.IsExactly(expectedEma);
+        smaHub.Results.IsExactly(expectedSma);
 
         // Cleanup
         smaHub.Unsubscribe();

--- a/tests/indicators/_common/StreamHub/StreamHub.RollbackCoverage.Tests.cs
+++ b/tests/indicators/_common/StreamHub/StreamHub.RollbackCoverage.Tests.cs
@@ -1,0 +1,165 @@
+namespace Observables;
+
+/// <summary>
+/// Rollback-engine coverage for the aggregator hubs and deep chains that the
+/// generic catalog-driven rollback contract does not reach. The
+/// <c>QuoteAggregatorHub</c>/<c>TickAggregatorHub</c> override
+/// <c>RollbackState</c>/<c>Rebuild</c> but are not catalog-registered, so they
+/// are exercised here directly; and a late arrival routed through an aggregator
+/// into a downstream indicator must produce the same results as a fresh chain.
+/// </summary>
+[TestClass]
+public class RollbackCoverage : TestBase
+{
+    private const int TickCount = 500;
+
+    // TC-V31-4 — aggregator rollback-equivalence
+
+    [TestMethod]
+    public void QuoteAggregator_AfterRebuild_MatchesFreshStream()
+    {
+        IReadOnlyList<Quote> quotes = Quotes.Take(500).ToList();
+        DateTime rollback = quotes[300].Timestamp;
+
+        // a hub that was rolled back mid-stream and replayed
+        QuoteHub providerA = new();
+        QuoteAggregatorHub aggA = providerA.ToQuoteAggregatorHub(PeriodSize.Week);
+        providerA.Add(quotes);
+        aggA.Rebuild(rollback);
+
+        // a fresh hub fed the same quotes once
+        QuoteHub providerB = new();
+        QuoteAggregatorHub aggB = providerB.ToQuoteAggregatorHub(PeriodSize.Week);
+        providerB.Add(quotes);
+
+        // independent batch oracle: the streamed aggregation (fresh or rebuilt)
+        // must equal the batch Aggregate, upgrading this from rollback-
+        // equivalence to rollback-and-correctness
+        IReadOnlyList<Quote> batch = quotes.Aggregate(PeriodSize.Week);
+
+        aggA.Results.Should().NotBeEmpty();
+        aggB.Results.IsExactly(batch);
+        aggA.Results.IsExactly(aggB.Results);
+
+        providerA.DisposeChain();
+        providerB.DisposeChain();
+    }
+
+    [TestMethod]
+    public void TickAggregator_AfterRebuild_MatchesFreshStream()
+    {
+        List<Tick> ticks = BuildTicks(TickCount);
+        DateTime rollback = ticks[300].Timestamp;
+
+        TickHub providerA = new();
+        TickAggregatorHub aggA = providerA.ToTickAggregatorHub(PeriodSize.FifteenMinutes);
+        providerA.Add(ticks);
+        aggA.Rebuild(rollback);
+
+        TickHub providerB = new();
+        TickAggregatorHub aggB = providerB.ToTickAggregatorHub(PeriodSize.FifteenMinutes);
+        providerB.Add(ticks);
+
+        aggA.Results.Should().NotBeEmpty();
+        aggB.Results.Should().NotBeEmpty();
+        aggA.Results.IsExactly(aggB.Results);
+
+        providerA.DisposeChain();
+        providerB.DisposeChain();
+    }
+
+    // TC-V31-8 — late arrival through an aggregator into a downstream indicator
+
+    [TestMethod]
+    public void QuoteHub_Aggregator_Ema_LateArrival_MatchesFreshChain()
+    {
+        const int total = 500;
+        const int skipIndex = 200;
+        const int emaPeriods = 5;
+
+        IReadOnlyList<Quote> quotes = Quotes.Take(total).ToList();
+
+        // late chain: feed all but one bar, then add it late
+        QuoteHub lateProvider = new();
+        EmaHub lateEma = lateProvider
+            .ToQuoteAggregatorHub(PeriodSize.Week)
+            .ToEmaHub(emaPeriods);
+
+        for (int i = 0; i < total; i++)
+        {
+            if (i == skipIndex) { continue; }
+            lateProvider.Add(quotes[i]);
+        }
+
+        lateProvider.Add(quotes[skipIndex]);  // late arrival → rollback through the aggregator
+
+        // fresh chain: in-order oracle
+        QuoteHub freshProvider = new();
+        EmaHub freshEma = freshProvider
+            .ToQuoteAggregatorHub(PeriodSize.Week)
+            .ToEmaHub(emaPeriods);
+
+        freshProvider.Add(quotes);
+
+        lateEma.Results.Should().NotBeEmpty();
+        freshEma.Results.Should().NotBeEmpty();
+        lateEma.Results.IsExactly(freshEma.Results);
+
+        lateProvider.DisposeChain();
+        freshProvider.DisposeChain();
+    }
+
+    [TestMethod]
+    public void TickHub_Aggregator_Ema_LateArrival_MatchesFreshChain()
+    {
+        const int skipIndex = 200;
+        const int emaPeriods = 5;
+
+        List<Tick> ticks = BuildTicks(TickCount);
+
+        TickHub lateProvider = new();
+        EmaHub lateEma = lateProvider
+            .ToTickAggregatorHub(PeriodSize.FifteenMinutes)
+            .ToEmaHub(emaPeriods);
+
+        for (int i = 0; i < ticks.Count; i++)
+        {
+            if (i == skipIndex) { continue; }
+            lateProvider.Add(ticks[i]);
+        }
+
+        lateProvider.Add(ticks[skipIndex]);  // late arrival
+
+        TickHub freshProvider = new();
+        EmaHub freshEma = freshProvider
+            .ToTickAggregatorHub(PeriodSize.FifteenMinutes)
+            .ToEmaHub(emaPeriods);
+
+        freshProvider.Add(ticks);
+
+        lateEma.Results.Should().NotBeEmpty();
+        freshEma.Results.Should().NotBeEmpty();
+        lateEma.Results.IsExactly(freshEma.Results);
+
+        lateProvider.DisposeChain();
+        freshProvider.DisposeChain();
+    }
+
+    /// <summary>
+    /// Synthetic one-minute ticks with strictly increasing timestamps.
+    /// </summary>
+    private static List<Tick> BuildTicks(int count)
+    {
+        DateTime start = new(2023, 11, 9, 9, 30, 0, DateTimeKind.Utc);
+        List<Tick> ticks = new(count);
+
+        for (int i = 0; i < count; i++)
+        {
+            // a mild deterministic wave so OHLC aggregation is non-trivial
+            decimal price = 100m + (i % 37) - (i % 13);
+            ticks.Add(new Tick(start.AddMinutes(i), price, 10m + (i % 5)));
+        }
+
+        return ticks;
+    }
+}


### PR DESCRIPTION
## Summary

Closes three rollback-engine coverage gaps the generic catalog-driven contract doesn't reach. Sixth of the stacked §L "v3.0 stable-readiness" PRs — **test-only**.

Implements **TC-V31-4**, **TC-V31-8**, and **SR020** from `docs/plans/streaming-indicators.plan.md` (§L).

> **Stacked on #2063** (→ #2062 → #2061 → #2060 → #2059 → v3). Base is `test/stream-concurrency`.

## What's covered (`StreamHub.RollbackCoverage.Tests.cs`)

- **TC-V31-4 — aggregator rollback-equivalence.** `QuoteAggregatorHub`/`TickAggregatorHub` override `RollbackState`/`Rebuild` but aren't catalog-registered, so the generic rollback contract skips them. New cases feed a full stream, call `Rebuild(timestamp)` mid-stream, and assert `IsExactly` vs a fresh hub fed the same data. The Quote case additionally cross-checks against the independent batch `Aggregate(PeriodSize.Week)` oracle (rollback **and** correctness).
- **TC-V31-8 — chained late arrival through an aggregator.** `QuoteHub`/`TickHub → AggregatorHub → EmaHub`; a skipped-then-late bar must yield `EmaHub` results bit-equal to a fresh in-order chain.

## SR020 — deep-chain value-equality (`StreamHub.BoundsChecking.Tests.cs`)

The existing `DeeplyChainedHubs_RemoveAndRebuild` test asserted count/timestamp only; it now asserts `IsExactly` across all three levels (`Atr→Ema→Sma`) against the equivalent batch Series on the revised quotes, and is renamed to `…_MatchesSeries`.

## Notes

- `Rebuild(timestamp)` is intentionally **not** subject to the root-only mutation guard from #2059 (it's the rollback mechanism, runs on every hub), so calling it on a subscribed aggregator is valid.
- Sensitivity confirmed by sabotage: neutralizing `QuoteAggregatorHub.RollbackState` breaks the aggregator rebuild test.
- Self-review prompted the independent batch-`Aggregate` cross-check and symmetric `NotBeEmpty` guards on the rebuilt/late (SUT) side.

Full local run green: **indicators 2449 / 12 baseline-skipped** (net10.0); format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)