### PR TITLE
test(buffer): Add bounded-value parity tests to BufferLists

### DIFF
--- a/docs/plans/streaming-indicators.plan.md
+++ b/docs/plans/streaming-indicators.plan.md
@@ -172,7 +172,7 @@ The v3 streaming engine is the headline of this release after a long development
 - [x] **TC-V31-4 — Aggregator-hub rollback-equivalence** (2 hours). `QuoteAggregatorHub`/`TickAggregatorHub` override `RollbackState` but aren't in the catalog, so TC001 doesn't exercise them; catalog-register or add two hand-built rollback-equivalence cases to `StreamHub.RollbackContract.Tests.cs`. *(PR #2064)*
 - [x] **SR020 — Deep-chain rebuild value-equality** (2 hours). `StreamHub.BoundsChecking.Tests.cs:810` asserts count/timestamp only after a chained `RemoveAt`; extend to `IsExactly` vs a Series-equivalent chain. *(PR #2064)*
 - [x] **TC-V31-8 — Chained-downstream late-arrival through an aggregator** (1–2 hours). `QuoteHub → AggregatorHub → EmaHub` (+ tick analog) late-arrival test; assert downstream `EmaHub.Results` bit-equality between late and fresh chains — catches a dropped-notification-per-replay regression. *(PR #2064)*
-- [ ] **TC-V31-7 — BufferList bounded-value parity** (1–2 hours). Add `Boundary_WithRandomQuotes_StaysWithinBounds` to each bounded `*.BufferList.Tests.cs` (RSI/Stoch/Aroon/MFI/Ultimate/ConnorsRsi/WilliamsR), matching the Series + StreamHub coverage.
+- [x] **TC-V31-7 — BufferList bounded-value parity** (1–2 hours). Add `Boundary_WithRandomQuotes_StaysWithinBounds` to each bounded `*.BufferList.Tests.cs` (RSI/Stoch/Aroon/MFI/Ultimate/ConnorsRsi/WilliamsR), matching the Series + StreamHub coverage. *(PR #2065)*
 
 #### ⚠️ Pending maintainer decisions — highlighted, NOT in the next batch
 

--- a/tests/indicators/a-d/Aroon/Aroon.BufferList.Tests.cs
+++ b/tests/indicators/a-d/Aroon/Aroon.BufferList.Tests.cs
@@ -9,6 +9,18 @@ public class Aroon : BufferListTestBase
         = Quotes.ToAroon(lookbackPeriods);
 
     [TestMethod]
+    public void Boundary_WithRandomQuotes_StaysWithinBounds()
+    {
+        IReadOnlyList<AroonResult> sut = Data
+            .GetRandom(2500)
+            .ToAroonList(25);
+
+        sut.IsBetween(static x => x.AroonUp, 0d, 100d);
+        sut.IsBetween(static x => x.AroonDown, 0d, 100d);
+        sut.IsBetween(static x => x.Oscillator, -100d, 100d);
+    }
+
+    [TestMethod]
     public void Results_AreAlwaysBounded()
     {
         AroonList sut = new(25, Quotes);

--- a/tests/indicators/a-d/ConnorsRsi/ConnorsRsi.BufferList.Tests.cs
+++ b/tests/indicators/a-d/ConnorsRsi/ConnorsRsi.BufferList.Tests.cs
@@ -16,6 +16,16 @@ public class ConnorsRsi : BufferListTestBase, ITestChainBufferList
        = Quotes.ToConnorsRsi(rsiPeriods, streakPeriods, rankPeriods);
 
     [TestMethod]
+    public void Boundary_WithRandomQuotes_StaysWithinBounds()
+    {
+        IReadOnlyList<ConnorsRsiResult> sut = Data
+            .GetRandom(2500)
+            .ToConnorsRsiList(3, 2, 100);
+
+        sut.IsBetween(static x => x.ConnorsRsi, 0d, 100d);
+    }
+
+    [TestMethod]
     public void AddQuote_IncrementsResults()
     {
         ConnorsRsiList sut = new(rsiPeriods, streakPeriods, rankPeriods);

--- a/tests/indicators/m-r/Mfi/Mfi.BufferList.Tests.cs
+++ b/tests/indicators/m-r/Mfi/Mfi.BufferList.Tests.cs
@@ -9,6 +9,16 @@ public class Mfi : BufferListTestBase
        = Quotes.ToMfi(lookbackPeriods);
 
     [TestMethod]
+    public void Boundary_WithRandomQuotes_StaysWithinBounds()
+    {
+        IReadOnlyList<MfiResult> sut = Data
+            .GetRandom(2500)
+            .ToMfiList(14);
+
+        sut.IsBetween(static x => x.Mfi, 0d, 100d);
+    }
+
+    [TestMethod]
     public void Results_WithAnyInput_AreAlwaysBounded()
     {
         MfiList sut = new(14, Quotes);

--- a/tests/indicators/m-r/Rsi/Rsi.BufferList.Tests.cs
+++ b/tests/indicators/m-r/Rsi/Rsi.BufferList.Tests.cs
@@ -14,6 +14,16 @@ public class Rsi : BufferListTestBase, ITestChainBufferList
        = Quotes.ToRsi(lookbackPeriods);
 
     [TestMethod]
+    public void Boundary_WithRandomQuotes_StaysWithinBounds()
+    {
+        IReadOnlyList<RsiResult> sut = Data
+            .GetRandom(2500)
+            .ToRsiList(14);
+
+        sut.IsBetween(static x => x.Rsi, 0d, 100d);
+    }
+
+    [TestMethod]
     public void AddQuote_IncrementsResults()
     {
         RsiList sut = new(lookbackPeriods);

--- a/tests/indicators/s-z/Stoch/Stoch.BufferList.Tests.cs
+++ b/tests/indicators/s-z/Stoch/Stoch.BufferList.Tests.cs
@@ -14,6 +14,18 @@ public class Stoch : BufferListTestBase
        = Quotes.ToStoch(lookbackPeriods, signalPeriods, smoothPeriods);
 
     [TestMethod]
+    public void Boundary_WithRandomQuotes_StaysWithinBounds()
+    {
+        // %J is unbounded by design so not asserted.
+        IReadOnlyList<StochResult> sut = Data
+            .GetRandom(2500)
+            .ToStochList(14, 3, 3);
+
+        sut.IsBetween(static x => x.Oscillator, 0d, 100d);
+        sut.IsBetween(static x => x.Signal, 0d, 100d);
+    }
+
+    [TestMethod]
     public void AddQuotes_WithValidQuotes_IncrementsResults()
     {
         StochList sut = new(lookbackPeriods, signalPeriods, smoothPeriods);

--- a/tests/indicators/s-z/Ultimate/Ultimate.BufferList.Tests.cs
+++ b/tests/indicators/s-z/Ultimate/Ultimate.BufferList.Tests.cs
@@ -11,6 +11,16 @@ public class Ultimate : BufferListTestBase
        = Quotes.ToUltimate(shortPeriods, middlePeriods, longPeriods);
 
     [TestMethod]
+    public void Boundary_WithRandomQuotes_StaysWithinBounds()
+    {
+        IReadOnlyList<UltimateResult> sut = Data
+            .GetRandom(2500)
+            .ToUltimateList(7, 14, 28);
+
+        sut.IsBetween(static x => x.Ultimate, 0d, 100d);
+    }
+
+    [TestMethod]
     public void Results_AreAlwaysBounded()
     {
         UltimateList sut = new(7, 14, 28, Quotes);

--- a/tests/indicators/s-z/WilliamsR/WilliamsR.BufferList.Tests.cs
+++ b/tests/indicators/s-z/WilliamsR/WilliamsR.BufferList.Tests.cs
@@ -9,6 +9,16 @@ public class WilliamsR : BufferListTestBase
        = Quotes.ToWilliamsR(lookbackPeriods);
 
     [TestMethod]
+    public void Boundary_WithRandomQuotes_StaysWithinBounds()
+    {
+        IReadOnlyList<WilliamsResult> sut = Data
+            .GetRandom(2500)
+            .ToWilliamsRList(14);
+
+        sut.IsBetween(static x => x.WilliamsR, -100d, 0d);
+    }
+
+    [TestMethod]
     public void AddQuotes_WithValidQuotes_IncrementsResults()
     {
         WilliamsRList sut = new(lookbackPeriods);


### PR DESCRIPTION
## Summary

Adds the `Boundary_WithRandomQuotes_StaysWithinBounds` test to the seven bounded-oscillator BufferList suites, matching the coverage already present in their Series and StreamHub suites. Last of the stacked §L "v3.0 stable-readiness" PRs — **test-only**.

Implements **TC-V31-7** from `docs/plans/streaming-indicators.plan.md` (§L).

> **Stacked on #2064** (→ #2063 → #2062 → #2061 → #2060 → #2059 → v3). Base is `test/stream-rollback-coverage`.

## What changed

One test added to each of `Rsi`, `Stoch`, `Aroon`, `Mfi`, `Ultimate`, `ConnorsRsi`, `WilliamsR` `*.BufferList.Tests.cs`: stream 2,500 random (GBM) quotes through the BufferList and assert every non-null value stays within the indicator's documented range —

| Indicator | Bounds |
|---|---|
| Rsi | `Rsi` 0–100 |
| Stoch | `Oscillator`, `Signal` 0–100 (`%J` unbounded by design, not asserted) |
| Aroon | `AroonUp`, `AroonDown` 0–100; `Oscillator` -100..100 |
| Mfi | `Mfi` 0–100 |
| Ultimate | `Ultimate` 0–100 |
| ConnorsRsi | `ConnorsRsi` 0–100 |
| WilliamsR | `WilliamsR` -100..0 |

Selectors, bounds, parameters, and the `%J` omission are byte-for-byte identical to the existing StreamHub boundary tests.

## Notes

- Sensitivity confirmed by sabotage (tightening the RSI bound to 40..60 fails).
- Self-review verified the assertions are non-vacuous (>2,000 non-null values per indicator at 2,500 quotes; deepest warmup is ConnorsRsi `rankPeriods=100`) and that the random-GBM input is consistent with the established boundary-test pattern.

Full local run green: **indicators 2456 / 12 baseline-skipped** (net10.0); format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)