### PR TITLE
docs(stream): Fix Remove(ITick) remarks to match replacement semantics

### DIFF
--- a/src/_common/Quotes/Tick.StreamHub.cs
+++ b/src/_common/Quotes/Tick.StreamHub.cs
@@ -97,8 +97,7 @@ public class TickHub
                 return;
             }
 
-            // For ticks with different execution IDs but same timestamp,
-            // we need to store them properly (not drop them)
+            // determine execution ID presence for same-timestamp replacement logic
             bool hasExecutionId = !string.IsNullOrEmpty(result.ExecutionId);
             bool hasCachedExecutionId = !string.IsNullOrEmpty(Cache[index].ExecutionId);
 
@@ -192,11 +191,13 @@ public class TickHub
     /// locates the entry by timestamp.
     /// </summary>
     /// <remarks>
-    /// The match is by timestamp, not by value. Because a <see cref="TickHub"/>
-    /// can legitimately hold several ticks at the same timestamp (distinct
-    /// trades), if more than one cached tick shares the timestamp an unspecified
-    /// one is removed; identify the entry positionally via
-    /// <see cref="StreamHub{TIn, TOut}.RemoveAt(int)"/> when that matters.
+    /// The match is by timestamp. For root hubs, the cache holds at most one
+    /// entry per timestamp — when a new tick is added with the same timestamp as
+    /// an existing entry, the earlier entry is replaced — so <c>Remove</c>
+    /// unambiguously removes that single entry. If a custom derived hub stores
+    /// multiple entries per timestamp, use
+    /// <see cref="StreamHub{TIn, TOut}.RemoveAt(int)"/> to target a specific
+    /// positional entry.
     /// </remarks>
     /// <param name="tick">
     /// Tick whose <see cref="ISeries.Timestamp"/> identifies the cache entry


### PR DESCRIPTION
## Summary

Addresses the one open CodeRabbit review thread on PR #2059 (`PRRT_kwDODcBM8c6F63vP`).

**What changed** (`src/_common/Quotes/Tick.StreamHub.cs`):

- Fixed `<remarks>` on `Remove(ITick)`: the previous text claimed a root `TickHub` can hold multiple entries per timestamp (distinct trades), but `OnAdd` always replaces the existing cache entry when timestamps match — the cache never accumulates more than one entry per timestamp on root hubs. Updated remarks to state the actual contract.
- Removed a misleading code comment (`"we need to store them properly (not drop them)"`) that directly contradicted the replacement logic that followed it.

**Option chosen:** CodeRabbit's Option A — narrow the docs to match the current replacement semantics, keeping the behavior unchanged.

https://claude.ai/code/session_015VujeUMTxJJsgCdZ9TVKkK

---
_Generated by [Claude Code](https://claude.ai/code/session_015VujeUMTxJJsgCdZ9TVKkK)_