### PR TITLE
test(stream): End-to-end concurrency safety-net suite

### DIFF
--- a/docs/plans/streaming-indicators.plan.md
+++ b/docs/plans/streaming-indicators.plan.md
@@ -168,7 +168,7 @@ The v3 streaming engine is the headline of this release after a long development
 
 #### Test coverage — prove the rollback/concurrency engine before the tag
 
-- [ ] **TC-V31-1 — StreamHub concurrency test suite** (4–6 hours). Parallel `Add` from N threads, interleaved late arrivals, concurrent observer subscribe/dispose. The safety net validating the documented single-writer / thread-safety contract.
+- [x] **TC-V31-1 — StreamHub concurrency test suite** (4–6 hours). Parallel `Add` from N threads, interleaved late arrivals, concurrent observer subscribe/dispose. The safety net validating the documented single-writer / thread-safety contract. *(PR #2070)*
 - [ ] **TC-V31-4 — Aggregator-hub rollback-equivalence** (2 hours). `QuoteAggregatorHub`/`TickAggregatorHub` override `RollbackState` but aren't in the catalog, so TC001 doesn't exercise them; catalog-register or add two hand-built rollback-equivalence cases to `StreamHub.RollbackContract.Tests.cs`.
 - [ ] **SR020 — Deep-chain rebuild value-equality** (2 hours). `StreamHub.BoundsChecking.Tests.cs:810` asserts count/timestamp only after a chained `RemoveAt`; extend to `IsExactly` vs a Series-equivalent chain.
 - [ ] **TC-V31-8 — Chained-downstream late-arrival through an aggregator** (1–2 hours). `QuoteHub → AggregatorHub → EmaHub` (+ tick analog) late-arrival test; assert downstream `EmaHub.Results` bit-equality between late and fresh chains — catches a dropped-notification-per-replay regression.
@@ -285,7 +285,7 @@ Non-blocking items from the same swarm review; the stable-blocking subset is in 
 
 ### Test coverage v3.1+
 
-- [ ] **TC-V31-1 — Concurrency test suite for StreamHub** (4–6 hours).
+- [x] **TC-V31-1 — Concurrency test suite for StreamHub** (4–6 hours). *(PR #2070 — see §L)*
   - Source: Tester F4. Production hardening (PR #1927) shipped; tests are the safety net for future regressions. Parallel `Add` from N threads, interleaved late-arrivals, concurrent observer subscribe/dispose.
 
 - [ ] **TC-V31-2 — Tighten `Catalog.Listings.Tests.cs` per-indicator metadata assertions** (3–4 hours).

--- a/tests/indicators/_common/StreamHub/StreamHub.Concurrency.Tests.cs
+++ b/tests/indicators/_common/StreamHub/StreamHub.Concurrency.Tests.cs
@@ -1,0 +1,283 @@
+using System.Collections.Concurrent;
+
+namespace Observables;
+
+/// <summary>
+/// End-to-end safety net for the documented streaming threading contract: a
+/// single writer (one thread, or many funneled through a gate) drives results
+/// that are bit-for-bit identical to the batch Series, and concurrent readers
+/// or observer churn never corrupt the hub. These exercise real indicator
+/// chains and assert Series convergence, complementing the low-level
+/// mechanism pins in <c>StreamHub.RaceGuards.Tests.cs</c> (which assert only
+/// that the observer set survives concurrent mutation).
+/// </summary>
+[TestClass]
+public class Concurrency : TestBase
+{
+    public TestContext TestContext { get; set; }
+
+    [TestMethod]
+    public void SingleWriterGate_OutOfOrderParallelProducers_ConvergeToSeries()
+    {
+        // N producers each feed a strided subset (ascending), funneled through a
+        // single-writer gate. Threads interleave, so quotes arrive globally out
+        // of order and drive rollback/replay. Regardless of arrival order, every
+        // quote is added exactly once under serialization, so a deep chain must
+        // converge bit-for-bit to the batch Series.
+        const int count = 500;
+        const int producerCount = 8;
+        const int emaPeriods = 20;
+        const int smaPeriods = 10;
+
+        List<Quote> quotes = Quotes.Take(count).ToList();
+        IReadOnlyList<EmaResult> expectedEma = quotes.ToEma(emaPeriods);
+        IReadOnlyList<SmaResult> expectedSma = expectedEma.ToSma(smaPeriods);
+
+        QuoteHub quoteHub = new();
+        EmaHub emaHub = quoteHub.ToEmaHub(emaPeriods);
+        SmaHub smaHub = emaHub.ToSmaHub(smaPeriods);
+
+        // Seed the global-minimum quote first so no later out-of-order arrival is
+        // "before head". A standalone QuoteHub drops before-head quotes by
+        // design; once index 0 is the head, every other quote is >= it and lands
+        // mid-cache (rollback) or at the tail.
+        quoteHub.Add(quotes[0]);
+
+        object gate = new();
+        Thread[] producers = new Thread[producerCount];
+        for (int t = 0; t < producerCount; t++)
+        {
+            int start = t;
+            producers[t] = new Thread(() => {
+                for (int i = start; i < count; i += producerCount)
+                {
+                    if (i == 0) { continue; }  // already seeded
+
+                    lock (gate)
+                    {
+                        quoteHub.Add(quotes[i]);
+                    }
+                }
+            });
+            producers[t].Start();
+        }
+
+        foreach (Thread p in producers) { p.Join(); }
+
+        quoteHub.Quotes.Should().HaveCount(count);
+        emaHub.Results.IsExactly(expectedEma);
+        smaHub.Results.IsExactly(expectedSma);
+
+        smaHub.Unsubscribe();
+        emaHub.Unsubscribe();
+        quoteHub.EndTransmission();
+    }
+
+    [TestMethod]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Design", "CA1031:Do not catch general exception types",
+        Justification = "The test deliberately records any exception thrown by the concurrent reader threads to assert thread-safety.")]
+    public void ConcurrentSnapshotReaders_DuringFeed_StayConsistentAndConverge()
+    {
+        // A single writer feeds the chain while reader threads continuously
+        // Snapshot a downstream hub. Each snapshot must be internally consistent
+        // (sorted) and no read may throw; the final results must equal the
+        // Series. This pins Snapshot() against a chained hub under live writes —
+        // the standalone single-reader pin lives in StreamHub.Snapshot.Tests.cs.
+        const int count = 800;
+        const int emaPeriods = 20;
+        const int readerCount = 4;
+
+        List<Quote> quotes = Quotes.Take(count).ToList();
+        IReadOnlyList<EmaResult> expected = quotes.ToEma(emaPeriods);
+
+        QuoteHub quoteHub = new();
+        EmaHub emaHub = quoteHub.ToEmaHub(emaPeriods);
+
+        ConcurrentBag<Exception> failures = [];
+        using CancellationTokenSource done = new();
+        using CountdownEvent readersStarted = new(readerCount);
+
+        Thread[] readers = new Thread[readerCount];
+        for (int r = 0; r < readerCount; r++)
+        {
+            readers[r] = new Thread(() => {
+                try
+                {
+                    readersStarted.Signal();  // rendezvous: guarantee overlap with the feed
+                    while (!done.Token.IsCancellationRequested)
+                    {
+                        IReadOnlyList<EmaResult> snap = emaHub.Snapshot();
+                        for (int i = 1; i < snap.Count; i++)
+                        {
+                            snap[i].Timestamp.Should().BeOnOrAfter(snap[i - 1].Timestamp);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    failures.Add(ex);
+                }
+            });
+            readers[r].Start();
+        }
+
+        // ensure every reader is live before feeding
+        readersStarted.Wait(TimeSpan.FromSeconds(5), TestContext.CancellationToken);
+
+        foreach (Quote q in quotes)
+        {
+            quoteHub.Add(q);
+        }
+
+        done.Cancel();
+        foreach (Thread reader in readers) { reader.Join(); }
+
+        failures.Should().BeEmpty("concurrent Snapshot() reads must never throw");
+        emaHub.Results.IsExactly(expected);
+
+        emaHub.Unsubscribe();
+        quoteHub.EndTransmission();
+    }
+
+    [TestMethod]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Design", "CA1031:Do not catch general exception types",
+        Justification = "The test deliberately records any exception thrown by the concurrent churn thread to assert thread-safety.")]
+    public void SubscribeDisposeChurn_DuringFeed_PreservesStableObserver()
+    {
+        // A stable downstream hub stays subscribed while another thread churns
+        // subscribe/dispose of throwaway observers. RaceGuards pins that the
+        // observer set survives this; here the added assertion is that the
+        // stable observer still converges bit-for-bit to the Series despite the
+        // churn.
+        const int count = 600;
+        const int emaPeriods = 20;
+
+        List<Quote> quotes = Quotes.Take(count).ToList();
+        IReadOnlyList<EmaResult> expected = quotes.ToEma(emaPeriods);
+
+        QuoteHub quoteHub = new();
+        EmaHub stable = quoteHub.ToEmaHub(emaPeriods);
+
+        ConcurrentBag<Exception> failures = [];
+        using CancellationTokenSource done = new();
+        using ManualResetEventSlim churnStarted = new(false);
+
+        Thread churn = new(() => {
+            try
+            {
+                NoopObserver[] pool = [.. Enumerable.Range(0, 8).Select(_ => new NoopObserver())];
+                while (!done.Token.IsCancellationRequested)
+                {
+                    List<IDisposable> subs = [.. pool.Select(quoteHub.Subscribe)];
+                    churnStarted.Set();  // rendezvous: guarantee overlap with the feed
+                    foreach (IDisposable s in subs)
+                    {
+                        s.Dispose();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                failures.Add(ex);
+            }
+        });
+        churn.Start();
+
+        // ensure the churn is live before feeding
+        churnStarted.Wait(TimeSpan.FromSeconds(5), TestContext.CancellationToken);
+
+        try
+        {
+            foreach (Quote q in quotes)
+            {
+                quoteHub.Add(q);
+            }
+        }
+        catch (Exception ex)
+        {
+            failures.Add(ex);
+        }
+        finally
+        {
+            done.Cancel();
+            churn.Join();
+        }
+
+        failures.Should().BeEmpty();
+        stable.Results.IsExactly(expected);
+
+        stable.Unsubscribe();
+        quoteHub.EndTransmission();
+    }
+
+    [TestMethod]
+    public void SingleWriterGate_WithLateArrivalAndRemoval_ConvergeToRevisedSeries()
+    {
+        // Gated parallel producers plus a late arrival and a removal, all
+        // serialized through the single-writer gate — the chain converges to the
+        // revised Series.
+        const int count = 400;
+        const int skipIndex = 200;
+        const int removeIndex = 120;
+        const int emaPeriods = 20;
+
+        List<Quote> quotes = Quotes.Take(count).ToList();
+
+        QuoteHub quoteHub = new();
+        EmaHub emaHub = quoteHub.ToEmaHub(emaPeriods);
+
+        // seed the global-minimum quote first (see the convergence test for why)
+        quoteHub.Add(quotes[0]);
+
+        object gate = new();
+
+        // feed everything except one index, from 4 strided producers
+        Thread[] producers = new Thread[4];
+        for (int t = 0; t < 4; t++)
+        {
+            int start = t;
+            producers[t] = new Thread(() => {
+                for (int i = start; i < count; i += 4)
+                {
+                    if (i == 0 || i == skipIndex) { continue; }
+
+                    lock (gate)
+                    {
+                        quoteHub.Add(quotes[i]);
+                    }
+                }
+            });
+            producers[t].Start();
+        }
+
+        foreach (Thread p in producers) { p.Join(); }
+
+        // late arrival + removal (single writer)
+        lock (gate)
+        {
+            quoteHub.Add(quotes[skipIndex]);
+            quoteHub.RemoveAt(removeIndex);
+        }
+
+        List<Quote> revised = [.. quotes];
+        revised.RemoveAt(removeIndex);
+
+        emaHub.Results.IsExactly(revised.ToEma(emaPeriods));
+
+        emaHub.Unsubscribe();
+        quoteHub.EndTransmission();
+    }
+
+    private sealed class NoopObserver : IStreamObserver<IQuote>
+    {
+        public bool IsSubscribed => false;
+        public void Unsubscribe() { }
+        public void OnAdd(IQuote item, bool notify, int? indexHint) { }
+        public void OnRebuild(DateTime fromTimestamp) { }
+        public void OnPrune(DateTime toTimestamp) { }
+        public void OnError(Exception exception) { }
+        public void OnCompleted() { }
+    }
+}

--- a/tests/indicators/_common/StreamHub/StreamHub.Concurrency.Tests.cs
+++ b/tests/indicators/_common/StreamHub/StreamHub.Concurrency.Tests.cs
@@ -16,6 +16,13 @@ public class Concurrency : TestBase
 {
     public TestContext TestContext { get; set; }
 
+    // Generous failsafe for rendezvous waits and thread joins. It costs nothing
+    // on the normal path (each Wait/Join returns the instant the threads signal
+    // or finish) and turns a regression deadlock into a fast, clear test failure
+    // instead of a hung CI job — while staying far above any real scheduling
+    // delay, so it cannot itself flake.
+    private static readonly TimeSpan ThreadBudget = TimeSpan.FromSeconds(30);
+
     [TestMethod]
     public void SingleWriterGate_OutOfOrderParallelProducers_ConvergeToSeries()
     {
@@ -62,7 +69,10 @@ public class Concurrency : TestBase
             producers[t].Start();
         }
 
-        foreach (Thread p in producers) { p.Join(); }
+        foreach (Thread p in producers)
+        {
+            p.Join(ThreadBudget).Should().BeTrue("producer threads must finish promptly");
+        }
 
         quoteHub.Quotes.Should().HaveCount(count);
         emaHub.Results.IsExactly(expectedEma);
@@ -84,11 +94,12 @@ public class Concurrency : TestBase
         // (sorted) and no read may throw; the final results must equal the
         // Series. This pins Snapshot() against a chained hub under live writes —
         // the standalone single-reader pin lives in StreamHub.Snapshot.Tests.cs.
-        const int count = 800;
         const int emaPeriods = 20;
         const int readerCount = 4;
 
-        List<Quote> quotes = Quotes.Take(count).ToList();
+        // the default fixture caps at ~500 quotes; feed all of them rather than a
+        // larger constant that would silently truncate
+        List<Quote> quotes = Quotes.ToList();
         IReadOnlyList<EmaResult> expected = quotes.ToEma(emaPeriods);
 
         QuoteHub quoteHub = new();
@@ -122,8 +133,10 @@ public class Concurrency : TestBase
             readers[r].Start();
         }
 
-        // ensure every reader is live before feeding
-        readersStarted.Wait(TimeSpan.FromSeconds(5), TestContext.CancellationToken);
+        // ensure every reader is live before feeding (assert, so a thread that
+        // dies before signaling fails loudly instead of silently under-testing)
+        readersStarted.Wait(ThreadBudget, TestContext.CancellationToken)
+            .Should().BeTrue("all reader threads must be live before feeding");
 
         foreach (Quote q in quotes)
         {
@@ -131,7 +144,10 @@ public class Concurrency : TestBase
         }
 
         done.Cancel();
-        foreach (Thread reader in readers) { reader.Join(); }
+        foreach (Thread reader in readers)
+        {
+            reader.Join(ThreadBudget).Should().BeTrue("reader threads must finish promptly");
+        }
 
         failures.Should().BeEmpty("concurrent Snapshot() reads must never throw");
         emaHub.Results.IsExactly(expected);
@@ -151,10 +167,10 @@ public class Concurrency : TestBase
         // observer set survives this; here the added assertion is that the
         // stable observer still converges bit-for-bit to the Series despite the
         // churn.
-        const int count = 600;
         const int emaPeriods = 20;
 
-        List<Quote> quotes = Quotes.Take(count).ToList();
+        // feed the whole default fixture (a larger constant would silently truncate)
+        List<Quote> quotes = Quotes.ToList();
         IReadOnlyList<EmaResult> expected = quotes.ToEma(emaPeriods);
 
         QuoteHub quoteHub = new();
@@ -185,8 +201,9 @@ public class Concurrency : TestBase
         });
         churn.Start();
 
-        // ensure the churn is live before feeding
-        churnStarted.Wait(TimeSpan.FromSeconds(5), TestContext.CancellationToken);
+        // ensure the churn is live before feeding (assert, per the reader analog)
+        churnStarted.Wait(ThreadBudget, TestContext.CancellationToken)
+            .Should().BeTrue("the churn thread must overlap the live feed");
 
         try
         {
@@ -202,7 +219,7 @@ public class Concurrency : TestBase
         finally
         {
             done.Cancel();
-            churn.Join();
+            churn.Join(ThreadBudget).Should().BeTrue("the churn thread must finish promptly");
         }
 
         failures.Should().BeEmpty();
@@ -252,7 +269,10 @@ public class Concurrency : TestBase
             producers[t].Start();
         }
 
-        foreach (Thread p in producers) { p.Join(); }
+        foreach (Thread p in producers)
+        {
+            p.Join(ThreadBudget).Should().BeTrue("producer threads must finish promptly");
+        }
 
         // late arrival + removal (single writer)
         lock (gate)


### PR DESCRIPTION
## Summary

Adds an end-to-end **concurrency safety-net suite** for the documented StreamHub single-writer threading contract. Implements TC-V31-1 from `docs/plans/streaming-indicators.plan.md`.

These tests run through **real indicator chains** and assert **bit-exact convergence to the batch Series** under realistic concurrency. They are the behavioral complement to the mechanism pins added in #2069 (`StreamHub.RaceGuards.Tests.cs`), which assert only that the observer set survives concurrent mutation (noop observers, no Series assertion).

## Tests (`tests/indicators/_common/StreamHub/StreamHub.Concurrency.Tests.cs`)

| Test | Pins |
| --- | --- |
| `SingleWriterGate_OutOfOrderParallelProducers_ConvergeToSeries` | 8 strided producers funneled through a single-writer gate arrive globally out of order → rollback/replay → a deep `Ema→Sma` chain converges bit-for-bit to Series |
| `ConcurrentSnapshotReaders_DuringFeed_StayConsistentAndConverge` | 4 reader threads `Snapshot()` a downstream hub during a live feed; every snapshot stays sorted, no read throws, final results equal Series |
| `SubscribeDisposeChurn_DuringFeed_PreservesStableObserver` | subscribe/dispose churn on throwaway observers leaves a stable downstream hub bit-exact to Series |
| `SingleWriterGate_WithLateArrivalAndRemoval_ConvergeToRevisedSeries` | gated producers + late arrival + removal converge to the revised Series |

## Lessons carried from the earlier (abandoned) stack

- Long-running reader/churn loops use **dedicated `Thread`s** (not `Task.Run` with a scheduling token) to avoid the pre-start-cancellation flakiness that surfaced only under the parallel full-suite run.
- Rendezvous waits take `TestContext.CancellationToken` (MSTEST0049-clean now that #2061 enabled the MSTest analyzers).

## Verification

- `dotnet build` with `TreatWarningsAsErrors=true`: 0 warnings / 0 errors
- `dotnet format --verify-no-changes --severity info`: clean
- `roslynator analyze --severity-level hidden`: 0 diagnostics
- New suite: 4/4, repeat-run stable; full `Observables` streaming suite: 88/88

🤖 Generated with [Claude Code](https://claude.com/claude-code)
