### PR TITLE
test(stream): Aggregator-hub rollback and deep-chain value-equality coverage

### DIFF
--- a/docs/plans/streaming-indicators.plan.md
+++ b/docs/plans/streaming-indicators.plan.md
@@ -169,9 +169,9 @@ The v3 streaming engine is the headline of this release after a long development
 #### Test coverage — prove the rollback/concurrency engine before the tag
 
 - [x] **TC-V31-1 — StreamHub concurrency test suite** (4–6 hours). Parallel `Add` from N threads, interleaved late arrivals, concurrent observer subscribe/dispose. The safety net validating the documented single-writer / thread-safety contract. *(PR #2070)*
-- [ ] **TC-V31-4 — Aggregator-hub rollback-equivalence** (2 hours). `QuoteAggregatorHub`/`TickAggregatorHub` override `RollbackState` but aren't in the catalog, so TC001 doesn't exercise them; catalog-register or add two hand-built rollback-equivalence cases to `StreamHub.RollbackContract.Tests.cs`.
-- [ ] **SR020 — Deep-chain rebuild value-equality** (2 hours). `StreamHub.BoundsChecking.Tests.cs:810` asserts count/timestamp only after a chained `RemoveAt`; extend to `IsExactly` vs a Series-equivalent chain.
-- [ ] **TC-V31-8 — Chained-downstream late-arrival through an aggregator** (1–2 hours). `QuoteHub → AggregatorHub → EmaHub` (+ tick analog) late-arrival test; assert downstream `EmaHub.Results` bit-equality between late and fresh chains — catches a dropped-notification-per-replay regression.
+- [x] **TC-V31-4 — Aggregator-hub rollback-equivalence** (2 hours). `QuoteAggregatorHub`/`TickAggregatorHub` override `RollbackState` but aren't in the catalog, so TC001 doesn't exercise them; catalog-register or add two hand-built rollback-equivalence cases to `StreamHub.RollbackContract.Tests.cs`. *(PR #2071)*
+- [x] **SR020 — Deep-chain rebuild value-equality** (2 hours). `StreamHub.BoundsChecking.Tests.cs:810` asserts count/timestamp only after a chained `RemoveAt`; extend to `IsExactly` vs a Series-equivalent chain. *(PR #2071)*
+- [x] **TC-V31-8 — Chained-downstream late-arrival through an aggregator** (1–2 hours). `QuoteHub → AggregatorHub → EmaHub` (+ tick analog) late-arrival test; assert downstream `EmaHub.Results` bit-equality between late and fresh chains — catches a dropped-notification-per-replay regression. *(PR #2071)*
 - [ ] **TC-V31-7 — BufferList bounded-value parity** (1–2 hours). Add `Boundary_WithRandomQuotes_StaysWithinBounds` to each bounded `*.BufferList.Tests.cs` (RSI/Stoch/Aroon/MFI/Ultimate/ConnorsRsi/WilliamsR), matching the Series + StreamHub coverage.
 
 #### ⚠️ Pending maintainer decisions — highlighted, NOT in the next batch
@@ -279,8 +279,8 @@ Non-blocking items from the same swarm review; the stable-blocking subset is in 
 - [ ] **SR008e — Enforce the BufferList chronological-input precondition** (maintainer-gated; 2–4 hours). Code half of §E SR008 (documented + pinned in PR #2054). A guard in `BufferList.AddInternal` (`item.Timestamp < _internalList[^1].Timestamp` → throw) is viable: an experiment broke **exactly one** indicators-project test (`Pmo.CustomBuffer_OverMaxListSize_AutoAdjustsListAndBuffers`, which itself re-feeds `Quotes.TakeLast(50)` out of order). Before adopting: confirm blast radius across the integration + public-api test projects and consumer impact (a new exception across all 79 BufferLists is a breaking change at stable), decide whether duplicates (`==`) are also rejected, settle the exception type/message, and update `BufferList.OrderingContract.Tests.cs` (which currently pins the *unenforced* behavior) plus the Pmo test.
 - [x] **SR006c — Close the `Reinitialize` rebuild→subscribe race** (part of T205 / `src/_common/StreamHub/StreamHub.cs:233`). Code half of §E SR006: subscribe-before/atomic-with rebuild, or re-run a catch-up rebuild after Subscribe returns. *(PR #2069 — see §L)*
 - [ ] **SR017 — Chain lifecycle ergonomics** (3–4 hours). No `Dispose`/`DisposeChain` on `StreamHub` (it does not implement `IDisposable`); teardown is per-hub via `EndTransmission`/`Unsubscribe` and undiscoverable. Document the `EndTransmission`→`OnCompleted` teardown sequence in `stream.md` and consider implementing `IDisposable`. Surface the `Reinitialize` caveat in xmldoc.
-- [ ] **SR020 — Deep-chain rebuild value-equality tests** (2 hours). `tests/indicators/_common/StreamHub/StreamHub.BoundsChecking.Tests.cs:810` asserts count/timestamp only after a chained `RemoveAt`; extend to `IsExactly` vs a Series-equivalent chain. StochRsi already pins one 3-deep chain and the empirical harness found no divergence — low priority.
-- [ ] **SR019 — Aggregator rollback-equivalence coverage** — already tracked as **TC-V31-4**; the review reconfirms the gap (aggregator hubs excluded from the generic contract at `tests/indicators/_common/StreamHub/StreamHub.RollbackContract.Tests.cs:16`).
+- [x] **SR020 — Deep-chain rebuild value-equality tests** (2 hours). `tests/indicators/_common/StreamHub/StreamHub.BoundsChecking.Tests.cs:810` asserts count/timestamp only after a chained `RemoveAt`; extend to `IsExactly` vs a Series-equivalent chain. StochRsi already pins one 3-deep chain and the empirical harness found no divergence — low priority. *(PR #2071 — see §L)*
+- [x] **SR019 — Aggregator rollback-equivalence coverage** — already tracked as **TC-V31-4**; the review reconfirms the gap (aggregator hubs excluded from the generic contract at `tests/indicators/_common/StreamHub/StreamHub.RollbackContract.Tests.cs:16`). *(PR #2071 — see §L)*
 - Minor cleanups (Low; batch when next touching the files): `OverflowCount` not reset alongside `LastItem` in `RemoveRange` (replay self-heals; `StreamHub.cs:190`); standalone same-timestamp replacement leaves base `LastItem` stale → one extra rebuild cascade on an idempotent re-send (`Quote.StreamHub.cs:135`); `RemoveRange(DateTime)` is the lone cache mutator with no `CacheLock` (defense-in-depth under the single-writer contract; `StreamHub.cs:175`); `_isRebuilding` is a non-volatile instance bool (add an "only read/written under CacheLock" invariant comment; `:23`); `Add(IEnumerable)` `OrderBy`-allocates + locks per item and `RemoveRange` allocates a delegate per rollback (micro-costs); `stream.md:128` "treat as thread-safe (… RemoveRange …)" wording over-promises versus the documented single-writer model.
 
 ### Test coverage v3.1+
@@ -294,7 +294,7 @@ Non-blocking items from the same swarm review; the stable-blocking subset is in 
 - [ ] **TC-V31-3 — BufferList `MaxListSize` runtime trimming test** (1–2 hours).
   - Source: Tester F8. Mirror TickHub's `WithCachePruning` pattern for BufferList.
 
-- [ ] **TC-V31-4 — Aggregator hub rollback-equivalence coverage** (2 hours).
+- [x] **TC-V31-4 — Aggregator hub rollback-equivalence coverage** (2 hours). *(PR #2071 — see §L)*
   - Source: TC001 follow-up. `QuoteAggregatorHub` and `TickAggregatorHub` override `RollbackState` but are not in the catalog, so TC001 does not exercise them. Decide whether to catalog-register them or add two hand-built rollback-equivalence cases to `StreamHub.RollbackContract.Tests.cs`.
 
 - [ ] **TC-V31-5 — Compound-hub inner↔outer rollback interaction** (3 hours).
@@ -308,7 +308,7 @@ Non-blocking items from the same swarm review; the stable-blocking subset is in 
   - Source: PR #2021 scope decision. The bounded-value invariant work (RSI, Stoch, Aroon, MFI, Ultimate, ConnorsRSI, WilliamsR) shipped Series + StreamHub coverage but skipped BufferList. The math is identical across all three styles, so a BufferList violation would be a regression bug rather than an algorithmic edge case; still, a symmetry pass closes the contract.
   - Add `Boundary_WithRandomQuotes_StaysWithinBounds` to each `*.BufferList.Tests.cs` sibling using `Data.GetRandom(2500)`, matching the Series and StreamHub pattern.
 
-- [ ] **TC-V31-8 — Chained-downstream late-arrival aggregator coverage** (1–2 hours).
+- [x] **TC-V31-8 — Chained-downstream late-arrival aggregator coverage** (1–2 hours). *(PR #2071 — see §L)*
   - Source: TC005 self-review (Tester finding). The new TC005 tests exercise the aggregator hub in isolation. A `QuoteHub → AggregatorHub → EmaHub` (and tick analog) late-arrival test would additionally pin that the aggregator's upstream-triggered rebuild propagates downstream observer notifications correctly, catching a hypothetical regression where the rebuild silently dropped one notification per replay. Inline test per pattern; assert downstream `EmaHub.Results` bit-equality between late and fresh chains.
 
 - [ ] **TC-V31-9 — Aggregator late-arrival × gap-fill interaction** (1–2 hours).

--- a/tests/indicators/_common/StreamHub/StreamHub.BoundsChecking.Tests.cs
+++ b/tests/indicators/_common/StreamHub/StreamHub.BoundsChecking.Tests.cs
@@ -793,14 +793,17 @@ public class BoundsCheckingTests : TestBase
     }
 
     /// <summary>
-    /// Test Case 31: Test deeply chained StreamHubs (3 levels).
+    /// Test Case 31: A removal cascading through a deep chain must leave every
+    /// level bit-for-bit equal to the equivalent batch Series chain (not just
+    /// the right count) — the rollback engine is value-exact end to end.
     /// </summary>
     [TestMethod]
-    public void DeeplyChainedHubs_RemoveAndRebuild_ShouldNotThrow()
+    public void DeeplyChainedHubs_RemoveAndRebuild_MatchesSeries()
     {
         // Arrange
+        List<Quote> quotes = Quotes.Take(100).ToList();
         QuoteHub quoteHub = new();
-        quoteHub.Add(Quotes.Take(100));
+        quoteHub.Add(quotes);
 
         // Create a deep chain: QuoteHub -> AtrHub -> EmaHub -> SmaHub
         AtrHub atrHub = quoteHub.ToAtrHub(14);
@@ -808,12 +811,21 @@ public class BoundsCheckingTests : TestBase
         SmaHub smaHub = emaHub.ToSmaHub(5);
 
         // Act - remove a quote, triggering cascade through all levels
-        quoteHub.RemoveAt(60);
+        const int removeIndex = 60;
+        quoteHub.RemoveAt(removeIndex);
 
-        // Assert - should not throw
+        // Assert - every level matches the equivalent batch chain on the revised quotes
+        List<Quote> revised = [.. quotes];
+        revised.RemoveAt(removeIndex);
+
+        IReadOnlyList<AtrResult> expectedAtr = revised.ToAtr(14);
+        IReadOnlyList<EmaResult> expectedEma = expectedAtr.ToEma(10);
+        IReadOnlyList<SmaResult> expectedSma = expectedEma.ToSma(5);
+
         atrHub.Results.Should().HaveCount(99);
-        emaHub.Results.Should().HaveCount(99);
-        smaHub.Results.Should().HaveCount(99);
+        atrHub.Results.IsExactly(expectedAtr);
+        emaHub.Results.IsExactly(expectedEma);
+        smaHub.Results.IsExactly(expectedSma);
 
         // Cleanup
         smaHub.Unsubscribe();

--- a/tests/indicators/_common/StreamHub/StreamHub.RollbackCoverage.Tests.cs
+++ b/tests/indicators/_common/StreamHub/StreamHub.RollbackCoverage.Tests.cs
@@ -1,0 +1,183 @@
+namespace Observables;
+
+/// <summary>
+/// Rollback-engine coverage for the aggregator hubs and through-aggregator
+/// chains that the generic catalog-driven rollback contract does not reach.
+/// <c>QuoteAggregatorHub</c>/<c>TickAggregatorHub</c> override
+/// <c>RollbackState</c>/<c>Rebuild</c> but are not catalog-registered, so they
+/// are exercised here directly; and a late arrival routed through an aggregator
+/// into a downstream indicator must converge to the same results as a fresh
+/// chain.
+/// </summary>
+[TestClass]
+public class RollbackCoverage : TestBase
+{
+    private const int TickCount = 500;
+
+    [TestMethod]
+    public void QuoteAggregator_AfterRebuild_MatchesFreshStreamAndBatch()
+    {
+        IReadOnlyList<Quote> quotes = Quotes.Take(500).ToList();
+        DateTime rollback = quotes[300].Timestamp;
+
+        // a hub that was rolled back mid-stream and replayed
+        QuoteHub providerA = new();
+        QuoteAggregatorHub aggA = providerA.ToQuoteAggregatorHub(PeriodSize.Week);
+        providerA.Add(quotes);
+        aggA.Rebuild(rollback);
+
+        // a fresh hub fed the same quotes once
+        QuoteHub providerB = new();
+        QuoteAggregatorHub aggB = providerB.ToQuoteAggregatorHub(PeriodSize.Week);
+        providerB.Add(quotes);
+
+        // independent batch oracle: the streamed aggregation (fresh or rebuilt)
+        // must equal the batch Aggregate — this upgrades the rollback-equivalence
+        // check to rollback-and-correctness
+        IReadOnlyList<Quote> batch = quotes.Aggregate(PeriodSize.Week);
+
+        aggA.Results.Should().NotBeEmpty();
+        aggB.Results.IsExactly(batch);
+        aggA.Results.IsExactly(aggB.Results);
+
+        aggA.Unsubscribe();
+        aggB.Unsubscribe();
+        providerA.EndTransmission();
+        providerB.EndTransmission();
+    }
+
+    [TestMethod]
+    public void TickAggregator_AfterRebuild_MatchesFreshStream()
+    {
+        List<Tick> ticks = BuildTicks(TickCount);
+        DateTime rollback = ticks[300].Timestamp;
+
+        TickHub providerA = new();
+        TickAggregatorHub aggA = providerA.ToTickAggregatorHub(PeriodSize.FifteenMinutes);
+        providerA.Add(ticks);
+        aggA.Rebuild(rollback);
+
+        TickHub providerB = new();
+        TickAggregatorHub aggB = providerB.ToTickAggregatorHub(PeriodSize.FifteenMinutes);
+        providerB.Add(ticks);
+
+        aggA.Results.Should().NotBeEmpty();
+        aggB.Results.Should().NotBeEmpty();
+        aggA.Results.IsExactly(aggB.Results);
+
+        aggA.Unsubscribe();
+        aggB.Unsubscribe();
+        providerA.EndTransmission();
+        providerB.EndTransmission();
+    }
+
+    [TestMethod]
+    public void QuoteHub_Aggregator_Ema_LateArrival_MatchesFreshChain()
+    {
+        const int total = 500;
+        const int skipIndex = 200;
+        const int emaPeriods = 5;
+
+        IReadOnlyList<Quote> quotes = Quotes.Take(total).ToList();
+
+        // late chain: feed all but one bar, then add it late so the correction
+        // rolls back through the aggregator and replays into the EMA
+        QuoteHub lateProvider = new();
+        QuoteAggregatorHub lateAgg = lateProvider.ToQuoteAggregatorHub(PeriodSize.Week);
+        EmaHub lateEma = lateAgg.ToEmaHub(emaPeriods);
+
+        for (int i = 0; i < total; i++)
+        {
+            if (i == skipIndex) { continue; }
+
+            lateProvider.Add(quotes[i]);
+        }
+
+        lateProvider.Add(quotes[skipIndex]);  // late arrival → rollback through the aggregator
+
+        // fresh chain: in-order oracle
+        QuoteHub freshProvider = new();
+        QuoteAggregatorHub freshAgg = freshProvider.ToQuoteAggregatorHub(PeriodSize.Week);
+        EmaHub freshEma = freshAgg.ToEmaHub(emaPeriods);
+
+        freshProvider.Add(quotes);
+
+        // Aggregator-level equality is the sensitive pin: a bucket's Volume is a
+        // sum, so a dropped or duplicated quote in the rollback replay diverges
+        // here even when the EMA (which sees only the bucket close) would not.
+        // The downstream EMA equality then confirms the correction propagates
+        // through the aggregator into the chained indicator.
+        lateAgg.Results.IsExactly(freshAgg.Results);
+
+        lateEma.Results.Should().NotBeEmpty();
+        freshEma.Results.Should().NotBeEmpty();
+        lateEma.Results.IsExactly(freshEma.Results);
+
+        lateEma.Unsubscribe();
+        lateAgg.Unsubscribe();
+        lateProvider.EndTransmission();
+        freshEma.Unsubscribe();
+        freshAgg.Unsubscribe();
+        freshProvider.EndTransmission();
+    }
+
+    [TestMethod]
+    public void TickHub_Aggregator_Ema_LateArrival_MatchesFreshChain()
+    {
+        const int skipIndex = 200;
+        const int emaPeriods = 5;
+
+        List<Tick> ticks = BuildTicks(TickCount);
+
+        TickHub lateProvider = new();
+        TickAggregatorHub lateAgg = lateProvider.ToTickAggregatorHub(PeriodSize.FifteenMinutes);
+        EmaHub lateEma = lateAgg.ToEmaHub(emaPeriods);
+
+        for (int i = 0; i < ticks.Count; i++)
+        {
+            if (i == skipIndex) { continue; }
+
+            lateProvider.Add(ticks[i]);
+        }
+
+        lateProvider.Add(ticks[skipIndex]);  // late arrival
+
+        TickHub freshProvider = new();
+        TickAggregatorHub freshAgg = freshProvider.ToTickAggregatorHub(PeriodSize.FifteenMinutes);
+        EmaHub freshEma = freshAgg.ToEmaHub(emaPeriods);
+
+        freshProvider.Add(ticks);
+
+        // aggregator-level equality is the sensitive pin (see the quote analog)
+        lateAgg.Results.IsExactly(freshAgg.Results);
+
+        lateEma.Results.Should().NotBeEmpty();
+        freshEma.Results.Should().NotBeEmpty();
+        lateEma.Results.IsExactly(freshEma.Results);
+
+        lateEma.Unsubscribe();
+        lateAgg.Unsubscribe();
+        lateProvider.EndTransmission();
+        freshEma.Unsubscribe();
+        freshAgg.Unsubscribe();
+        freshProvider.EndTransmission();
+    }
+
+    /// <summary>
+    /// Synthetic one-minute ticks with strictly increasing timestamps and a mild
+    /// deterministic wave so OHLC aggregation is non-trivial.
+    /// </summary>
+    private static List<Tick> BuildTicks(int count)
+    {
+        DateTime start = new(2023, 11, 9, 9, 30, 0, DateTimeKind.Utc);
+        List<Tick> ticks = new(count);
+
+        for (int i = 0; i < count; i++)
+        {
+            decimal price = 100m + (i % 37) - (i % 13);
+            ticks.Add(new Tick(start.AddMinutes(i), price, 10m + (i % 5)));
+        }
+
+        return ticks;
+    }
+}


### PR DESCRIPTION
## Summary

Adds rollback-engine coverage for the aggregator hubs and through-aggregator chains that the generic catalog-driven rollback contract (TC001) does not reach. Implements **TC-V31-4**, **TC-V31-8**, and **SR020** from `docs/plans/streaming-indicators.plan.md`.

## What's covered

`tests/indicators/_common/StreamHub/StreamHub.RollbackCoverage.Tests.cs` (new):

| Test | Pins |
| --- | --- |
| `QuoteAggregator_AfterRebuild_MatchesFreshStreamAndBatch` | `QuoteAggregatorHub` rolled back via `Rebuild(timestamp)` and replayed equals a freshly-fed hub **and** the batch `Aggregate` oracle (rollback-and-correctness) |
| `TickAggregator_AfterRebuild_MatchesFreshStream` | `TickAggregatorHub` rollback-equivalence |
| `QuoteHub_Aggregator_Ema_LateArrival_MatchesFreshChain` | late arrival through `QuoteHub → AggregatorHub → EmaHub` converges to a fresh in-order chain |
| `TickHub_Aggregator_Ema_LateArrival_MatchesFreshChain` | tick analog |

`StreamHub.BoundsChecking.Tests.cs` — `DeeplyChainedHubs_RemoveAndRebuild_ShouldNotThrow` → `…_MatchesSeries`: a cascading `RemoveAt` through `QuoteHub → Atr → Ema → Sma` now asserts **bit-for-bit equality vs the equivalent batch Series chain** at every level, not just the result count.

## Improvement over the abandoned reference

The reference late-arrival tests asserted only the downstream `EmaHub.Results`. I sabotage-tested that (never add the late quote) and it **passed** — EMA sees only the bucket *close*, so dropping a non-boundary quote leaves every downstream EMA value identical. That makes the EMA-only assertion blind to the exact dropped-notification regression TC-V31-8 targets.

Fix: assert at the **aggregator level** first (`lateAgg.Results.IsExactly(freshAgg.Results)`) — a bucket's `Volume` is a sum, so any dropped/duplicated quote in the replay diverges there — then keep the downstream EMA equality to confirm propagation. Re-running the sabotage now **fails** as intended (`Expected …Volume to be 273161956M, but found 230491136M`).

## Verification

- `dotnet build` with `TreatWarningsAsErrors=true`: 0 / 0
- `dotnet format --verify-no-changes --severity info`: clean
- `roslynator analyze --severity-level hidden`: 0 diagnostics
- New tests 4/4 + SR020 1/1; full `Observables` streaming suite 88/88
- Sabotage-verified the strengthened late-arrival assertion is sensitive

Cleanup uses the established bottom-up `Unsubscribe()` + root `EndTransmission()` idiom (no chain-wide disposal API — that work is deferred per #2068).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
