### PR TITLE
test(buffer): BufferList bounded-value parity (random-quote fuzz)

### DIFF
--- a/docs/plans/streaming-indicators.plan.md
+++ b/docs/plans/streaming-indicators.plan.md
@@ -172,7 +172,7 @@ The v3 streaming engine is the headline of this release after a long development
 - [ ] **TC-V31-4 — Aggregator-hub rollback-equivalence** (2 hours). `QuoteAggregatorHub`/`TickAggregatorHub` override `RollbackState` but aren't in the catalog, so TC001 doesn't exercise them; catalog-register or add two hand-built rollback-equivalence cases to `StreamHub.RollbackContract.Tests.cs`.
 - [ ] **SR020 — Deep-chain rebuild value-equality** (2 hours). `StreamHub.BoundsChecking.Tests.cs:810` asserts count/timestamp only after a chained `RemoveAt`; extend to `IsExactly` vs a Series-equivalent chain.
 - [ ] **TC-V31-8 — Chained-downstream late-arrival through an aggregator** (1–2 hours). `QuoteHub → AggregatorHub → EmaHub` (+ tick analog) late-arrival test; assert downstream `EmaHub.Results` bit-equality between late and fresh chains — catches a dropped-notification-per-replay regression.
-- [ ] **TC-V31-7 — BufferList bounded-value parity** (1–2 hours). Add `Boundary_WithRandomQuotes_StaysWithinBounds` to each bounded `*.BufferList.Tests.cs` (RSI/Stoch/Aroon/MFI/Ultimate/ConnorsRsi/WilliamsR), matching the Series + StreamHub coverage.
+- [x] **TC-V31-7 — BufferList bounded-value parity** (1–2 hours). Add `Boundary_WithRandomQuotes_StaysWithinBounds` to each bounded `*.BufferList.Tests.cs` (RSI/Stoch/Aroon/MFI/Ultimate/ConnorsRsi/WilliamsR), matching the Series + StreamHub coverage. *(PR #2072)*
 
 #### ⚠️ Pending maintainer decisions — highlighted, NOT in the next batch
 
@@ -304,7 +304,7 @@ Non-blocking items from the same swarm review; the stable-blocking subset is in 
   - Source: Discussion #1018 @elAndyG. Companion to T236 (`GapFillMode` enum) and G008 (docs).
   - Add tests under `tests/indicators/_common/Quotes/Quote.AggregatorHub.Tests.cs`: synthesized tick sequences with intentional gaps (e.g., missing 1-minute bars during low-volume periods); assert behavior under each future `GapFillMode` value (None/ForwardFill/Interpolate). Today the test gap is in §D TC005 (boundary tests) — TC-V31-6 extends that pattern once T236 ships. Distinct from TC-V31-4 (which covers rollback equivalence on the aggregator hubs themselves).
 
-- [ ] **TC-V31-7 — BufferList parity for bounded-value invariant tests** (1–2 hours).
+- [x] **TC-V31-7 — BufferList parity for bounded-value invariant tests** (1–2 hours). *(PR #2072 — see §L)*
   - Source: PR #2021 scope decision. The bounded-value invariant work (RSI, Stoch, Aroon, MFI, Ultimate, ConnorsRSI, WilliamsR) shipped Series + StreamHub coverage but skipped BufferList. The math is identical across all three styles, so a BufferList violation would be a regression bug rather than an algorithmic edge case; still, a symmetry pass closes the contract.
   - Add `Boundary_WithRandomQuotes_StaysWithinBounds` to each `*.BufferList.Tests.cs` sibling using `Data.GetRandom(2500)`, matching the Series and StreamHub pattern.
 

--- a/tests/indicators/a-d/Aroon/Aroon.BufferList.Tests.cs
+++ b/tests/indicators/a-d/Aroon/Aroon.BufferList.Tests.cs
@@ -9,6 +9,18 @@ public class Aroon : BufferListTestBase
         = Quotes.ToAroon(lookbackPeriods);
 
     [TestMethod]
+    public void Boundary_WithRandomQuotes_StaysWithinBounds()
+    {
+        IReadOnlyList<AroonResult> sut = Data
+            .GetRandom(2500)
+            .ToAroonList(25);
+
+        sut.IsBetween(static x => x.AroonUp, 0d, 100d);
+        sut.IsBetween(static x => x.AroonDown, 0d, 100d);
+        sut.IsBetween(static x => x.Oscillator, -100d, 100d);
+    }
+
+    [TestMethod]
     public void Results_AreAlwaysBounded()
     {
         AroonList sut = new(25, Quotes);

--- a/tests/indicators/a-d/ConnorsRsi/ConnorsRsi.BufferList.Tests.cs
+++ b/tests/indicators/a-d/ConnorsRsi/ConnorsRsi.BufferList.Tests.cs
@@ -16,6 +16,16 @@ public class ConnorsRsi : BufferListTestBase, ITestChainBufferList
        = Quotes.ToConnorsRsi(rsiPeriods, streakPeriods, rankPeriods);
 
     [TestMethod]
+    public void Boundary_WithRandomQuotes_StaysWithinBounds()
+    {
+        IReadOnlyList<ConnorsRsiResult> sut = Data
+            .GetRandom(2500)
+            .ToConnorsRsiList(3, 2, 100);
+
+        sut.IsBetween(static x => x.ConnorsRsi, 0d, 100d);
+    }
+
+    [TestMethod]
     public void AddQuote_IncrementsResults()
     {
         ConnorsRsiList sut = new(rsiPeriods, streakPeriods, rankPeriods);

--- a/tests/indicators/m-r/Mfi/Mfi.BufferList.Tests.cs
+++ b/tests/indicators/m-r/Mfi/Mfi.BufferList.Tests.cs
@@ -9,6 +9,16 @@ public class Mfi : BufferListTestBase
        = Quotes.ToMfi(lookbackPeriods);
 
     [TestMethod]
+    public void Boundary_WithRandomQuotes_StaysWithinBounds()
+    {
+        IReadOnlyList<MfiResult> sut = Data
+            .GetRandom(2500)
+            .ToMfiList(14);
+
+        sut.IsBetween(static x => x.Mfi, 0d, 100d);
+    }
+
+    [TestMethod]
     public void Results_WithAnyInput_AreAlwaysBounded()
     {
         MfiList sut = new(14, Quotes);

--- a/tests/indicators/m-r/Rsi/Rsi.BufferList.Tests.cs
+++ b/tests/indicators/m-r/Rsi/Rsi.BufferList.Tests.cs
@@ -14,6 +14,16 @@ public class Rsi : BufferListTestBase, ITestChainBufferList
        = Quotes.ToRsi(lookbackPeriods);
 
     [TestMethod]
+    public void Boundary_WithRandomQuotes_StaysWithinBounds()
+    {
+        IReadOnlyList<RsiResult> sut = Data
+            .GetRandom(2500)
+            .ToRsiList(14);
+
+        sut.IsBetween(static x => x.Rsi, 0d, 100d);
+    }
+
+    [TestMethod]
     public void AddQuote_IncrementsResults()
     {
         RsiList sut = new(lookbackPeriods);

--- a/tests/indicators/s-z/Stoch/Stoch.BufferList.Tests.cs
+++ b/tests/indicators/s-z/Stoch/Stoch.BufferList.Tests.cs
@@ -14,6 +14,18 @@ public class Stoch : BufferListTestBase
        = Quotes.ToStoch(lookbackPeriods, signalPeriods, smoothPeriods);
 
     [TestMethod]
+    public void Boundary_WithRandomQuotes_StaysWithinBounds()
+    {
+        // %J is unbounded by design so not asserted.
+        IReadOnlyList<StochResult> sut = Data
+            .GetRandom(2500)
+            .ToStochList(14, 3, 3);
+
+        sut.IsBetween(static x => x.Oscillator, 0d, 100d);
+        sut.IsBetween(static x => x.Signal, 0d, 100d);
+    }
+
+    [TestMethod]
     public void AddQuotes_WithValidQuotes_IncrementsResults()
     {
         StochList sut = new(lookbackPeriods, signalPeriods, smoothPeriods);

--- a/tests/indicators/s-z/Ultimate/Ultimate.BufferList.Tests.cs
+++ b/tests/indicators/s-z/Ultimate/Ultimate.BufferList.Tests.cs
@@ -11,6 +11,16 @@ public class Ultimate : BufferListTestBase
        = Quotes.ToUltimate(shortPeriods, middlePeriods, longPeriods);
 
     [TestMethod]
+    public void Boundary_WithRandomQuotes_StaysWithinBounds()
+    {
+        IReadOnlyList<UltimateResult> sut = Data
+            .GetRandom(2500)
+            .ToUltimateList(7, 14, 28);
+
+        sut.IsBetween(static x => x.Ultimate, 0d, 100d);
+    }
+
+    [TestMethod]
     public void Results_AreAlwaysBounded()
     {
         UltimateList sut = new(7, 14, 28, Quotes);

--- a/tests/indicators/s-z/WilliamsR/WilliamsR.BufferList.Tests.cs
+++ b/tests/indicators/s-z/WilliamsR/WilliamsR.BufferList.Tests.cs
@@ -9,6 +9,16 @@ public class WilliamsR : BufferListTestBase
        = Quotes.ToWilliamsR(lookbackPeriods);
 
     [TestMethod]
+    public void Boundary_WithRandomQuotes_StaysWithinBounds()
+    {
+        IReadOnlyList<WilliamsResult> sut = Data
+            .GetRandom(2500)
+            .ToWilliamsRList(14);
+
+        sut.IsBetween(static x => x.WilliamsR, -100d, 0d);
+    }
+
+    [TestMethod]
     public void AddQuotes_WithValidQuotes_IncrementsResults()
     {
         WilliamsRList sut = new(lookbackPeriods);


### PR DESCRIPTION
## Summary

Completes the bounded-value invariant contract across all three indicator styles. Implements **TC-V31-7** from `docs/plans/streaming-indicators.plan.md`.

The bounded-value work (RSI, Stoch, Aroon, MFI, Ultimate, ConnorsRsi, WilliamsR) already shipped **two** bounds tests in the **Series** and **StreamHub** styles:
- `Results_AreAlwaysBounded` — default fixture (real-data regression)
- `Boundary_WithRandomQuotes_StaysWithinBounds` — `Data.GetRandom(2500)` (random-walk fuzz)

The **BufferList** style had only the first. This PR adds the random-walk half to each of the 7 BufferList suites, mirroring the other styles' bounds and parameters exactly.

## Tests added (one per file)

| Indicator | Bounds asserted |
| --- | --- |
| Aroon | AroonUp/AroonDown `[0,100]`, Oscillator `[-100,100]` |
| ConnorsRsi | ConnorsRsi `[0,100]` |
| Mfi | Mfi `[0,100]` |
| Rsi | Rsi `[0,100]` |
| Stoch | Oscillator/Signal `[0,100]` (%J unbounded — not asserted) |
| Ultimate | Ultimate `[0,100]` |
| WilliamsR | WilliamsR `[-100,0]` |

## Not a duplicate

Each file already had a default-fixture `Results_AreAlwaysBounded`; this is the **random-walk** companion that Series and StreamHub both carry. I verified the gap directly (Series/StreamHub keep both tests; BufferList kept only the default one) before adding, and sabotage-checked sensitivity (tightening the RSI bound to `[0,50]` fails with `found 69.04`), confirming the random data is non-vacuous.

## Verification

- `dotnet build` with `TreatWarningsAsErrors=true`: 0 / 0
- `dotnet format --verify-no-changes --severity info`: clean
- `roslynator analyze --severity-level hidden`: 0 diagnostics
- 7 new tests pass; full BufferLists suite 562/562

🤖 Generated with [Claude Code](https://claude.com/claude-code)
