### PR TITLE
perf: Optimize memory/GC and reduce API surface in BufferList and StreamHub

### DIFF
--- a/src/_common/BufferLists/BufferList.Utilities.cs
+++ b/src/_common/BufferLists/BufferList.Utilities.cs
@@ -3,7 +3,7 @@ namespace Skender.Stock.Indicators;
 /// <summary>
 /// Utility and extension methods for <see cref="BufferList{T}"/> implementations.
 /// </summary>
-public static class BufferListUtilities
+internal static class BufferListUtilities
 {
     /// <summary>
     /// Updates a rolling buffer by removing the oldest value when at capacity and adding a new value.

--- a/src/_common/BufferLists/BufferList.cs
+++ b/src/_common/BufferLists/BufferList.cs
@@ -36,9 +36,6 @@ public abstract class BufferList<TResult> : IReadOnlyList<TResult>
     /// <inheritdoc/>
     public int Count => _internalList.Count;
 
-    /// <inheritdoc/>
-    public bool IsReadOnly => true;
-
     /// <summary>
     /// Gets the name of the buffer list.
     /// </summary>
@@ -104,12 +101,6 @@ public abstract class BufferList<TResult> : IReadOnlyList<TResult>
 
         _internalList[index] = item;
     }
-
-    /// <summary>
-    /// Removes the item at the specified index from the internal list.
-    /// </summary>
-    /// <param name="index">Zero-based index of the item to remove.</param>
-    protected void RemoveAt(int index) => _internalList.RemoveAt(index);
 
     /// <summary>
     /// Removes the oldest results when the list exceeds <see cref="MaxListSize"/>.

--- a/src/_common/BufferLists/IIncrementFromChain.cs
+++ b/src/_common/BufferLists/IIncrementFromChain.cs
@@ -7,7 +7,7 @@ namespace Skender.Stock.Indicators;
 /// This patterns supports chainable indicators that can be calculated from single values.
 /// Examples: TR, RSI, moving averages, and others.
 /// </remarks>
-public interface IIncrementFromChain
+internal interface IIncrementFromChain
 {
     /// <summary>
     /// Apply new reusable input value to increment indicator list values.

--- a/src/_common/BufferLists/IIncrementFromQuote.cs
+++ b/src/_common/BufferLists/IIncrementFromQuote.cs
@@ -7,7 +7,7 @@ namespace Skender.Stock.Indicators;
 /// This patterns supports indicators that can only be calculated from OHLCV quotes.
 /// Examples: TR, RSI, moving averages, and others.
 /// </remarks>
-public interface IIncrementFromQuote
+internal interface IIncrementFromQuote
 {
     /// <summary>
     /// Apply new quote to increment indicator list values.

--- a/src/_common/Quotes/Quote.AggregatorHub.cs
+++ b/src/_common/Quotes/Quote.AggregatorHub.cs
@@ -277,11 +277,29 @@ public class QuoteAggregatorHub
 
         DateTime barTimestamp = item.Timestamp.RoundDown(AggregationPeriod);
 
-        int index = indexHint ?? Cache.IndexGte(barTimestamp);
-
-        if (index == -1)
+        // bar fast path: quotes nearly always land on the forming (last) bar
+        // or open a new one; skip the binary search for both cases
+        int index;
+        if (indexHint.HasValue)
+        {
+            index = indexHint.Value;
+        }
+        else if (Cache.Count == 0 || barTimestamp > Cache[^1].Timestamp)
         {
             index = Cache.Count;
+        }
+        else if (barTimestamp == Cache[^1].Timestamp)
+        {
+            index = Cache.Count - 1;
+        }
+        else
+        {
+            index = Cache.IndexGte(barTimestamp);
+
+            if (index == -1)
+            {
+                index = Cache.Count;
+            }
         }
 
         return (item, index);

--- a/src/_common/Quotes/Quote.StreamHub.cs
+++ b/src/_common/Quotes/Quote.StreamHub.cs
@@ -56,6 +56,14 @@ public class QuoteHub
     {
         ArgumentNullException.ThrowIfNull(item);
 
+        // append fast path: live feeds almost always deliver new quotes,
+        // so skip the binary search when the item extends the timeline
+        if (indexHint is null
+            && (Cache.Count == 0 || item.Timestamp > Cache[^1].Timestamp))
+        {
+            return (item, Cache.Count);
+        }
+
         int index = indexHint
             ?? Cache.IndexGte(item.Timestamp);
 

--- a/src/_common/Quotes/Tick.AggregatorHub.cs
+++ b/src/_common/Quotes/Tick.AggregatorHub.cs
@@ -131,14 +131,15 @@ public class TickAggregatorHub
                 if (_processedExecutionIds.Count > (maxExecutionIdCacheSize / 2))
                 {
                     DateTime pruneThreshold = item.Timestamp.Add(-_executionIdRetentionPeriod);
-                    List<string> toRemove = _processedExecutionIds
-                        .Where(kvp => kvp.Value < pruneThreshold)
-                        .Select(kvp => kvp.Key)
-                        .ToList();
 
-                    foreach (string key in toRemove)
+                    // Dictionary<TKey,TValue> supports Remove during enumeration,
+                    // avoiding a per-tick list allocation on this hot path
+                    foreach (KeyValuePair<string, DateTime> entry in _processedExecutionIds)
                     {
-                        _processedExecutionIds.Remove(key);
+                        if (entry.Value < pruneThreshold)
+                        {
+                            _processedExecutionIds.Remove(entry.Key);
+                        }
                     }
                 }
 

--- a/src/_common/Quotes/Tick.AggregatorHub.cs
+++ b/src/_common/Quotes/Tick.AggregatorHub.cs
@@ -143,18 +143,42 @@ public class TickAggregatorHub
                     }
                 }
 
-                // Hard limit: if still too large after pruning, remove oldest entries
+                // Hard limit: if still too large after pruning, remove oldest entries.
+                // A sorted-timestamp threshold replaces the former
+                // OrderBy/Take/Select/ToList chain: one array allocation
+                // instead of four intermediate collections on this
+                // emergency overflow path.
                 if (_processedExecutionIds.Count > maxExecutionIdCacheSize)
                 {
-                    List<string> toRemove = _processedExecutionIds
-                        .OrderBy(kvp => kvp.Value)
-                        .Take(_processedExecutionIds.Count - (maxExecutionIdCacheSize / 2))
-                        .Select(kvp => kvp.Key)
-                        .ToList();
+                    int removeCount = _processedExecutionIds.Count - (maxExecutionIdCacheSize / 2);
 
-                    foreach (string key in toRemove)
+                    DateTime[] timestamps = new DateTime[_processedExecutionIds.Count];
+                    _processedExecutionIds.Values.CopyTo(timestamps, 0);
+                    Array.Sort(timestamps);
+                    DateTime threshold = timestamps[removeCount - 1];
+
+                    // remove all entries older than the threshold, then trim
+                    // threshold-equal entries until the quota is met
+                    int removed = 0;
+                    foreach (KeyValuePair<string, DateTime> entry in _processedExecutionIds)
                     {
-                        _processedExecutionIds.Remove(key);
+                        if (entry.Value < threshold && _processedExecutionIds.Remove(entry.Key))
+                        {
+                            removed++;
+                        }
+                    }
+
+                    foreach (KeyValuePair<string, DateTime> entry in _processedExecutionIds)
+                    {
+                        if (removed >= removeCount)
+                        {
+                            break;
+                        }
+
+                        if (entry.Value == threshold && _processedExecutionIds.Remove(entry.Key))
+                        {
+                            removed++;
+                        }
                     }
                 }
             }
@@ -270,11 +294,29 @@ public class TickAggregatorHub
 
         DateTime barTimestamp = item.Timestamp.RoundDown(AggregationPeriod);
 
-        int index = indexHint ?? Cache.IndexGte(barTimestamp);
-
-        if (index == -1)
+        // bar fast path: ticks nearly always land on the forming (last) bar
+        // or open a new one; skip the binary search for both cases
+        int index;
+        if (indexHint.HasValue)
+        {
+            index = indexHint.Value;
+        }
+        else if (Cache.Count == 0 || barTimestamp > Cache[^1].Timestamp)
         {
             index = Cache.Count;
+        }
+        else if (barTimestamp == Cache[^1].Timestamp)
+        {
+            index = Cache.Count - 1;
+        }
+        else
+        {
+            index = Cache.IndexGte(barTimestamp);
+
+            if (index == -1)
+            {
+                index = Cache.Count;
+            }
         }
 
         // Convert tick to a single-price bar

--- a/src/_common/Quotes/Tick.StreamHub.cs
+++ b/src/_common/Quotes/Tick.StreamHub.cs
@@ -61,16 +61,19 @@ public class TickHub
 
         // append fast path: live feeds almost always deliver new ticks,
         // so skip the binary search when the item extends the timeline
-        if (indexHint is null
-            && (Cache.Count == 0 || item.Timestamp > Cache[^1].Timestamp))
+        lock (CacheLock)
         {
-            return (item, Cache.Count);
+            if (indexHint is null
+                && (Cache.Count == 0 || item.Timestamp > Cache[^1].Timestamp))
+            {
+                return (item, Cache.Count);
+            }
+
+            int index = indexHint
+                ?? Cache.IndexGte(item.Timestamp);
+
+            return (item, index == -1 ? Cache.Count : index);
         }
-
-        int index = indexHint
-            ?? Cache.IndexGte(item.Timestamp);
-
-        return (item, index == -1 ? Cache.Count : index);
     }
 
     /// <inheritdoc/>

--- a/src/_common/Quotes/Tick.StreamHub.cs
+++ b/src/_common/Quotes/Tick.StreamHub.cs
@@ -59,6 +59,14 @@ public class TickHub
     {
         ArgumentNullException.ThrowIfNull(item);
 
+        // append fast path: live feeds almost always deliver new ticks,
+        // so skip the binary search when the item extends the timeline
+        if (indexHint is null
+            && (Cache.Count == 0 || item.Timestamp > Cache[^1].Timestamp))
+        {
+            return (item, Cache.Count);
+        }
+
         int index = indexHint
             ?? Cache.IndexGte(item.Timestamp);
 

--- a/src/_common/StreamHub/Providers/BaseProvider.cs
+++ b/src/_common/StreamHub/Providers/BaseProvider.cs
@@ -23,7 +23,7 @@ internal interface IInertProvider;
 /// Only used to initialize a <see cref="QuoteHub"/> base that does not have its own provider.
 /// </remarks>
 /// <param name="maxCacheSize">Maximum cache size for the provider.</param>
-public class BaseProvider<T>(int maxCacheSize = 0)
+internal class BaseProvider<T>(int maxCacheSize = 0)
     : IStreamObservable<T>, IInertProvider
     where T : IReusable
 {

--- a/src/_common/StreamHub/RollbackRing.cs
+++ b/src/_common/StreamHub/RollbackRing.cs
@@ -38,6 +38,12 @@ internal sealed class RollbackRing<TState>
     /// <param name="capacity">Maximum retained snapshots.</param>
     internal RollbackRing(int capacity = defaultCapacity)
     {
+        if (capacity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(capacity), capacity,
+                "Capacity must be greater than 0.");
+        }
+
         _capacity = capacity;
         _timestamps = new DateTime[capacity];
         _states = new TState[capacity];

--- a/src/_common/StreamHub/RollbackRing.cs
+++ b/src/_common/StreamHub/RollbackRing.cs
@@ -1,0 +1,106 @@
+namespace Skender.Stock.Indicators;
+
+/// <summary>
+/// Fixed-size ring of recent <c>(timestamp, state)</c> snapshots that makes
+/// <see cref="StreamHub{TIn, TOut}.RollbackState(int)"/> O(1) for near-tail
+/// rollbacks — the dominant case for live feeds, where corrections target
+/// recent bars and aggregators re-send the forming bar on every tick.
+/// </summary>
+/// <remarks>
+/// A hub records a snapshot of its internal state after processing each item.
+/// On rollback, the state for the restore point is recovered from the ring
+/// by timestamp — bit-exact, because it is the very value the live
+/// computation produced — and only rollbacks deeper than the ring's capacity
+/// fall back to the indicator's full state replay.
+/// <para>
+/// Adding with the same timestamp as the newest entry replaces that entry,
+/// so repeated forming-bar updates (and same-timestamp duplicates from
+/// providers like Renko) occupy a single slot and cannot flush the ring.
+/// Lookups scan newest-first, so re-recorded states after a replay shadow
+/// any stale older entries for the same timestamp.
+/// </para>
+/// </remarks>
+/// <typeparam name="TState">Snapshot value, typically a small struct.</typeparam>
+internal sealed class RollbackRing<TState>
+{
+    private const int defaultCapacity = 32;
+
+    private readonly DateTime[] _timestamps;
+    private readonly TState[] _states;
+    private readonly int _capacity;
+
+    private int _next;  // next write position
+    private int _count; // filled entries
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RollbackRing{TState}"/> class.
+    /// </summary>
+    /// <param name="capacity">Maximum retained snapshots.</param>
+    internal RollbackRing(int capacity = defaultCapacity)
+    {
+        _capacity = capacity;
+        _timestamps = new DateTime[capacity];
+        _states = new TState[capacity];
+    }
+
+    /// <summary>
+    /// Records a snapshot, replacing the newest entry when the timestamp
+    /// repeats (forming-bar updates, same-timestamp duplicates).
+    /// </summary>
+    /// <param name="timestamp">Timestamp of the processed item.</param>
+    /// <param name="state">State after processing the item.</param>
+    internal void Add(DateTime timestamp, in TState state)
+    {
+        if (_count > 0)
+        {
+            int newest = (_next - 1 + _capacity) % _capacity;
+
+            if (_timestamps[newest] == timestamp)
+            {
+                _states[newest] = state;
+                return;
+            }
+        }
+
+        _timestamps[_next] = timestamp;
+        _states[_next] = state;
+        _next = (_next + 1) % _capacity;
+
+        if (_count < _capacity)
+        {
+            _count++;
+        }
+    }
+
+    /// <summary>
+    /// Finds the newest snapshot recorded for <paramref name="timestamp"/>.
+    /// </summary>
+    /// <param name="timestamp">Restore-point timestamp to find.</param>
+    /// <param name="state">Recovered state, when found.</param>
+    /// <returns>True when a snapshot was found.</returns>
+    internal bool TryGet(DateTime timestamp, out TState state)
+    {
+        for (int back = 1; back <= _count; back++)
+        {
+            int index = (_next - back + _capacity) % _capacity;
+
+            if (_timestamps[index] == timestamp)
+            {
+                state = _states[index];
+                return true;
+            }
+        }
+
+        state = default!;
+        return false;
+    }
+
+    /// <summary>
+    /// Removes all snapshots.
+    /// </summary>
+    internal void Clear()
+    {
+        _next = 0;
+        _count = 0;
+    }
+}

--- a/src/_common/StreamHub/StreamHub.Observable.cs
+++ b/src/_common/StreamHub/StreamHub.Observable.cs
@@ -18,6 +18,15 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamObservable<TOut>
     private readonly object _observersLock = new();
 
     /// <summary>
+    /// Cached point-in-time copy of <see cref="_observers"/>, rebuilt lazily by
+    /// <see cref="SnapshotObservers"/> and invalidated (under the lock) whenever
+    /// the subscriber set changes. Notification fan-out runs once per cached
+    /// item across four notify paths, so reusing the snapshot avoids an array
+    /// allocation per event when subscriptions are stable (the common case).
+    /// </summary>
+    private IStreamObserver<TOut>[]? _observersSnapshot;
+
+    /// <summary>
     /// Baseline minimum cache size requirement for this hub (set by ValidateCacheSize).
     /// </summary>
     private int _minCacheSizeBaseline;
@@ -62,7 +71,8 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamObservable<TOut>
     {
         lock (_observersLock)
         {
-            return _observers.Count == 0 ? [] : [.. _observers];
+            return _observersSnapshot ??=
+                _observers.Count == 0 ? [] : [.. _observers];
         }
     }
 
@@ -71,7 +81,10 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamObservable<TOut>
     {
         lock (_observersLock)
         {
-            _observers.Add(observer);
+            if (_observers.Add(observer))
+            {
+                _observersSnapshot = null;
+            }
         }
 
         // Update MinCacheSize to the maximum of all subscribers
@@ -87,6 +100,10 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamObservable<TOut>
         lock (_observersLock)
         {
             removed = _observers.Remove(observer);
+            if (removed)
+            {
+                _observersSnapshot = null;
+            }
         }
 
         // Re-evaluate MinCacheSize after unsubscribing
@@ -131,6 +148,7 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamObservable<TOut>
 
             snapshot = [.. _observers];
             _observers.Clear();
+            _observersSnapshot = null;
 
             // Reset to baseline when all subscribers are removed
             MinCacheSize = _minCacheSizeBaseline;
@@ -177,7 +195,7 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamObservable<TOut>
     /// </summary>
     /// <param name="item"><c>TSeries</c> item to send.</param>
     /// <param name="indexHint">Provider index hint.</param>
-    protected void NotifyObserversOnAdd(TOut item, int? indexHint)
+    private protected void NotifyObserversOnAdd(TOut item, int? indexHint)
     {
         foreach (IStreamObserver<TOut> o in SnapshotObservers())
         {
@@ -196,7 +214,7 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamObservable<TOut>
     /// Sends rebuilds point in time to all subscribers.
     /// </summary>
     /// <param name="fromTimestamp">Rebuild starting date.</param>
-    protected void NotifyObserversOnRebuild(DateTime fromTimestamp)
+    private protected void NotifyObserversOnRebuild(DateTime fromTimestamp)
     {
         foreach (IStreamObserver<TOut> o in SnapshotObservers())
         {

--- a/src/_common/StreamHub/StreamHub.Observer.cs
+++ b/src/_common/StreamHub/StreamHub.Observer.cs
@@ -90,10 +90,17 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamObserver<TIn>
             // Only prune if this hub participates in provider-driven pruning
             if (ShouldPruneOnProviderPrune)
             {
-                while (Cache.Count > 0 && Cache[0].Timestamp <= toTimestamp)
+                // count, then remove in one operation: per-item RemoveAt(0)
+                // shifts the whole backing array on every removal
+                while (removedCount < Cache.Count
+                    && Cache[removedCount].Timestamp <= toTimestamp)
                 {
-                    Cache.RemoveAt(0);
                     removedCount++;
+                }
+
+                if (removedCount > 0)
+                {
+                    Cache.RemoveRange(0, removedCount);
                 }
             }
 

--- a/src/_common/StreamHub/StreamHub.Utilities.cs
+++ b/src/_common/StreamHub/StreamHub.Utilities.cs
@@ -3,7 +3,7 @@ namespace Skender.Stock.Indicators;
 /// <summary>
 /// Provides static utility methods for stream hub operations.
 /// </summary>
-public static class StreamHub
+internal static class StreamHub
 {
     /// <summary>
     /// Try to find index position of the provided timestamp.

--- a/src/_common/StreamHub/StreamHub.cs
+++ b/src/_common/StreamHub/StreamHub.cs
@@ -13,7 +13,7 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamHub<TIn, TOut>
     /// This protects against concurrent cache modifications when out-of-order
     /// data triggers rebuild operations.
     /// </summary>
-    protected object CacheLock { get; } = new();
+    private protected object CacheLock { get; } = new();
 
     /// <summary>
     /// Prevents self-recursion: during rebuild, OnAdd calls AppendCache,
@@ -44,10 +44,9 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamHub<TIn, TOut>
         MaxCacheSize = provider.MaxCacheSize;
 
         // pre-allocate cache if reasonable size
-        if (MaxCacheSize is > 0 and < 10_000)
-        {
-            Cache = new List<TOut>(MaxCacheSize);
-        }
+        Cache = MaxCacheSize is > 0 and < 10_000
+            ? new List<TOut>(MaxCacheSize)
+            : new List<TOut>(800);
 
         // build read-only cache reference
         Results = Cache.AsReadOnly();
@@ -115,7 +114,7 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamHub<TIn, TOut>
     /// <summary>
     /// Gets the cache of stored values (base).
     /// </summary>
-    internal List<TOut> Cache { get; } = new List<TOut>(800);
+    internal List<TOut> Cache { get; }
 
     /// <summary>
     /// Gets the current count of repeated caching attempts.
@@ -210,7 +209,35 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamHub<TIn, TOut>
     public void Add(IEnumerable<TIn> batchIn)
     {
         ThrowIfNotRootHub();
-        foreach (TIn newIn in batchIn.OrderBy(static x => x.Timestamp))
+
+        // fast path: streaming batches are almost always pre-sorted, so
+        // skip the O(n) sort allocation (keys + map + buffer) when a single
+        // scan confirms chronological order; OrderBy is kept for the
+        // unsorted case because its stable sort preserves same-timestamp
+        // arrival order
+        List<TIn> items = batchIn as List<TIn> ?? [.. batchIn];
+
+        bool isSorted = true;
+        for (int i = 1; i < items.Count; i++)
+        {
+            if (items[i].Timestamp < items[i - 1].Timestamp)
+            {
+                isSorted = false;
+                break;
+            }
+        }
+
+        if (isSorted)
+        {
+            foreach (TIn newIn in items)
+            {
+                OnAdd(newIn, notify: true, null);
+            }
+
+            return;
+        }
+
+        foreach (TIn newIn in items.OrderBy(static x => x.Timestamp))
         {
             OnAdd(newIn, notify: true, null);
         }
@@ -281,8 +308,14 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamHub<TIn, TOut>
         // rollback internal state
         RollbackState(restoreIndex);
 
-        // remove cache entries
-        Cache.RemoveAll(c => c.Timestamp >= fromTimestamp);
+        // remove cache entries: the cache is chronological, so a binary
+        // search + RemoveRange avoids the full predicate scan and the
+        // per-call closure allocation of List.RemoveAll
+        int cacheGteIndex = Cache.IndexGte(fromTimestamp);
+        if (cacheGteIndex >= 0)
+        {
+            Cache.RemoveRange(cacheGteIndex, Cache.Count - cacheGteIndex);
+        }
 
         // reset LastItem to prevent IsOverflowing from incorrectly detecting
         // duplicates when rebuilding (the new items may have same timestamp

--- a/src/_common/StreamHub/StreamHub.cs
+++ b/src/_common/StreamHub/StreamHub.cs
@@ -43,10 +43,11 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamHub<TIn, TOut>
         // inherit max cache size from provider
         MaxCacheSize = provider.MaxCacheSize;
 
-        // pre-allocate cache if reasonable size
-        Cache = MaxCacheSize is > 0 and < 10_000
-            ? new List<TOut>(MaxCacheSize)
-            : new List<TOut>(800);
+        // start the cache empty and let List<T> growth amortize: a fixed
+        // pre-allocation (formerly 800 slots, ~6.4KB per hub) dominates the
+        // footprint of multi-symbol deployments with thousands of hubs,
+        // while growth-on-demand costs only a handful of one-time copies
+        Cache = [];
 
         // build read-only cache reference
         Results = Cache.AsReadOnly();

--- a/src/a-d/Adx/Adx.StreamHub.cs
+++ b/src/a-d/Adx/Adx.StreamHub.cs
@@ -61,10 +61,7 @@ public class AdxHub
     private double _sumMdm;
     private double _sumDx;
 
-    /// <summary>
-    /// Snapshot of all mutable scalar state, recorded after each item
-    /// for O(1) near-tail rollback.
-    /// </summary>
+    // snapshot of mutable scalar state, recorded after each item for O(1) near-tail rollback
     private readonly record struct AdxState(
         bool IsFirstPeriod,
         double PrevHigh,

--- a/src/a-d/Adx/Adx.StreamHub.cs
+++ b/src/a-d/Adx/Adx.StreamHub.cs
@@ -61,6 +61,26 @@ public class AdxHub
     private double _sumMdm;
     private double _sumDx;
 
+    /// <summary>
+    /// Snapshot of all mutable scalar state, recorded after each item
+    /// for O(1) near-tail rollback.
+    /// </summary>
+    private readonly record struct AdxState(
+        bool IsFirstPeriod,
+        double PrevHigh,
+        double PrevLow,
+        double PrevClose,
+        double PrevTrs,
+        double PrevPdm,
+        double PrevMdm,
+        double PrevAdx,
+        double SumTr,
+        double SumPdm,
+        double SumMdm,
+        double SumDx);
+
+    // recent state snapshots for O(1) near-tail rollback
+    private readonly RollbackRing<AdxState> _rollback = new();
 
     /// <inheritdoc/>
     public override string ToString() => Cache.Count > 0
@@ -86,6 +106,9 @@ public class AdxHub
             _prevLow = low;
             _prevClose = close;
             _isFirstPeriod = false;
+
+            // snapshot state for O(1) near-tail rollback
+            _rollback.Add(item.Timestamp, CaptureState());
 
             return (new AdxResult(item.Timestamp), i);
         }
@@ -189,6 +212,9 @@ public class AdxHub
         _prevLow = low;
         _prevClose = close;
 
+        // snapshot state for O(1) near-tail rollback
+        _rollback.Add(item.Timestamp, CaptureState());
+
         AdxResult result = new(
             item.Timestamp,
             pdi,
@@ -222,6 +248,17 @@ public class AdxHub
 
         if (restoreIndex < 0)
         {
+            return;
+        }
+
+        // O(1) fast path: restore the exact state snapshot recorded when the
+        // restore-point item was processed (near-tail rollbacks, the common
+        // case for live corrections and forming-bar updates)
+        if (_rollback.TryGet(
+            ProviderCache[restoreIndex].Timestamp,
+            out AdxState snapshot))
+        {
+            RestoreState(snapshot);
             return;
         }
 
@@ -314,6 +351,39 @@ public class AdxHub
             _prevLow = low;
             _prevClose = close;
         }
+    }
+
+    // Captures all mutable scalar state for rollback snapshots.
+    private AdxState CaptureState()
+        => new(
+            _isFirstPeriod,
+            _prevHigh,
+            _prevLow,
+            _prevClose,
+            _prevTrs,
+            _prevPdm,
+            _prevMdm,
+            _prevAdx,
+            _sumTr,
+            _sumPdm,
+            _sumMdm,
+            _sumDx);
+
+    // Restores all mutable scalar state from a rollback snapshot.
+    private void RestoreState(in AdxState snapshot)
+    {
+        _isFirstPeriod = snapshot.IsFirstPeriod;
+        _prevHigh = snapshot.PrevHigh;
+        _prevLow = snapshot.PrevLow;
+        _prevClose = snapshot.PrevClose;
+        _prevTrs = snapshot.PrevTrs;
+        _prevPdm = snapshot.PrevPdm;
+        _prevMdm = snapshot.PrevMdm;
+        _prevAdx = snapshot.PrevAdx;
+        _sumTr = snapshot.SumTr;
+        _sumPdm = snapshot.SumPdm;
+        _sumMdm = snapshot.SumMdm;
+        _sumDx = snapshot.SumDx;
     }
 }
 

--- a/src/a-d/BollingerBands/BollingerBands.BufferList.cs
+++ b/src/a-d/BollingerBands/BollingerBands.BufferList.cs
@@ -51,12 +51,25 @@ public class BollingerBandsList : BufferList<BollingerBandsResult>, IIncrementFr
         // Calculate Bollinger Bands when we have enough values
         if (_buffer.Count == LookbackPeriods)
         {
-            // Calculate SMA
-            double sma = _buffer.Average();
+            // Calculate SMA (sum then divide, same as LINQ Average)
+            double sum = 0;
+            foreach (double val in _buffer)
+            {
+                sum += val;
+            }
 
-            // Calculate standard deviation using the same algorithm as the static series
-            double[] window = _buffer.ToArray();
-            double stdDev = window.StdDev();
+            double sma = sum / _buffer.Count;
+
+            // Calculate standard deviation using the same
+            // algorithm as the static series (Numerical.StdDev),
+            // where the mean is computed identically to SMA above
+            double sumSq = 0;
+            foreach (double val in _buffer)
+            {
+                sumSq += (val - sma) * (val - sma);
+            }
+
+            double stdDev = Math.Sqrt(sumSq / LookbackPeriods);
 
             // Calculate bands
             double upperBand = sma + (StandardDeviations * stdDev);

--- a/src/a-d/Bop/Bop.BufferList.cs
+++ b/src/a-d/Bop/Bop.BufferList.cs
@@ -52,7 +52,14 @@ public class BopList : BufferList<BopResult>, IIncrementFromQuote, IBop
         double? bop = null;
         if (_buffer.Count == SmoothPeriods)
         {
-            bop = _buffer.Average().NaN2Null();
+            // Average buffered values (sum then divide, same as LINQ Average)
+            double sum = 0;
+            foreach (double val in _buffer)
+            {
+                sum += val;
+            }
+
+            bop = (sum / _buffer.Count).NaN2Null();
         }
 
         AddInternal(new BopResult(timestamp, bop));

--- a/src/a-d/Cci/Cci.BufferList.cs
+++ b/src/a-d/Cci/Cci.BufferList.cs
@@ -50,8 +50,14 @@ public class CciList : BufferList<CciResult>, IIncrementFromQuote, ICci
         // Calculate CCI when we have enough data
         if (_buffer.Count == LookbackPeriods)
         {
-            // Calculate average TP over lookback
-            double avgTp = _buffer.Average();
+            // Calculate average TP over lookback (sum then divide, same as LINQ Average)
+            double sumTp = 0;
+            foreach (double tpValue in _buffer)
+            {
+                sumTp += tpValue;
+            }
+
+            double avgTp = sumTp / _buffer.Count;
 
             // Calculate average Deviation over lookback
             double avgDv = 0;

--- a/src/e-k/Fcb/Fcb.BufferList.cs
+++ b/src/e-k/Fcb/Fcb.BufferList.cs
@@ -55,31 +55,53 @@ public class FcbList : BufferList<FcbResult>, IIncrementFromQuote, IFcb
         // check if we can identify fractals
         if (_quoteBuffer.Count >= (2 * _windowSpan) + 1)
         {
-            // get quotes as list for fractal detection
-            List<IQuote> bufferList = _quoteBuffer.ToList();
+            // locate middle quote without copying the buffer
             int midIndex = _windowSpan;
-            IQuote midQuote = bufferList[midIndex];
+            IQuote? midQuote = null;
+            int index = 0;
+
+            foreach (IQuote q in _quoteBuffer)
+            {
+                if (index == midIndex)
+                {
+                    midQuote = q;
+                    break;
+                }
+
+                index++;
+            }
+
+            decimal midHigh = midQuote!.High;
+            decimal midLow = midQuote.Low;
 
             // check for bearish fractal (high point)
             bool isBearishFractal = true;
-            for (int i = 0; i < bufferList.Count; i++)
+            index = 0;
+
+            foreach (IQuote q in _quoteBuffer)
             {
-                if (i != midIndex && bufferList[i].High >= midQuote.High)
+                if (index != midIndex && q.High >= midHigh)
                 {
                     isBearishFractal = false;
                     break;
                 }
+
+                index++;
             }
 
             // check for bullish fractal (low point)
             bool isBullishFractal = true;
-            for (int i = 0; i < bufferList.Count; i++)
+            index = 0;
+
+            foreach (IQuote q in _quoteBuffer)
             {
-                if (i != midIndex && bufferList[i].Low <= midQuote.Low)
+                if (index != midIndex && q.Low <= midLow)
                 {
                     isBullishFractal = false;
                     break;
                 }
+
+                index++;
             }
 
             // update lines based on fractals detected windowSpan periods ago
@@ -87,12 +109,12 @@ public class FcbList : BufferList<FcbResult>, IIncrementFromQuote, IFcb
             {
                 if (isBearishFractal)
                 {
-                    _upperLine = midQuote.High;
+                    _upperLine = midHigh;
                 }
 
                 if (isBullishFractal)
                 {
-                    _lowerLine = midQuote.Low;
+                    _lowerLine = midLow;
                 }
             }
         }

--- a/src/e-k/Hurst/Hurst.BufferList.cs
+++ b/src/e-k/Hurst/Hurst.BufferList.cs
@@ -6,6 +6,8 @@ namespace Skender.Stock.Indicators;
 public class HurstList : BufferList<HurstResult>, IIncrementFromChain, IHurst
 {
     private readonly Queue<double> _buffer;
+    private readonly double[] _bufferArray;
+    private readonly double[] _values;
     private readonly double[] _alCorrections;
 
     /// <summary>
@@ -18,6 +20,8 @@ public class HurstList : BufferList<HurstResult>, IIncrementFromChain, IHurst
         Hurst.Validate(lookbackPeriods);
         LookbackPeriods = lookbackPeriods;
         _buffer = new Queue<double>(lookbackPeriods + 1);
+        _bufferArray = new double[lookbackPeriods + 1];
+        _values = new double[lookbackPeriods];
         _alCorrections = Hurst.PrecomputeAlCorrections(lookbackPeriods);
 
         Name = $"HURST({lookbackPeriods})";
@@ -47,8 +51,10 @@ public class HurstList : BufferList<HurstResult>, IIncrementFromChain, IHurst
         if (_buffer.Count == LookbackPeriods + 1)
         {
             // get evaluation batch - calculate returns from buffer values
-            double[] values = new double[LookbackPeriods];
-            double[] bufferArray = _buffer.ToArray();
+            // using reusable arrays (avoids per-Add allocation)
+            double[] values = _values;
+            double[] bufferArray = _bufferArray;
+            _buffer.CopyTo(bufferArray, 0);
 
             int x = 0;
             double l = bufferArray[0];

--- a/src/e-k/Hurst/Hurst.StreamHub.cs
+++ b/src/e-k/Hurst/Hurst.StreamHub.cs
@@ -8,6 +8,7 @@ public class HurstHub
 {
     private readonly Queue<double> _buffer;
     private readonly double[] _alCorrections;
+    private readonly double[] _windowValues;
 
     internal HurstHub(
         IChainProvider<IReusable> provider,
@@ -18,6 +19,7 @@ public class HurstHub
         Name = $"HURST({lookbackPeriods})";
         _buffer = new Queue<double>(lookbackPeriods + 1);
         _alCorrections = Hurst.PrecomputeAlCorrections(lookbackPeriods);
+        _windowValues = new double[lookbackPeriods];
 
         // Validate cache size for warmup requirements
         // Hurst requires (lookbackPeriods + 1) values in ProviderCache to compute lookbackPeriods returns.
@@ -47,16 +49,21 @@ public class HurstHub
         if (_buffer.Count == LookbackPeriods + 1)
         {
             // Get evaluation batch - calculate returns from buffer values
-            double[] values = new double[LookbackPeriods];
-            double[] bufferArray = _buffer.ToArray();
+            double[] values = _windowValues;
 
             int x = 0;
-            double l = bufferArray[0];
+            double l = double.NaN;
+            bool isFirst = true;
 
             // Skip first value (used as initial l) and calculate returns for the rest
-            for (int p = 1; p < bufferArray.Length; p++)
+            foreach (double ps in _buffer)
             {
-                double ps = bufferArray[p];
+                if (isFirst)
+                {
+                    l = ps;
+                    isFirst = false;
+                    continue;
+                }
 
                 // log returns require strictly positive prices on both ends
                 values[x] = (l > 0 && ps > 0) ? DeMath.Log(ps / l) : double.NaN;

--- a/src/e-k/Kama/Kama.BufferList.cs
+++ b/src/e-k/Kama/Kama.BufferList.cs
@@ -6,6 +6,7 @@ namespace Skender.Stock.Indicators;
 public class KamaList : BufferList<KamaResult>, IIncrementFromChain, IKama
 {
     private readonly Queue<double> _buffer;
+    private readonly double[] _bufferArray;
     private readonly int _erPeriods;
     private readonly double _scFast;
     private readonly double _scSlow;
@@ -35,6 +36,7 @@ public class KamaList : BufferList<KamaResult>, IIncrementFromChain, IKama
         _scSlow = 2d / (slowPeriods + 1);
 
         _buffer = new Queue<double>(erPeriods + 1);
+        _bufferArray = new double[erPeriods + 1];
 
         Name = $"KAMA({erPeriods}, {fastPeriods}, {slowPeriods})";
     }
@@ -82,7 +84,9 @@ public class KamaList : BufferList<KamaResult>, IIncrementFromChain, IKama
         // Calculate if we have enough data
         if (_buffer.Count == _erPeriods + 1)
         {
-            double[] bufferArray = _buffer.ToArray();
+            // copy buffer into reusable array (avoids per-Add allocation)
+            double[] bufferArray = _bufferArray;
+            _buffer.CopyTo(bufferArray, 0);
             double newVal = bufferArray[^1]; // Current value
 
             // Check if we have a previous KAMA value

--- a/src/e-k/Kvo/Kvo.StreamHub.cs
+++ b/src/e-k/Kvo/Kvo.StreamHub.cs
@@ -47,6 +47,9 @@ public class KvoHub
     private double _prevVfSlowEma;
     private double _sumVf;
 
+    // recent state snapshots for O(1) near-tail rollback
+    private readonly RollbackRing<KvoState> _rollback = new();
+
     internal KvoHub(
         IQuoteProvider<IQuote> provider,
         int fastPeriods,
@@ -109,6 +112,7 @@ public class KvoHub
         if (i <= 0)
         {
             _prevHlc = hlc;
+            _rollback.Add(item.Timestamp, CaptureState());
             KvoResult r0 = new(item.Timestamp);
             return (r0, i);
         }
@@ -122,6 +126,7 @@ public class KvoHub
             _prevTrend = trend;
             _prevDm = dm;
             _prevCm = 0;
+            _rollback.Add(item.Timestamp, CaptureState());
             KvoResult r1 = new(item.Timestamp);
             return (r1, i);
         }
@@ -202,6 +207,9 @@ public class KvoHub
         _prevVfFastEma = vfFastEma;
         _prevVfSlowEma = vfSlowEma;
 
+        // snapshot state for O(1) near-tail rollback
+        _rollback.Add(item.Timestamp, CaptureState());
+
         return (r, i);
     }
 
@@ -222,6 +230,23 @@ public class KvoHub
 
         if (restoreIndex < 0)
         {
+            return;
+        }
+
+        // O(1) fast path: restore the exact state snapshot recorded when the
+        // restore-point item was processed (near-tail rollbacks, the common
+        // case for live corrections and forming-bar updates)
+        if (_rollback.TryGet(
+            ProviderCache[restoreIndex].Timestamp,
+            out KvoState snapshot))
+        {
+            _prevHlc = snapshot.PrevHlc;
+            _prevTrend = snapshot.PrevTrend;
+            _prevDm = snapshot.PrevDm;
+            _prevCm = snapshot.PrevCm;
+            _prevVfFastEma = snapshot.PrevVfFastEma;
+            _prevVfSlowEma = snapshot.PrevVfSlowEma;
+            _sumVf = snapshot.SumVf;
             return;
         }
 
@@ -305,4 +330,25 @@ public class KvoHub
             _prevVfSlowEma = vfSlowEma;
         }
     }
+
+    // Captures the current scalar state for rollback snapshots.
+    private KvoState CaptureState()
+        => new(
+            _prevHlc,
+            _prevTrend,
+            _prevDm,
+            _prevCm,
+            _prevVfFastEma,
+            _prevVfSlowEma,
+            _sumVf);
+
+    // Scalar state snapshot for O(1) near-tail rollback.
+    private readonly record struct KvoState(
+        double PrevHlc,
+        double PrevTrend,
+        double PrevDm,
+        double PrevCm,
+        double PrevVfFastEma,
+        double PrevVfSlowEma,
+        double SumVf);
 }

--- a/src/m-r/ParabolicSar/ParabolicSar.StreamHub.cs
+++ b/src/m-r/ParabolicSar/ParabolicSar.StreamHub.cs
@@ -92,8 +92,7 @@ public class ParabolicSarHub
             // _buffer contains the PREVIOUS quotes (not including current)
             if (_buffer.Count >= 2)
             {
-                (double _, double l1) = _buffer.ElementAt(1);  // i-1
-                (double _, double l2) = _buffer.ElementAt(0);  // i-2
+                ((double _, double l2), (double _, double l1)) = PeekLastTwo();  // i-2, i-1
                 double minLastTwo = Math.Min(l1, l2);
                 sar = Math.Min(sar, minLastTwo);
             }
@@ -133,8 +132,7 @@ public class ParabolicSarHub
             // _buffer contains the PREVIOUS quotes (not including current)
             if (_buffer.Count >= 2)
             {
-                (double h1, double _) = _buffer.ElementAt(1);  // i-1
-                (double h2, double _) = _buffer.ElementAt(0);  // i-2
+                ((double h2, double _), (double h1, double _)) = PeekLastTwo();  // i-2, i-1
                 double maxLastTwo = Math.Max(h1, h2);
                 sar = Math.Max(sar, maxLastTwo);
             }
@@ -198,6 +196,19 @@ public class ParabolicSarHub
         return (result, i);
     }
 
+    /// <summary>
+    /// Gets the two buffered prior quotes (oldest first) without
+    /// boxing the queue enumerator, unlike LINQ <c>ElementAt</c>.
+    /// </summary>
+    private ((double High, double Low) Oldest, (double High, double Low) Latest) PeekLastTwo()
+    {
+        Queue<(double High, double Low)>.Enumerator e = _buffer.GetEnumerator();
+        e.MoveNext();
+        (double High, double Low) oldest = e.Current;
+        e.MoveNext();
+        return (oldest, e.Current);
+    }
+
     /// <inheritdoc/>
     protected override void RollbackState(int restoreIndex)
     {
@@ -239,8 +250,7 @@ public class ParabolicSarHub
 
                 if (_buffer.Count >= 2)
                 {
-                    (double _, double l1) = _buffer.ElementAt(1);
-                    (double _, double l2) = _buffer.ElementAt(0);
+                    ((double _, double l2), (double _, double l1)) = PeekLastTwo();
                     double minLastTwo = Math.Min(l1, l2);
                     sar = Math.Min(sar, minLastTwo);
                 }
@@ -273,8 +283,7 @@ public class ParabolicSarHub
 
                 if (_buffer.Count >= 2)
                 {
-                    (double h1, double _) = _buffer.ElementAt(1);
-                    (double h2, double _) = _buffer.ElementAt(0);
+                    ((double h2, double _), (double h1, double _)) = PeekLastTwo();
                     double maxLastTwo = Math.Max(h1, h2);
                     sar = Math.Max(sar, maxLastTwo);
                 }

--- a/src/m-r/ParabolicSar/ParabolicSar.StreamHub.cs
+++ b/src/m-r/ParabolicSar/ParabolicSar.StreamHub.cs
@@ -16,6 +16,18 @@ public class ParabolicSarHub
     private bool _isInitialized;
     private bool _firstReversalFound;
 
+    // recent state snapshots for O(1) near-tail rollback
+    private readonly RollbackRing<SarState> _rollback = new();
+
+    // snapshot of mutable scalar/flag state recorded after each processed item
+    private readonly record struct SarState(
+        double AccelerationFactor,
+        double ExtremePoint,
+        double PriorSar,
+        bool IsRising,
+        bool IsInitialized,
+        bool FirstReversalFound);
+
     internal ParabolicSarHub(
         IQuoteProvider<IQuote> provider,
         double accelerationStep = 0.02,
@@ -76,6 +88,11 @@ public class ParabolicSarHub
 
             // Ensure prior-quote buffer contains the first quote for next-bar clamps
             _buffer.Update(2, (high, low));
+
+            // snapshot state for O(1) near-tail rollback
+            _rollback.Add(item.Timestamp, new SarState(
+                _accelerationFactor, _extremePoint, _priorSar,
+                _isRising, _isInitialized, _firstReversalFound));
 
             return (new ParabolicSarResult(item.Timestamp), i);
         }
@@ -193,6 +210,11 @@ public class ParabolicSarHub
         // Update buffer for last two quotes AFTER using it for calculations
         _buffer.Update(2, (high, low));
 
+        // snapshot state for O(1) near-tail rollback
+        _rollback.Add(item.Timestamp, new SarState(
+            _accelerationFactor, _extremePoint, _priorSar,
+            _isRising, _isInitialized, _firstReversalFound));
+
         return (result, i);
     }
 
@@ -219,6 +241,33 @@ public class ParabolicSarHub
 
         if (restoreIndex < 0)
         {
+            return;
+        }
+
+        // O(1) fast path: restore the exact state snapshot recorded when the
+        // restore-point item was processed (near-tail rollbacks, the common
+        // case for live corrections and forming-bar updates)
+        if (_rollback.TryGet(ProviderCache[restoreIndex].Timestamp, out SarState snapshot))
+        {
+            _accelerationFactor = snapshot.AccelerationFactor;
+            _extremePoint = snapshot.ExtremePoint;
+            _priorSar = snapshot.PriorSar;
+            _isRising = snapshot.IsRising;
+            _isInitialized = snapshot.IsInitialized;
+            _firstReversalFound = snapshot.FirstReversalFound;
+
+            // Rebuild the prior-quote buffer exactly as sequential processing
+            // would leave it: the last two quotes up to restoreIndex (only the
+            // first quote when restoreIndex is 0)
+            if (restoreIndex >= 1)
+            {
+                IQuote prior = ProviderCache[restoreIndex - 1];
+                _buffer.Update(2, ((double)prior.High, (double)prior.Low));
+            }
+
+            IQuote restore = ProviderCache[restoreIndex];
+            _buffer.Update(2, ((double)restore.High, (double)restore.Low));
+
             return;
         }
 

--- a/src/m-r/Pivots/Pivots.BufferList.cs
+++ b/src/m-r/Pivots/Pivots.BufferList.cs
@@ -42,7 +42,7 @@ public class PivotsList : BufferList<PivotsResult>, IIncrementFromQuote
         _endType = endType;
 
         // Buffer needs to hold enough quotes to compute fractals and track trends
-        _quoteBuffer = [];
+        _quoteBuffer = new List<QuoteBuffer>(leftSpan + rightSpan + maxTrendPeriods + 1);
 
         Name = $"PIVOTS({leftSpan}, {rightSpan}, {maxTrendPeriods}, {endType})";
     }

--- a/src/m-r/RocWb/RocWb.BufferList.cs
+++ b/src/m-r/RocWb/RocWb.BufferList.cs
@@ -89,7 +89,13 @@ public class RocWbList : BufferList<RocWbResult>, IIncrementFromChain, IRocWb
             // Initialize EMA with SMA when we have enough values
             if (_rocEmaInitBuffer.Count >= EmaPeriods)
             {
-                rocEma = _rocEmaInitBuffer.Average();
+                double sum = 0;
+                foreach (double val in _rocEmaInitBuffer)
+                {
+                    sum += val;
+                }
+
+                rocEma = sum / _rocEmaInitBuffer.Count;
             }
             else
             {
@@ -108,7 +114,13 @@ public class RocWbList : BufferList<RocWbResult>, IIncrementFromChain, IRocWb
         double? rocDev = null;
         if (_rocSqBuffer.Count >= StdDevPeriods && !double.IsNaN(roc))
         {
-            rocDev = Math.Sqrt(_rocSqBuffer.Sum() / StdDevPeriods).NaN2Null();
+            double sumSq = 0;
+            foreach (double val in _rocSqBuffer)
+            {
+                sumSq += val;
+            }
+
+            rocDev = Math.Sqrt(sumSq / StdDevPeriods).NaN2Null();
         }
 
         AddInternal(new RocWbResult(

--- a/src/m-r/RocWb/RocWb.StreamHub.cs
+++ b/src/m-r/RocWb/RocWb.StreamHub.cs
@@ -95,7 +95,13 @@ public class RocWbHub
             // Initialize EMA with SMA when we have enough values
             if (rocEmaInitBuffer.Count >= EmaPeriods)
             {
-                rocEma = rocEmaInitBuffer.Average();
+                double sum = 0;
+                foreach (double value in rocEmaInitBuffer)
+                {
+                    sum += value;
+                }
+
+                rocEma = sum / rocEmaInitBuffer.Count;
             }
             else
             {
@@ -114,7 +120,13 @@ public class RocWbHub
         double? rocDev = null;
         if (rocSqBuffer.Count >= StdDevPeriods)
         {
-            rocDev = Math.Sqrt(rocSqBuffer.Sum() / StdDevPeriods).NaN2Null();
+            double sumSq = 0;
+            foreach (double value in rocSqBuffer)
+            {
+                sumSq += value;
+            }
+
+            rocDev = Math.Sqrt(sumSq / StdDevPeriods).NaN2Null();
         }
 
         // candidate result
@@ -190,7 +202,13 @@ public class RocWbHub
                 // Initialize EMA with SMA when we have enough values
                 if (rocEmaInitBuffer.Count >= EmaPeriods)
                 {
-                    rocEma = rocEmaInitBuffer.Average();
+                    double sum = 0;
+                    foreach (double value in rocEmaInitBuffer)
+                    {
+                        sum += value;
+                    }
+
+                    rocEma = sum / rocEmaInitBuffer.Count;
                 }
                 else
                 {

--- a/src/m-r/RollingPivots/RollingPivots.BufferList.cs
+++ b/src/m-r/RollingPivots/RollingPivots.BufferList.cs
@@ -77,22 +77,37 @@ public class RollingPivotsList : BufferList<RollingPivotsResult>, IIncrementFrom
             // Window ends at (bufferCount - 1 - 1 - offsetPeriods) = (bufferCount - 2 - offsetPeriods)
             // because the current quote itself is not part of the window when offsetPeriods = 0
 
-            IQuote[] bufferArray = _buffer.ToArray();
-            int bufferCount = bufferArray.Length;
+            int bufferCount = _buffer.Count;
 
             // Window ends offsetPeriods + 1 positions before the end (the "+1" accounts for the current quote)
             int windowEndIndex = bufferCount - 2 - OffsetPeriods;
             int windowStartIndex = windowEndIndex - WindowPeriods + 1;
 
-            double windowHigh = (double)bufferArray[windowStartIndex].High;
-            double windowLow = (double)bufferArray[windowStartIndex].Low;
-            double windowClose = (double)bufferArray[windowEndIndex].Close;
+            double windowHigh = double.MinValue;
+            double windowLow = double.MaxValue;
+            double windowClose = double.NaN;
 
-            for (int p = windowStartIndex; p <= windowEndIndex; p++)
+            // scan the window in place (queue enumerates front-to-back) without copying the buffer
+            int index = 0;
+            foreach (IQuote d in _buffer)
             {
-                IQuote d = bufferArray[p];
-                windowHigh = (double)d.High > windowHigh ? (double)d.High : windowHigh;
-                windowLow = (double)d.Low < windowLow ? (double)d.Low : windowLow;
+                if (index > windowEndIndex)
+                {
+                    break;
+                }
+
+                if (index >= windowStartIndex)
+                {
+                    windowHigh = (double)d.High > windowHigh ? (double)d.High : windowHigh;
+                    windowLow = (double)d.Low < windowLow ? (double)d.Low : windowLow;
+
+                    if (index == windowEndIndex)
+                    {
+                        windowClose = (double)d.Close;
+                    }
+                }
+
+                index++;
             }
 
             // Calculate pivot points

--- a/src/m-r/Rsi/Rsi.StreamHub.cs
+++ b/src/m-r/Rsi/Rsi.StreamHub.cs
@@ -14,6 +14,9 @@ public class RsiHub
     private double _avgGain = double.NaN;
     private double _avgLoss = double.NaN;
 
+    // recent state snapshots for O(1) near-tail rollback
+    private readonly RollbackRing<(double AvgGain, double AvgLoss)> _rollback = new();
+
     internal RsiHub(
         IChainProvider<IReusable> provider,
         int lookbackPeriods) : base(provider)
@@ -93,6 +96,9 @@ public class RsiHub
             // else: state is NaN, will be re-initialized when valid data appears
         }
 
+        // snapshot state for O(1) near-tail rollback
+        _rollback.Add(item.Timestamp, (_avgGain, _avgLoss));
+
         // candidate result
         RsiResult r = new(
             Timestamp: item.Timestamp,
@@ -121,6 +127,18 @@ public class RsiHub
         // Not enough data to initialize state
         if (restoreIndex < LookbackPeriods)
         {
+            return;
+        }
+
+        // O(1) fast path: restore the exact state snapshot recorded when the
+        // restore-point item was processed (near-tail rollbacks, the common
+        // case for live corrections and forming-bar updates)
+        if (_rollback.TryGet(
+            ProviderCache[restoreIndex].Timestamp,
+            out (double AvgGain, double AvgLoss) snapshot))
+        {
+            _avgGain = snapshot.AvgGain;
+            _avgLoss = snapshot.AvgLoss;
             return;
         }
 

--- a/src/s-z/Slope/Slope.BufferList.cs
+++ b/src/s-z/Slope/Slope.BufferList.cs
@@ -92,7 +92,13 @@ public class SlopeList : BufferList<SlopeResult>, IIncrementFromChain, ISlope
         // Two passes required: 1) get avgY, 2) calculate deviations
 
         // First pass: calculate avgY
-        double avgY = _buffer.Average();
+        double sumY = 0;
+        foreach (double bufferValue in _buffer)
+        {
+            sumY += bufferValue;
+        }
+
+        double avgY = sumY / _buffer.Count;
 
         // Second pass: calculate deviations and their products
         double sumSqY = 0;

--- a/src/s-z/SmaAnalysis/SmaAnalysis.BufferList.cs
+++ b/src/s-z/SmaAnalysis/SmaAnalysis.BufferList.cs
@@ -50,7 +50,13 @@ public class SmaAnalysisList : BufferList<SmaAnalysisResult>, IIncrementFromChai
         if (_buffer.Count == lookbackPeriods)
         {
             // Calculate SMA
-            sma = _buffer.Average();
+            double sum = 0;
+            foreach (double val in _buffer)
+            {
+                sum += val;
+            }
+
+            sma = sum / _buffer.Count;
 
             // Calculate analysis metrics
             double sumMad = 0;

--- a/src/s-z/StdDev/StdDev.BufferList.cs
+++ b/src/s-z/StdDev/StdDev.BufferList.cs
@@ -47,7 +47,13 @@ public class StdDevList : BufferList<StdDevResult>, IIncrementFromChain, IStdDev
         if (_buffer.Count == LookbackPeriods)
         {
             // Calculate mean
-            mean = _buffer.Average();
+            double sum = 0;
+            foreach (double val in _buffer)
+            {
+                sum += val;
+            }
+
+            mean = sum / _buffer.Count;
 
             // Calculate standard deviation
             double sumSq = 0;

--- a/src/s-z/Stoch/Stoch.BufferList.cs
+++ b/src/s-z/Stoch/Stoch.BufferList.cs
@@ -173,7 +173,14 @@ public class StochList : BufferList<StochResult>, IIncrementFromQuote, IStoch
                 case MaType.SMA:
                     if (_rawKBuffer.Count == SmoothPeriods)
                     {
-                        smoothK = _rawKBuffer.Average();
+                        // Average buffered values (sum then divide, same as LINQ Average)
+                        double sum = 0;
+                        foreach (double val in _rawKBuffer)
+                        {
+                            sum += val;
+                        }
+
+                        smoothK = sum / _rawKBuffer.Count;
                     }
 
                     break;
@@ -184,7 +191,14 @@ public class StochList : BufferList<StochResult>, IIncrementFromQuote, IStoch
                     // This matches standard SMMA pattern (see Alligator, SMMA indicators)
                     if (double.IsNaN(_prevSmoothK) && _rawKBuffer.Count == SmoothPeriods)
                     {
-                        _prevSmoothK = _rawKBuffer.Average();
+                        // Average buffered values (sum then divide, same as LINQ Average)
+                        double sum = 0;
+                        foreach (double val in _rawKBuffer)
+                        {
+                            sum += val;
+                        }
+
+                        _prevSmoothK = sum / _rawKBuffer.Count;
                     }
 
                     if (!double.IsNaN(_prevSmoothK))
@@ -216,7 +230,14 @@ public class StochList : BufferList<StochResult>, IIncrementFromQuote, IStoch
                 case MaType.SMA:
                     if (_smoothKBuffer.Count == SignalPeriods)
                     {
-                        signal = _smoothKBuffer.Average();
+                        // Average buffered values (sum then divide, same as LINQ Average)
+                        double sum = 0;
+                        foreach (double val in _smoothKBuffer)
+                        {
+                            sum += val;
+                        }
+
+                        signal = sum / _smoothKBuffer.Count;
                     }
 
                     break;
@@ -227,7 +248,14 @@ public class StochList : BufferList<StochResult>, IIncrementFromQuote, IStoch
                     // This matches standard SMMA pattern (see Alligator, SMMA indicators)
                     if (double.IsNaN(_prevSignal) && _smoothKBuffer.Count == SignalPeriods)
                     {
-                        _prevSignal = _smoothKBuffer.Average();
+                        // Average buffered values (sum then divide, same as LINQ Average)
+                        double sum = 0;
+                        foreach (double val in _smoothKBuffer)
+                        {
+                            sum += val;
+                        }
+
+                        _prevSignal = sum / _smoothKBuffer.Count;
                     }
 
                     if (!double.IsNaN(_prevSignal))

--- a/src/s-z/SuperTrend/SuperTrend.StreamHub.cs
+++ b/src/s-z/SuperTrend/SuperTrend.StreamHub.cs
@@ -37,6 +37,9 @@ public class SuperTrendHub
     private double LowerBand { get; set; } = double.MinValue;
     private double PrevAtr { get; set; } = double.NaN;
 
+    // recent state snapshots for O(1) near-tail rollback
+    private readonly RollbackRing<(bool IsBullish, double UpperBand, double LowerBand, double PrevAtr)> _rollback = new();
+
     /// <inheritdoc/>
     protected override (SuperTrendResult result, int index)
         ToIndicator(IQuote item, int? indexHint)
@@ -141,6 +144,9 @@ public class SuperTrendHub
                 LowerBand: (decimal?)LowerBand);
         }
 
+        // snapshot state for O(1) near-tail rollback
+        _rollback.Add(item.Timestamp, (IsBullish, UpperBand, LowerBand, PrevAtr));
+
         return (r, i);
     }
 
@@ -158,6 +164,20 @@ public class SuperTrendHub
 
         if (restoreIndex < 0)
         {
+            return;
+        }
+
+        // O(1) fast path: restore the exact state snapshot recorded when the
+        // restore-point item was processed (near-tail rollbacks, the common
+        // case for live corrections and forming-bar updates)
+        if (_rollback.TryGet(
+            ProviderCache[restoreIndex].Timestamp,
+            out (bool IsBullish, double UpperBand, double LowerBand, double PrevAtr) snapshot))
+        {
+            IsBullish = snapshot.IsBullish;
+            UpperBand = snapshot.UpperBand;
+            LowerBand = snapshot.LowerBand;
+            PrevAtr = snapshot.PrevAtr;
             return;
         }
 

--- a/src/s-z/UlcerIndex/UlcerIndex.BufferList.cs
+++ b/src/s-z/UlcerIndex/UlcerIndex.BufferList.cs
@@ -6,6 +6,7 @@ namespace Skender.Stock.Indicators;
 public class UlcerIndexList : BufferList<UlcerIndexResult>, IIncrementFromChain
 {
     private readonly Queue<double> _buffer;
+    private readonly double[] _bufferArray;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="UlcerIndexList"/> class.
@@ -18,6 +19,7 @@ public class UlcerIndexList : BufferList<UlcerIndexResult>, IIncrementFromChain
         LookbackPeriods = lookbackPeriods;
 
         _buffer = new Queue<double>(lookbackPeriods);
+        _bufferArray = new double[lookbackPeriods];
 
         Name = $"ULCERINDEX({lookbackPeriods})";
     }
@@ -46,7 +48,10 @@ public class UlcerIndexList : BufferList<UlcerIndexResult>, IIncrementFromChain
         {
             // Calculate Ulcer Index
             double sumSquared = 0;
-            double[] bufferArray = _buffer.ToArray();
+
+            // copy buffer into reusable array (avoids per-Add allocation)
+            double[] bufferArray = _bufferArray;
+            _buffer.CopyTo(bufferArray, 0);
 
             for (int p = 0; p < LookbackPeriods; p++)
             {

--- a/src/s-z/Ultimate/Ultimate.BufferList.cs
+++ b/src/s-z/Ultimate/Ultimate.BufferList.cs
@@ -6,6 +6,7 @@ namespace Skender.Stock.Indicators;
 public class UltimateList : BufferList<UltimateResult>, IIncrementFromQuote, IUltimate
 {
     private readonly Queue<(double Bp, double Tr)> _buffer;
+    private readonly (double Bp, double Tr)[] _bufferArray;
     private double _previousClose;
     private bool _isInitialized;
 
@@ -27,6 +28,7 @@ public class UltimateList : BufferList<UltimateResult>, IIncrementFromQuote, IUl
         LongPeriods = longPeriods;
 
         _buffer = new Queue<(double, double)>(longPeriods);
+        _bufferArray = new (double Bp, double Tr)[longPeriods];
         _isInitialized = false;
 
         Name = $"ULTIMATE({shortPeriods}, {middlePeriods}, {longPeriods})";
@@ -95,9 +97,10 @@ public class UltimateList : BufferList<UltimateResult>, IIncrementFromQuote, IUl
             double sumTr2 = 0;  // middle period
             double sumTr3 = 0;  // long period
 
-            // Convert buffer to array for indexed access
-            (double Bp, double Tr)[] bufferArray = _buffer.ToArray();
-            int bufferLength = bufferArray.Length;
+            // Copy buffer into reusable array for indexed access (avoids per-Add allocation)
+            (double Bp, double Tr)[] bufferArray = _bufferArray;
+            _buffer.CopyTo(bufferArray, 0);
+            int bufferLength = _buffer.Count;
 
             // Calculate sums for all three periods
             for (int i = 0; i < bufferLength; i++)

--- a/tests/indicators/_common/BufferLists/BufferList.Validation.Tests.cs
+++ b/tests/indicators/_common/BufferLists/BufferList.Validation.Tests.cs
@@ -1,0 +1,90 @@
+namespace BufferLists;
+
+/// <summary>
+/// Covers <see cref="BufferList{TResult}"/> guard clauses and maintenance
+/// behaviors that per-indicator contract tests exercise only indirectly:
+/// the <c>MaxListSize</c> setter validation and prune-on-set behavior, and
+/// the <c>UpdateInternal</c> bounds checks used by repainting indicators.
+/// </summary>
+[TestClass]
+public class BufferListValidation : TestBase
+{
+    [TestMethod]
+    public void MaxListSize_ZeroOrNegative_Throws()
+    {
+        SmaList sut = new(5);
+
+        Action setZero = () => sut.MaxListSize = 0;
+        Action setNegative = () => sut.MaxListSize = -1;
+
+        setZero.Should().Throw<ArgumentOutOfRangeException>();
+        setNegative.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [TestMethod]
+    public void MaxListSize_SetBelowCurrentCount_PrunesImmediately()
+    {
+        SmaList sut = new(5);
+        sut.Add(Quotes.Take(50).ToList());
+        sut.Should().HaveCount(50);
+
+        sut.MaxListSize = 20;
+
+        // oldest entries are pruned on assignment, newest are retained
+        sut.Should().HaveCount(20);
+        sut[^1].Timestamp.Should().Be(Quotes[49].Timestamp);
+        sut[0].Timestamp.Should().Be(Quotes[30].Timestamp);
+    }
+
+    [TestMethod]
+    public void MaxListSize_SetAboveCurrentCount_DoesNotPrune()
+    {
+        SmaList sut = new(5);
+        sut.Add(Quotes.Take(50).ToList());
+
+        sut.MaxListSize = 60;
+
+        sut.Should().HaveCount(50);
+    }
+
+    [TestMethod]
+    public void UpdateInternal_WithinBounds_ReplacesItem()
+    {
+        TestList sut = new();
+        sut.AddItem(new SmaResult(Quotes[0].Timestamp, 1d));
+        sut.AddItem(new SmaResult(Quotes[1].Timestamp, 2d));
+
+        sut.UpdateItem(1, new SmaResult(Quotes[1].Timestamp, 99d));
+
+        sut[1].Sma.Should().Be(99d);
+        sut.Should().HaveCount(2);
+    }
+
+    [TestMethod]
+    public void UpdateInternal_OutOfBounds_Throws()
+    {
+        TestList sut = new();
+        sut.AddItem(new SmaResult(Quotes[0].Timestamp, 1d));
+
+        Action updateNegative = () => sut.UpdateItem(-1, new SmaResult(Quotes[0].Timestamp, 5d));
+        Action updateBeyondEnd = () => sut.UpdateItem(1, new SmaResult(Quotes[0].Timestamp, 5d));
+
+        updateNegative.Should().Throw<ArgumentOutOfRangeException>();
+        updateBeyondEnd.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    /// <summary>
+    /// Minimal concrete list exposing the protected internals under test.
+    /// </summary>
+    private sealed class TestList : BufferList<SmaResult>
+    {
+        public TestList()
+        {
+            Name = "TEST";
+        }
+
+        public void AddItem(SmaResult item) => AddInternal(item);
+
+        public void UpdateItem(int index, SmaResult item) => UpdateInternal(index, item);
+    }
+}

--- a/tests/indicators/_common/StreamHub/StreamHub.InsertWithoutRebuild.Tests.cs
+++ b/tests/indicators/_common/StreamHub/StreamHub.InsertWithoutRebuild.Tests.cs
@@ -1,0 +1,127 @@
+namespace Observables;
+
+/// <summary>
+/// Covers the <c>InsertWithoutRebuild</c> branches of a root
+/// <see cref="QuoteHub"/>: a late arrival that lands mid-cache is inserted
+/// in place (no rebuild of the root's own cache), duplicates of that late
+/// arrival are suppressed, and downstream observers rebuild to match the
+/// corrected timeline exactly.
+/// </summary>
+[TestClass]
+public class InsertWithoutRebuild : TestBase
+{
+    [TestMethod]
+    public void LateArrival_MidCache_InsertsInPlace()
+    {
+        List<Quote> quotes = Quotes.Take(20).ToList();
+
+        QuoteHub quoteHub = new();
+        SmaHub observer = quoteHub.ToSmaHub(5);
+
+        // skip index 10, then deliver it late
+        for (int i = 0; i < quotes.Count; i++)
+        {
+            if (i == 10)
+            {
+                continue;
+            }
+
+            quoteHub.Add(quotes[i]);
+        }
+
+        quoteHub.Add(quotes[10]);
+
+        // root cache is chronological and complete
+        quoteHub.Results.Should().HaveCount(quotes.Count);
+        quoteHub.Results[10].Timestamp.Should().Be(quotes[10].Timestamp);
+
+        // observer matches the batch series exactly
+        observer.Results.IsExactly(quotes.ToSma(5));
+    }
+
+    [TestMethod]
+    public void LateArrival_DuplicateResend_IsSuppressed()
+    {
+        List<Quote> quotes = Quotes.Take(20).ToList();
+
+        QuoteHub quoteHub = new();
+
+        for (int i = 0; i < quotes.Count; i++)
+        {
+            if (i == 10)
+            {
+                continue;
+            }
+
+            quoteHub.Add(quotes[i]);
+        }
+
+        quoteHub.Add(quotes[10]);
+        quoteHub.Add(quotes[10]); // duplicate of the same late arrival
+
+        quoteHub.Results.Should().HaveCount(quotes.Count);
+        quoteHub.IsFaulted.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void LateArrival_FirstPosition_InsertsAtFront()
+    {
+        List<Quote> quotes = Quotes.Take(15).ToList();
+
+        QuoteHub quoteHub = new();
+        SmaHub observer = quoteHub.ToSmaHub(5);
+
+        // withhold the earliest quote, then deliver it late;
+        // note: a root QuoteHub rejects arrivals older than its first
+        // cached item, so the late arrival here is the second quote
+        for (int i = 0; i < quotes.Count; i++)
+        {
+            if (i == 1)
+            {
+                continue;
+            }
+
+            quoteHub.Add(quotes[i]);
+        }
+
+        quoteHub.Add(quotes[1]);
+
+        quoteHub.Results.Should().HaveCount(quotes.Count);
+        quoteHub.Results[1].Timestamp.Should().Be(quotes[1].Timestamp);
+
+        observer.Results.IsExactly(quotes.ToSma(5));
+    }
+
+    [TestMethod]
+    public void BatchAdd_UnsortedInput_IsSortedStably()
+    {
+        List<Quote> quotes = Quotes.Take(30).ToList();
+
+        // shuffle deterministically
+        List<Quote> shuffled = [.. quotes];
+        (shuffled[3], shuffled[22]) = (shuffled[22], shuffled[3]);
+        (shuffled[8], shuffled[15]) = (shuffled[15], shuffled[8]);
+
+        QuoteHub quoteHub = new();
+        SmaHub observer = quoteHub.ToSmaHub(5);
+
+        quoteHub.Add(shuffled);
+
+        quoteHub.Results.Should().HaveCount(quotes.Count);
+        observer.Results.IsExactly(quotes.ToSma(5));
+    }
+
+    [TestMethod]
+    public void BatchAdd_SortedInput_FastPathMatchesSeries()
+    {
+        List<Quote> quotes = Quotes.Take(30).ToList();
+
+        QuoteHub quoteHub = new();
+        SmaHub observer = quoteHub.ToSmaHub(5);
+
+        quoteHub.Add(quotes);
+
+        quoteHub.Results.Should().HaveCount(quotes.Count);
+        observer.Results.IsExactly(quotes.ToSma(5));
+    }
+}

--- a/tests/indicators/_common/StreamHub/StreamHub.RollbackRing.Tests.cs
+++ b/tests/indicators/_common/StreamHub/StreamHub.RollbackRing.Tests.cs
@@ -1,0 +1,161 @@
+namespace Observables;
+
+/// <summary>
+/// Verifies the O(1) near-tail rollback fast path (RollbackRing snapshots)
+/// and its deep-rollback fallback produce Series-exact results for stateful
+/// hubs. RSI is the reference implementation; shallow corrections restore
+/// state from ring snapshots while corrections deeper than the ring's
+/// capacity fall back to full state replay.
+/// </summary>
+[TestClass]
+public class RollbackRingState : TestBase
+{
+    [TestMethod]
+    public void ShallowCorrection_RestoresFromSnapshot_MatchesSeries()
+    {
+        List<Quote> quotes = Quotes.Take(120).ToList();
+
+        QuoteHub quoteHub = new();
+        RsiHub observer = quoteHub.ToRsiHub(14);
+
+        quoteHub.Add(quotes);
+
+        // correct a recent bar (well within ring capacity)
+        Quote corrected = quotes[117] with { Close = quotes[117].Close + 2m };
+        quotes[117] = corrected;
+        quoteHub.Add(corrected);
+
+        observer.Results.IsExactly(quotes.ToRsi(14));
+    }
+
+    [TestMethod]
+    public void DeepCorrection_FallsBackToReplay_MatchesSeries()
+    {
+        List<Quote> quotes = Quotes.Take(200).ToList();
+
+        QuoteHub quoteHub = new();
+        RsiHub observer = quoteHub.ToRsiHub(14);
+
+        quoteHub.Add(quotes);
+
+        // correct a bar far beyond the ring capacity (32 snapshots)
+        Quote corrected = quotes[60] with { Close = quotes[60].Close + 2m };
+        quotes[60] = corrected;
+        quoteHub.Add(corrected);
+
+        observer.Results.IsExactly(quotes.ToRsi(14));
+    }
+
+    [TestMethod]
+    public void FormingBarChurn_RepeatedTailCorrections_MatchesSeries()
+    {
+        List<Quote> quotes = Quotes.Take(80).ToList();
+
+        QuoteHub quoteHub = new();
+        RsiHub observer = quoteHub.ToRsiHub(14);
+
+        quoteHub.Add(quotes);
+
+        // emulate an aggregator re-sending the forming bar on every tick;
+        // more updates than the ring capacity, all on one timestamp
+        Quote formingBar = quotes[^1];
+        for (int update = 1; update <= 40; update++)
+        {
+            formingBar = formingBar with { Close = formingBar.Close + 0.25m };
+            quoteHub.Add(formingBar);
+        }
+
+        quotes[^1] = formingBar;
+        observer.Results.IsExactly(quotes.ToRsi(14));
+    }
+
+    [TestMethod]
+    public void SequentialCorrections_AcrossRecentBars_MatchesSeries()
+    {
+        List<Quote> quotes = Quotes.Take(100).ToList();
+
+        QuoteHub quoteHub = new();
+        RsiHub observer = quoteHub.ToRsiHub(14);
+
+        quoteHub.Add(quotes);
+
+        // several distinct recent bars corrected in sequence: each rollback
+        // restores from a snapshot recorded by the previous replay
+        for (int i = 95; i < 100; i++)
+        {
+            Quote corrected = quotes[i] with { Close = quotes[i].Close + 1m };
+            quotes[i] = corrected;
+            quoteHub.Add(corrected);
+        }
+
+        observer.Results.IsExactly(quotes.ToRsi(14));
+    }
+
+    [TestMethod]
+    public void ShallowCorrection_AdxHub_MatchesSeries()
+    {
+        List<Quote> quotes = Quotes.Take(150).ToList();
+
+        QuoteHub quoteHub = new();
+        AdxHub observer = quoteHub.ToAdxHub(14);
+
+        quoteHub.Add(quotes);
+
+        Quote corrected = quotes[147] with { Close = quotes[147].Close + 2m };
+        quotes[147] = corrected;
+        quoteHub.Add(corrected);
+
+        observer.Results.IsExactly(quotes.ToAdx(14));
+    }
+
+    [TestMethod]
+    public void ShallowCorrection_SuperTrendHub_MatchesSeries()
+    {
+        List<Quote> quotes = Quotes.Take(150).ToList();
+
+        QuoteHub quoteHub = new();
+        SuperTrendHub observer = quoteHub.ToSuperTrendHub(10, 3);
+
+        quoteHub.Add(quotes);
+
+        Quote corrected = quotes[147] with { Close = quotes[147].Close + 2m };
+        quotes[147] = corrected;
+        quoteHub.Add(corrected);
+
+        observer.Results.IsExactly(quotes.ToSuperTrend(10, 3));
+    }
+
+    [TestMethod]
+    public void ShallowCorrection_KvoHub_MatchesSeries()
+    {
+        List<Quote> quotes = Quotes.Take(150).ToList();
+
+        QuoteHub quoteHub = new();
+        KvoHub observer = quoteHub.ToKvoHub(34, 55, 13);
+
+        quoteHub.Add(quotes);
+
+        Quote corrected = quotes[147] with { Close = quotes[147].Close + 2m };
+        quotes[147] = corrected;
+        quoteHub.Add(corrected);
+
+        observer.Results.IsExactly(quotes.ToKvo(34, 55, 13));
+    }
+
+    [TestMethod]
+    public void ShallowCorrection_ParabolicSarHub_MatchesSeries()
+    {
+        List<Quote> quotes = Quotes.Take(150).ToList();
+
+        QuoteHub quoteHub = new();
+        ParabolicSarHub observer = quoteHub.ToParabolicSarHub(0.02, 0.2);
+
+        quoteHub.Add(quotes);
+
+        Quote corrected = quotes[147] with { Close = quotes[147].Close + 2m };
+        quotes[147] = corrected;
+        quoteHub.Add(corrected);
+
+        observer.Results.IsExactly(quotes.ToParabolicSar(0.02, 0.2));
+    }
+}


### PR DESCRIPTION
## Summary

Hardening pass over the v3 streaming features (BufferList + StreamHub) focused on memory/GC efficiency, API surface reduction, and infrastructure test coverage. **No feature or behavior changes** — all transformations preserve floating-point operation order, and the exact Series-parity suites pass unchanged.

### 1. Memory / GC optimizations

**StreamHub infrastructure** (`src/_common/StreamHub/`):

- **Cache double-allocation**: the 800-capacity field initializer always allocated a backing array that the constructor immediately replaced for small `MaxCacheSize`; now allocated once in the constructor.
- **Rollback path**: `Cache.RemoveAll(closure)` → binary-search `IndexGte` + `RemoveRange` (no per-rebuild delegate allocation, no full predicate scan over a sorted cache).
- **Observer fan-out**: the subscriber snapshot array is now cached and invalidated only on Subscribe/Unsubscribe/EndTransmission, instead of allocated on every Add/Rebuild/Prune/Error notification (4 paths × every cached item).
- **Batch `Add`**: sorted fast path skips the `OrderBy` allocation chain when input is already chronological (the common streaming case); unsorted input still uses the stable LINQ sort so same-timestamp arrival order is preserved.
- **`OnPrune`**: per-item `RemoveAt(0)` loop → counted `RemoveRange` (was O(n²) array shifting on provider prunes).

**Indicator hot paths** (per-tick / per-Add):

- LINQ `Average()`/`Sum()` on `Queue<double>` (boxed enumerator per call) → manual in-order sums: Stoch (4 sites), BollingerBands, Cci, Bop, StdDev, SmaAnalysis, Slope, RocWb (buffer + hub).
- Per-Add `ToArray()`/`ToList()` window copies → reusable pre-allocated arrays (`Queue.CopyTo`) or in-place struct-enumerator scans: Kama, Hurst (buffer + hub), UlcerIndex, Ultimate, Fcb, RollingPivots.
- ParabolicSar: LINQ `ElementAt` (boxes the queue enumerator) → direct enumerator access.
- TickAggregatorHub: dedup-cache prune now removes during dictionary enumeration instead of building a `Where/Select/ToList` list per tick.
- Pivots: quote buffer pre-sized to its computed maximum bound. (A capacity audit confirmed all other Queue/List state already has hints or has no derivable bound.)

### 2. API surface reduction

| Member | Before | After |
| --- | --- | --- |
| `BufferListUtilities` | public | internal |
| `IIncrementFromChain`, `IIncrementFromQuote` | public | internal |
| `BaseProvider<T>` (inert root placeholder) | public | internal |
| `StreamHub` static utilities class | public | internal |
| `StreamHub<TIn,TOut>.CacheLock` | protected | private protected |
| `NotifyObserversOnAdd` / `NotifyObserversOnRebuild` | protected | private protected |
| `BufferList<T>.IsReadOnly` (not part of any implemented interface) | public | removed |
| `BufferList<T>.RemoveAt(int)` (unused) | protected | removed |

> ⚠️ **Review point**: internalizing `IIncrementFromChain`/`IIncrementFromQuote` removes the ability for consumers to handle heterogeneous buffer lists polymorphically through those interfaces. Every concrete list keeps its public `Add(...)` methods, no docs or public-API tests reference the interfaces, and v3 is unreleased — but if polymorphic buffer-list handling is an intended use case, revert that one commit hunk.

### 3. Coverage gaps filled (10 new tests)

- `BufferList.MaxListSize` setter: rejects ≤ 0, prunes immediately when lowered below `Count`, no-op when raised.
- `BufferList.UpdateInternal`: in-range replace and out-of-range `ArgumentOutOfRangeException`.
- `StreamHub.InsertWithoutRebuild` branches via root `QuoteHub` late arrivals: mid-cache insert, duplicate re-send suppression, near-front insert — each verified against exact Series parity.
- Batch `Add` fast path (pre-sorted) and stable-sort (unsorted) paths.

Analysis also confirmed per-indicator coverage is already complete (78/78 indicators have full BufferList + StreamHub contract tests), and `RollbackState`/`PruneState` overrides are exercised behaviorally by every indicator's late-arrival and cache-pruning parity tests.

### Notable non-changes (deliberate)

- No running sums / incremental aggregates were introduced — they would change FP accumulation order and break bit-exact Series parity.
- HtTrendline/Mama state-list pruning was left as-is: ring-buffer conversion is high-risk for a hardening pass and the lists are bounded by provider-driven `PruneState`.
- `Snapshot()` still copies — a cached copy keyed on count would serve stale data when values change at equal count.
- `HubCollection` stays public (documented user-facing API).

## Verification

- `dotnet build Stock.Indicators.sln` — 0 warnings, 0 errors (net8.0/9.0/10.0)
- `dotnet test tests/indicators` — 2461 passed, 0 failed (includes new tests; 12 skips are pre-existing regression-baseline stubs)
- `dotnet test tests/public-api` — 71 passed, 0 failed
- `dotnet format --severity info` — clean
- Integration tests not run locally (SSE-server harness is CI-only; fails on WSL with a Windows-exe permission error unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Round 2: architecture & data-feed use-case assessment

A second pass evaluated the library against its real deployment profiles — correction-heavy live feeds, high-frequency tick aggregation, multi-symbol server fleets — and fixed three material gaps.

### O(1) near-tail rollback (`RollbackRing<TState>`)

The most material finding: RSI, ADX, SuperTrend, KVO, and ParabolicSar rebuilt internal state by **replaying their entire input history** on every rollback. Rollbacks are not rare in production — exchanges amend recent bars, and aggregator hubs cascade an `OnRebuild` to downstream hubs on **every forming-bar tick**, so a tick→bar→RSI chain paid O(cache size) per tick update.

New internal `RollbackRing<TState>` keeps the last 32 `(timestamp, state)` snapshots per hub (~1KB or less): near-tail rollbacks restore the exact live-computed state in O(1) (bit-exact by construction); deeper rollbacks use the existing full replay unchanged. Same-timestamp adds replace in place so forming-bar churn can't flush the ring. 8 new tests verify Series-exact results on ring-hit, fallback, churn, and sequential-correction paths for all five hubs.

### Append/same-bar fast paths

`QuoteHub`/`TickHub.Add` and both aggregators did an O(log n) binary search per item to find the cache position, even though live feeds overwhelmingly append (or update the forming bar). Both cases now short-circuit; out-of-order input still binary-searches.

### Multi-symbol footprint

Every hub pre-allocated an 800-slot cache array (~6.4KB; the default `MaxCacheSize` of 100k always takes this branch) — ~256MB of idle arrays across a 40k-hub fleet. Caches now start empty; `List<T>` doubling amortizes the cost. Also replaced the `TickAggregatorHub` dedup-overflow `OrderBy/Take/Select/ToList` chain with a single sorted-threshold pass.

### Assessed and deliberately not changed

- **Intra-bar notification conflation** (don't notify downstream until bar close): real win for HF chains but changes observable semantics — forming-bar consumers would break. Better as an opt-in `BinarySettings` flag in a future release.
- **Mutable forming-bar** in aggregators (one `Quote` allocation per intra-bar tick): would break the immutable-record contract; not worth it.
- **HtTrendline full-replay rollback**: Hilbert-transform phase state legitimately requires history; left as-is.
- **Lazy observer sets / merged locks**: <100 bytes per hub at real deadlock/complexity risk.

