### PR TITLE
fix: Test performance workflows

### DIFF
--- a/.github/workflows/test-performance-comparison.yml
+++ b/.github/workflows/test-performance-comparison.yml
@@ -39,7 +39,8 @@ jobs:
           # Export GitVersion variables to environment
           dotnet tool run dotnet-gitversion -config src/gitversion.yml | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> $GITHUB_ENV
 
-      - name: Build library
+      - name: Build performance project
+        working-directory: tools/performance
         run: >
           dotnet build
           --configuration Release

--- a/.github/workflows/test-performance-manual.yml
+++ b/.github/workflows/test-performance-manual.yml
@@ -150,7 +150,8 @@ jobs:
           # Export GitVersion variables to environment
           dotnet tool run dotnet-gitversion -config src/gitversion.yml | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> $GITHUB_ENV
 
-      - name: Build library
+      - name: Build performance project
+        working-directory: tools/performance
         run: >
           dotnet build
           --configuration Release

--- a/.github/workflows/test-performance-manual.yml
+++ b/.github/workflows/test-performance-manual.yml
@@ -176,16 +176,23 @@ jobs:
             exit 1
           fi
 
-          # If all three selected, run the broad wildcard; otherwise build a regex group
+          # If all three selected, run the broad wildcard; otherwise build a filter list
           if [ ${#TYPES[@]} -eq 3 ]; then
             FILTER="Performance.ManualTestDirect*"
           else
-            PATTERN=$(IFS='|'; echo "${TYPES[*]}")
-            FILTER="Performance.ManualTestDirect.(${PATTERN})"
+            # Build multiple --filter arguments for BenchmarkDotNet
+            FILTER_ARGS=()
+            for TYPE in "${TYPES[@]}"; do
+              FILTER_ARGS+=(--filter "Performance.ManualTestDirect.${TYPE}")
+            done
           fi
 
-          echo "Using filter: $FILTER"
-          dotnet run -c Release -- --filter "$FILTER" --job short --exporters json markdown
+          echo "Running benchmarks for: ${TYPES[*]}"
+          if [ ${#TYPES[@]} -eq 3 ]; then
+            dotnet run -c Release -- --filter "$FILTER" --job short --exporters json markdown
+          else
+            dotnet run -c Release -- "${FILTER_ARGS[@]}" --job short --exporters json markdown
+          fi
         env:
           PERF_TEST_KEYWORD: ${{ inputs.indicator }}
           PERF_TEST_PERIODS: ${{ inputs.periods }}

--- a/.github/workflows/test-performance-manual.yml
+++ b/.github/workflows/test-performance-manual.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       indicator:
-        description: Select indicator to benchmark
+        description: Select indicator to benchmark (Note - Some indicators only support Series style)
         type: choice
         required: true
         options:

--- a/.github/workflows/test-performance-manual.yml
+++ b/.github/workflows/test-performance-manual.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       indicator:
-        description: Select indicator to benchmark (Note - Some indicators only support Series style)
+        description: Select indicator to benchmark
         type: choice
         required: true
         options:

--- a/.github/workflows/test-performance.yml
+++ b/.github/workflows/test-performance.yml
@@ -39,7 +39,8 @@ jobs:
           # Export GitVersion variables to environment
           dotnet tool run dotnet-gitversion -config src/gitversion.yml | jq -r 'to_entries[] | "\(.key)=\(.value)"' >> $GITHUB_ENV
 
-      - name: Build library
+      - name: Build performance project
+        working-directory: tools/performance
         run: >
           dotnet build
           --configuration Release

--- a/tools/Directory.Packages.props
+++ b/tools/Directory.Packages.props
@@ -18,9 +18,9 @@
   <ItemGroup>
     <PackageVersion Include="Alpaca.Markets" Version="7.2.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="JKorf.Coinbase.Net" Version="3.10.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="10.0.8" />
+    <PackageVersion Include="JKorf.Coinbase.Net" Version="3.11.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="10.0.9" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
   </ItemGroup>
 </Project>

--- a/tools/performance/Perf.ManualTestDirect.cs
+++ b/tools/performance/Perf.ManualTestDirect.cs
@@ -132,7 +132,7 @@ public class ManualTestDirect
         "WILLR" => Quotes.ToWilliamsR(),
         "WMA" => Quotes.ToWma(14),
         "ZIGZAG" => Quotes.ToZigZag(),
-        _ => throw new NotSupportedException($"Indicator '{Keyword}' is not supported in ManualTestDirect."),
+        _ => throw new NotSupportedException($"Indicator '{Keyword}' is not supported in ManualTestDirect Series benchmark."),
     };
 
     /* BUFFER BENCHMARKS */
@@ -214,7 +214,7 @@ public class ManualTestDirect
         "VWMA" => Quotes.ToVwmaList(14),
         "WILLR" => Quotes.ToWilliamsRList(),
         "WMA" => Quotes.ToWmaList(14),
-        _ => throw new NotSupportedException($"Indicator '{Keyword}' is not supported in ManualTestDirect."),
+        _ => throw new NotSupportedException($"Indicator '{Keyword}' is not supported in ManualTestDirect Buffer benchmark. Some indicators only have Series implementations."),
     };
 
     /* STREAM HUB BENCHMARKS */
@@ -300,7 +300,7 @@ public class ManualTestDirect
         "VWMA" => quoteHub.ToVwmaHub(14).Results,
         "WILLR" => quoteHub.ToWilliamsRHub().Results,
         "WMA" => quoteHub.ToWmaHub(14).Results,
-        _ => throw new NotSupportedException($"Indicator '{Keyword}' is not supported in ManualTestDirect."),
+        _ => throw new NotSupportedException($"Indicator '{Keyword}' is not supported in ManualTestDirect StreamHub benchmark. Some indicators only have Series implementations."),
     };
 
 }

--- a/tools/performance/Tests.Performance.csproj
+++ b/tools/performance/Tests.Performance.csproj
@@ -26,7 +26,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" />
+    <!--
+      Override PrivateAssets default (All) so BenchmarkDotNet's compile assets flow
+      to the child harness project that BDN auto-generates at runtime.
+      This project is not a true leaf node: BDN creates a ProjectReference child from it.
+    -->
+    <PackageReference Include="BenchmarkDotNet"
+                      PrivateAssets="contentfiles;analyzers;build;buildMultitargeting;buildTransitive;native" />
     <PackageReference Include="Roslynator.Analyzers" />
   </ItemGroup>
 

--- a/tools/simulate/packages.lock.json
+++ b/tools/simulate/packages.lock.json
@@ -4,11 +4,11 @@
     "net10.0": {
       "JKorf.Coinbase.Net": {
         "type": "Direct",
-        "requested": "[3.10.0, )",
-        "resolved": "3.10.0",
-        "contentHash": "9UNxqhrkwaGylECPzrAJJtc79VBCRBhmolswWHWEjkobH0s+MWA1U2+zuv28IqLd0wT/+Hf9D9hklZqPUekHOQ==",
+        "requested": "[3.11.0, )",
+        "resolved": "3.11.0",
+        "contentHash": "EPYvBzATYdAlx8YzeisY/JMRwG4kI6L19l/6RZurIMBVlb7uGq7R0qxpmnnaxRCa4UXhtIdfBsr41QPDMhA66w==",
         "dependencies": {
-          "CryptoExchange.Net": "11.2.0",
+          "CryptoExchange.Net": "11.2.2",
           "Microsoft.IdentityModel.JsonWebTokens": "8.15.0"
         }
       },
@@ -20,8 +20,8 @@
       },
       "CryptoExchange.Net": {
         "type": "Transitive",
-        "resolved": "11.2.0",
-        "contentHash": "7SQ9TmevRCHfQOKNhoqAgP3txCDBuMkNWDmqQCBst+n7wr00j8IhgvbifK+eW7Bg/yVvt8rNdhtuyZMISefaTQ==",
+        "resolved": "11.2.2",
+        "contentHash": "rEaHoC6qgcFFmZD7n0R0NG0cSYWCwX45dKiEn8M01EtuVSwGTNuziuhtFxGgKdPMc1+/evS2M98cXzpyUu5KCA==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Binder": "10.0.1",
           "Microsoft.Extensions.Http": "10.0.1",

--- a/tools/sse-server/packages.lock.json
+++ b/tools/sse-server/packages.lock.json
@@ -4,18 +4,18 @@
     "net10.0": {
       "Microsoft.AspNetCore.OpenApi": {
         "type": "Direct",
-        "requested": "[10.0.8, )",
-        "resolved": "10.0.8",
-        "contentHash": "cw24xHE2QaWwyEG9GQwFbjboyabub6Vd80DIItUGENzcQOa/BEnTrXsg2GADqWTmY/3ycqk9ToLGjgvF/VRlGA==",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "1ihb8FO9cGgEK1/m3CTtT/SfnynwmiZib0W2pcDVj3KSWk/Sca4VOXEtaptKQc582zpFrzTFiwkGRCglt6H+WQ==",
         "dependencies": {
           "Microsoft.OpenApi": "2.0.0"
         }
       },
       "Microsoft.Extensions.ApiDescription.Server": {
         "type": "Direct",
-        "requested": "[10.0.8, )",
-        "resolved": "10.0.8",
-        "contentHash": "fikrKwWqzn/72glL9bTNnuberYPrKldDdgyR1cnW9gbfUXN4oG4eg+uXkTUXuIPcEjwCeOTTTja0VpsHf50tWA=="
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "n1m7EAbCbHMGiTy++F+mLSan4MrZe0t00XEpJrkai6BFpB6lwEcirflI9FiMm4G4u55h/2RnWToYBDwS+MnN6g=="
       },
       "Roslynator.Analyzers": {
         "type": "Direct",


### PR DESCRIPTION
## Problem

All three `workflow_dispatch` performance test workflows were silently failing — either producing no results or crashing with `CS0234` errors in `BenchmarkDotNet.Autogenerated.csproj`.

**Root cause:** BenchmarkDotNet generates a temporary child harness project at runtime and compiles it. The default `PrivateAssets="All"` on the NuGet reference blocked BDN's own compile/runtime assets from flowing to that child project, so `BenchmarkDotNet.Engines` and `BenchmarkDotNet.Portability` were unresolvable.

Example failing runs (pre-fix):
- `test-performance-manual.yml` — [run 27255830361](https://github.com/DaveSkender/Stock.Indicators/actions/runs/27255830361)
- `test-performance-comparison.yml` — [run 27283552067](https://github.com/DaveSkender/Stock.Indicators/actions/runs/27283552067)
- `test-performance.yml` — [run 27284507881](https://github.com/DaveSkender/Stock.Indicators/actions/runs/27284507881)

## Changes

- **`tools/performance/Tests.Performance.csproj`** — Override `PrivateAssets` on the BenchmarkDotNet package reference to `contentfiles;analyzers;build;buildMultitargeting;buildTransitive;native`, which excludes `compile` and `runtime` from the private list so they flow to BDN's auto-generated child project.
- **All three workflow files** — Scope the build step to `tools/performance` only (`working-directory: tools/performance`) instead of building the entire solution. Also corrected the BenchmarkDotNet `--filter` syntax in the manual workflow.