### PR TITLE
fix: Repair dead StaticChart.vue link breaking website build

### DIFF
--- a/docs/examples/custom-chart.md
+++ b/docs/examples/custom-chart.md
@@ -102,7 +102,7 @@ function buildEmaDataset(quotes: Quote[], period: number): ChartDataset<'line', 
 
 ## Vue component source
 
-The full Vue 3 SFC that drives the live demo is at [`docs/examples/StaticChart.vue`](StaticChart.vue) — that file is the source of truth (mount, theme observer, teardown, and EMA helpers). The page embeds it via `<ClientOnly>` so the Chart.js code only runs in the browser.
+The full Vue 3 SFC that drives the live demo is at [`docs/examples/StaticChart.vue`](https://github.com/facioquo/stock-indicators-dotnet/blob/main/docs/examples/StaticChart.vue) — that file is the source of truth (mount, theme observer, teardown, and EMA helpers). The page embeds it via `<ClientOnly>` so the Chart.js code only runs in the browser.
 
 ## Key points
 


### PR DESCRIPTION
## Problem

The production website deploy was failing on `main`. VitePress's build fails hard on any dead link, and `docs/examples/custom-chart.md` linked the Vue source as a page route:

```
(!) Found dead link ./StaticChart.vue in file docs/examples/custom-chart.md
[vitepress] 1 dead link(s) found.  ✗ Build failed
```

A markdown link to a `.vue` file isn't a resolvable page route, so the dead-link checker rejected it. (The `<script setup>` import of the same file is fine — that's a JS import, not a checked markdown link.)

## Fix

Repoint the prose link at the real GitHub source URL — consistent with how the page already links `OverlayChart`, and it gives readers a working link to the source of truth. Chose this over adding `ignoreDeadLinks`, which would blunt dead-link detection for future real breakage.

## Verification

Local production build now passes clean:

```
build complete in 12.39s   # 0 dead links, 0 errors
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)