### PR TITLE
chore: Reconfigure broken Codacy code coverage

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -8,11 +8,6 @@ description: >-
 
 # Contributing guidelines
 
-<p style="display:flex; justify-content:left; gap:1rem; flex-wrap:wrap;">
-<a href="https://app.codacy.com/gh/facioquo/stock-indicators-dotnet/dashboard" aria-label="View Codacy quality grade."><img src="https://app.codacy.com/project/badge/Grade/ca51220c29aa4d5697a9559bafdcdc17" alt="Codacy quality grade" /></a>
-<a href="https://app.codacy.com/gh/facioquo/stock-indicators-dotnet/dashboard" aria-label="View Codacy code coverage."><img src="https://app.codacy.com/project/badge/Coverage/ca51220c29aa4d5697a9559bafdcdc17" alt="Codacy code coverage" /></a>
-</p>
-
 **Thanks for taking the time to contribute!**
 
 This project is simpler than most, so it's a good place to start contributing to the open source community, even if you're a newbie.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -49,5 +49,5 @@ features:
 ---
 
 ::: tip ✨ Interactive demo
-See our [charts.stockindicators.dev](https://charts.stockindicators.dev) for interactive visualization demo of library generated indicators.
+See our [charts.stockindicators.dev](https://charts.stockindicators.dev) for interactive visualization demo of library indicators.
 :::

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ import LandingCharts from './.vitepress/components/LandingCharts.vue'
 Build trading algorithms, charting applications, machine learning models, or market analysis tools with your own [OHLCV](/guide/getting-started#historical-bars) price bars from any market: equities, commodities, forex, or cryptocurrencies.
 
 ::: tip ✨ v3 adds streaming support
-Our new **`FacioQuo.Stock.Indicators`** NuGet library, formerly named `Skender.Stock.Indicators`, adds stream hub and buffer list style indicators to enable your incremental and real-time price data scenarios.
+Our new **`FacioQuo.Stock.Indicators`** NuGet library, formerly `Skender.Stock.Indicators`, adds stream hub and buffer list style indicators to enable your incremental and real-time price data scenarios.
 Still on v2? See our [migration guide →](/migration/v3)
 :::
 


### PR DESCRIPTION
Codacy code coverage reporting and related configuration got messed up when we moved the repo a few days ago. Fixing a few things here related.

## Codacy quality-noise reconfiguration

Tuned the Codacy issue config against the Cloud production data (838 issues, all C#). All findings trace to just 2 tools / a few patterns, so the cleanup is surgical:

| Tool | Pattern | Change | Impact |
| --- | --- | --- | --- |
| SonarC# | `S2360` — Avoid Using Optional Parameters | **Disable** | −467 issues (55% of all findings) |
| Lizard | `ccn-medium` — cyclomatic complexity | threshold **8 → 15** | ~−100 |
| Lizard | `nloc-medium` — function length | threshold **50 → 80** | ~−85 |

**Why `S2360`:** it contradicts the library's intentional public-API design — indicator methods with optional, default-valued parameters (e.g. `int lookbackPeriods = 14`), present in ~324 source files. Pure convention mismatch (Warning/BestPractice), not a real defect.

**Why the Lizard tuning:** `ccn=8` / `nloc=50` are aggressive for numerical/financial algorithms. New thresholds align with the repo's own complexity goal (`fileComplexityValueThreshold = 20`) and keep genuine outliers flagged.

**Kept on purpose:** `SonarCSharp_S1244` (Avoid Testing Floating Point Numbers for Equality) — High/ErrorProne, 137 issues. Float-equality is a real correctness risk in a financial library; triage individual hits in Codacy rather than disabling.

**Projected result:** ~838 → ~195 Cloud issues (~77% reduction), remaining issues all high-value.

### How it's applied
These patterns are enabled by the org-level **"FacioQuo coding standard" (#148207)**, so the changes are made by editing that standard in the Codacy web UI (Organization → Coding Standards → Edit) rather than via repo config — this keeps governance intact and propagates to all linked repos. The local `.codacy/codacy.config.json` (gitignored) documents the exact change set.

> Note: local Codacy analysis can't validate this on Windows — the C# analyzers (SonarC# cloud-only, Lizard win32-unsupported) don't run locally — so decisions were driven by the Cloud issue overview, and the post-change count will be confirmed by Codacy reanalysis.
