### PR TITLE
perf: Eliminate O(n²) front-pruning in BufferList and StreamHub caches

### DIFF
--- a/docs/migration/v3.md
+++ b/docs/migration/v3.md
@@ -289,32 +289,6 @@ Popular indicators with complete streaming documentation:
 - Oscillators: [RSI](/indicators/rsi), [MACD](/indicators/macd), [Stochastic](/indicators/stoch)
 - Channels: [Bollinger Bands](/indicators/bollinger-bands), [Keltner](/indicators/keltner)
 
-## Known issues and tips
-
-A few v3 behaviors are known to be sub-optimal and are tracked in our backlog. They aren't breaking — the library stays usable — but we mention them here so you can recognize the symptoms and plan around them.
-
-### Streaming performance degrades after the cache prunes
-
-Both the BufferList (`MaxListSize`) and StreamHub (`maxCacheSize`) styles keep a rolling cache that defaults to **100,000 elements**. Once that limit is exceeded, the oldest results are automatically pruned, and two symptoms follow:
-
-- **Throughput drops noticeably** once pruning begins — still functional, just slower.
-- **Early results are no longer retrievable**, and a late arrival or correction that triggers a rebuild can't see the pruned history, so rebuilt values for stateful indicators become approximate.
-
-If you replay a large historical dataset — for example, several years of minute bars — and need the full history resident or steady performance, raise the cache size so pruning never triggers:
-
-::: tip ✨ Raise the cache size for large datasets
-
-```csharp
-// StreamHub: size the root hub (it cascades to chained hubs)
-BarHub barHub = new(maxCacheSize: 250_000);
-
-// BufferList: size the list
-SmaList smaList = new(20) { MaxListSize = 250_000 };
-```
-
-`maxCacheSize` is inherited by every chained hub, so size it for the **largest warmup in the whole chain**. Each hub validates the size against its own warmup floor at construction and throws `ArgumentOutOfRangeException` if it is too small. See [Stream hub memory management](/guide/styles/stream#memory-management) for details.
-:::
-
 ## Need help?
 
 - [Guide and Pro tips](/guide/getting-started) - Getting started with v3

--- a/src/_common/BufferLists/BufferList.cs
+++ b/src/_common/BufferLists/BufferList.cs
@@ -24,7 +24,7 @@ namespace FacioQuo.Stock.Indicators;
 public abstract class BufferList<TResult> : IReadOnlyList<TResult>
     where TResult : ISeries
 {
-    private readonly List<TResult> _internalList = [];
+    private readonly PruningList<TResult> _internalList = new();
 
     /// <summary>
     /// Gets the result at the specified index.

--- a/src/_common/Generics/PruningList.cs
+++ b/src/_common/Generics/PruningList.cs
@@ -1,0 +1,277 @@
+using System.Collections;
+
+namespace FacioQuo.Stock.Indicators;
+
+/// <summary>
+/// Append-only list with O(1) amortized removal from the front, used as the
+/// backing store for sliding-window caches that prune their oldest items.
+/// </summary>
+/// <remarks>
+/// A plain <see cref="List{T}"/> shifts every remaining element on each
+/// front removal, so pruning one item per add (the steady state once a
+/// cache reaches its cap) degrades to O(n²) over a long stream. This list
+/// keeps a logical <c>head</c> offset into an underlying <see cref="List{T}"/>:
+/// front removals just advance the offset in O(1), and the dead prefix is
+/// physically reclaimed only when it grows to the size of the live window —
+/// keeping amortized removal O(1) and storage bounded to ~2x the live count.
+/// <para>
+/// Index, count, enumeration, and mutation semantics match
+/// <see cref="List{T}"/> over the live window, so this type is a drop-in
+/// replacement wherever only the retained (post-prune) elements are observed.
+/// </para>
+/// </remarks>
+/// <typeparam name="T">Type of elements stored in the list.</typeparam>
+internal sealed class PruningList<T> : IList<T>, IReadOnlyList<T>
+{
+    private const string ModifiedDuringEnumeration
+        = "Collection was modified; enumeration operation may not execute.";
+
+    private readonly List<T> _items;
+
+    /// <summary>
+    /// Number of logically-removed items at the front of <see cref="_items"/>.
+    /// </summary>
+    private int _head;
+
+    /// <summary>
+    /// Mutation counter used to detect modification during enumeration.
+    /// </summary>
+    private int _version;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PruningList{T}"/> class.
+    /// </summary>
+    public PruningList() => _items = [];
+
+    /// <inheritdoc/>
+    public int Count => _items.Count - _head;
+
+    /// <inheritdoc/>
+    public bool IsReadOnly => false;
+
+    /// <inheritdoc/>
+    public T this[int index]
+    {
+        get {
+            if ((uint)index >= (uint)Count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+
+            return _items[_head + index];
+        }
+
+        set {
+            if ((uint)index >= (uint)Count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+
+            _items[_head + index] = value;
+            _version++;
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Add(T item)
+    {
+        _items.Add(item);
+        _version++;
+    }
+
+    /// <inheritdoc/>
+    public void Insert(int index, T item)
+    {
+        if ((uint)index > (uint)Count)
+        {
+            throw new ArgumentOutOfRangeException(nameof(index));
+        }
+
+        _items.Insert(_head + index, item);
+        _version++;
+    }
+
+    /// <inheritdoc/>
+    public void RemoveAt(int index)
+    {
+        if ((uint)index >= (uint)Count)
+        {
+            throw new ArgumentOutOfRangeException(nameof(index));
+        }
+
+        if (index == 0)
+        {
+            AdvanceHead(1);
+        }
+        else
+        {
+            _items.RemoveAt(_head + index);
+            _version++;
+        }
+    }
+
+    /// <summary>
+    /// Removes a range of elements from the live window.
+    /// Front removals (<paramref name="index"/> of 0) are O(1) amortized.
+    /// </summary>
+    /// <param name="index">Zero-based starting index of the range to remove.</param>
+    /// <param name="count">Number of elements to remove.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when index or count is negative.</exception>
+    /// <exception cref="ArgumentException">Thrown when the range exceeds the live window.</exception>
+    public void RemoveRange(int index, int count)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+
+        if (Count - index < count)
+        {
+            throw new ArgumentException(
+                "Offset and length were out of bounds for the list.");
+        }
+
+        if (count == 0)
+        {
+            return;
+        }
+
+        if (index == 0)
+        {
+            AdvanceHead(count);
+        }
+        else
+        {
+            _items.RemoveRange(_head + index, count);
+            _version++;
+        }
+    }
+
+    /// <summary>
+    /// Removes all elements in the live window that match the predicate.
+    /// </summary>
+    /// <param name="match">Predicate that defines the elements to remove.</param>
+    /// <returns>Number of elements removed.</returns>
+    public int RemoveAll(Predicate<T> match)
+    {
+        // physically reclaim the dead prefix so List<T>.RemoveAll only
+        // scans the live window (this path is infrequent)
+        Reclaim();
+
+        int removed = _items.RemoveAll(match);
+
+        if (removed > 0)
+        {
+            _version++;
+        }
+
+        return removed;
+    }
+
+    /// <inheritdoc/>
+    public void Clear()
+    {
+        _items.Clear();
+        _head = 0;
+        _version++;
+    }
+
+    /// <inheritdoc/>
+    public bool Contains(T item) => IndexOf(item) >= 0;
+
+    /// <inheritdoc/>
+    public int IndexOf(T item)
+    {
+        int found = _items.IndexOf(item, _head);
+        return found < 0 ? -1 : found - _head;
+    }
+
+    /// <inheritdoc/>
+    public bool Remove(T item)
+    {
+        int index = IndexOf(item);
+
+        if (index < 0)
+        {
+            return false;
+        }
+
+        RemoveAt(index);
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public void CopyTo(T[] array, int arrayIndex)
+        => _items.CopyTo(_head, array, arrayIndex, Count);
+
+    /// <summary>
+    /// Copies the live window to a new array.
+    /// </summary>
+    /// <returns>An array containing the live (retained) elements.</returns>
+    public T[] ToArray()
+    {
+        int count = Count;
+
+        if (count == 0)
+        {
+            return [];
+        }
+
+        T[] array = new T[count];
+        _items.CopyTo(_head, array, 0, count);
+        return array;
+    }
+
+    /// <inheritdoc/>
+    public IEnumerator<T> GetEnumerator()
+    {
+        int version = _version;
+        int end = _items.Count;
+
+        for (int i = _head; i < end; i++)
+        {
+            if (version != _version)
+            {
+                throw new InvalidOperationException(ModifiedDuringEnumeration);
+            }
+
+            yield return _items[i];
+        }
+
+        if (version != _version)
+        {
+            throw new InvalidOperationException(ModifiedDuringEnumeration);
+        }
+    }
+
+    /// <inheritdoc/>
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    /// <summary>
+    /// Advances the logical head, reclaiming storage once the dead prefix
+    /// reaches the size of the live window to keep amortized cost O(1).
+    /// </summary>
+    /// <param name="count">Number of front items to logically remove.</param>
+    private void AdvanceHead(int count)
+    {
+        _head += count;
+        _version++;
+
+        if (_head >= _items.Count - _head)
+        {
+            Reclaim();
+        }
+    }
+
+    /// <summary>
+    /// Physically removes the dead prefix from the underlying list.
+    /// </summary>
+    private void Reclaim()
+    {
+        if (_head == 0)
+        {
+            return;
+        }
+
+        _items.RemoveRange(0, _head);
+        _head = 0;
+    }
+}

--- a/src/_common/StreamHub/StreamHub.cs
+++ b/src/_common/StreamHub/StreamHub.cs
@@ -42,11 +42,12 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamHub<TIn, TOut>
         // inherit max cache size from provider
         MaxCacheSize = provider.MaxCacheSize;
 
-        // start the cache empty and let List<T> growth amortize: a fixed
+        // start the cache empty and let growth amortize: a fixed
         // pre-allocation (formerly 800 slots, ~6.4KB per hub) dominates the
         // footprint of multi-symbol deployments with thousands of hubs,
-        // while growth-on-demand costs only a handful of one-time copies
-        Cache = [];
+        // while growth-on-demand costs only a handful of one-time copies.
+        // PruningList gives O(1) amortized front pruning once capped.
+        Cache = new PruningList<TOut>();
 
         // build read-only cache reference
         Results = Cache.AsReadOnly();
@@ -114,7 +115,7 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamHub<TIn, TOut>
     /// <summary>
     /// Gets the cache of stored values (base).
     /// </summary>
-    internal List<TOut> Cache { get; }
+    internal PruningList<TOut> Cache { get; }
 
     /// <summary>
     /// Gets the current count of repeated caching attempts.

--- a/tests/indicators/_common/Generics/PruningList.Tests.cs
+++ b/tests/indicators/_common/Generics/PruningList.Tests.cs
@@ -1,0 +1,271 @@
+namespace Utilities;
+
+[TestClass]
+public class PruningListTests : TestBase
+{
+    [TestMethod]
+    public void Add_ThenIndex_ReflectsInsertionOrder()
+    {
+        PruningList<int> sut = [];
+
+        for (int i = 0; i < 5; i++)
+        {
+            sut.Add(i);
+        }
+
+        sut.Count.Should().Be(5);
+        sut[0].Should().Be(0);
+        sut[4].Should().Be(4);
+        sut.Should().ContainInOrder(0, 1, 2, 3, 4);
+    }
+
+    [TestMethod]
+    public void RemoveRange_FromFront_RetainsTailWindow()
+    {
+        PruningList<int> sut = [];
+
+        for (int i = 0; i < 10; i++)
+        {
+            sut.Add(i);
+        }
+
+        sut.RemoveRange(0, 3);
+
+        sut.Count.Should().Be(7);
+        sut[0].Should().Be(3);
+        sut.Should().ContainInOrder(3, 4, 5, 6, 7, 8, 9);
+    }
+
+    [TestMethod]
+    public void RemoveRange_FromMiddle_RemovesInteriorElements()
+    {
+        PruningList<int> sut = [];
+
+        for (int i = 0; i < 10; i++)
+        {
+            sut.Add(i);
+        }
+
+        // prune front first so a head offset is active
+        sut.RemoveRange(0, 2);
+        sut.RemoveRange(3, 2); // removes live indices 3,4 => values 5,6
+
+        sut.Should().ContainInOrder(2, 3, 4, 7, 8, 9);
+    }
+
+    [TestMethod]
+    public void RemoveAt_Front_AdvancesWindow()
+    {
+        PruningList<int> sut = [];
+
+        for (int i = 0; i < 4; i++)
+        {
+            sut.Add(i);
+        }
+
+        sut.RemoveAt(0);
+
+        sut.Count.Should().Be(3);
+        sut[0].Should().Be(1);
+    }
+
+    [TestMethod]
+    public void Insert_WithActiveHead_PlacesAtLiveIndex()
+    {
+        PruningList<int> sut = [];
+
+        for (int i = 0; i < 6; i++)
+        {
+            sut.Add(i);
+        }
+
+        sut.RemoveRange(0, 2); // live: 2,3,4,5
+        sut.Insert(1, 99);     // live: 2,99,3,4,5
+
+        sut.Should().ContainInOrder(2, 99, 3, 4, 5);
+    }
+
+    [TestMethod]
+    public void RemoveAll_WithActiveHead_RemovesMatchingLiveItems()
+    {
+        PruningList<int> sut = [];
+
+        for (int i = 0; i < 10; i++)
+        {
+            sut.Add(i);
+        }
+
+        sut.RemoveRange(0, 3); // live: 3..9
+
+        int removed = sut.RemoveAll(static x => x % 2 == 0);
+
+        removed.Should().Be(3); // 4, 6, 8
+        sut.Should().ContainInOrder(3, 5, 7, 9);
+    }
+
+    [TestMethod]
+    public void IndexOf_WithActiveHead_ReturnsLiveRelativeIndex()
+    {
+        PruningList<int> sut = [];
+
+        for (int i = 0; i < 6; i++)
+        {
+            sut.Add(i);
+        }
+
+        sut.RemoveRange(0, 2); // live: 2,3,4,5
+
+        sut.IndexOf(4).Should().Be(2);
+        sut.IndexOf(2).Should().Be(0);
+        sut.IndexOf(0).Should().Be(-1); // pruned
+        sut.Contains(3).Should().BeTrue();
+        sut.Contains(1).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void Remove_LiveItem_RemovesAndReturnsTrue()
+    {
+        PruningList<int> sut = [];
+
+        for (int i = 0; i < 5; i++)
+        {
+            sut.Add(i);
+        }
+
+        sut.Remove(2).Should().BeTrue();
+        sut.Remove(99).Should().BeFalse();
+        sut.Should().ContainInOrder(0, 1, 3, 4);
+    }
+
+    [TestMethod]
+    public void ToArrayAndCopyTo_ReturnLiveWindowOnly()
+    {
+        PruningList<int> sut = [];
+
+        for (int i = 0; i < 8; i++)
+        {
+            sut.Add(i);
+        }
+
+        sut.RemoveRange(0, 5); // live: 5,6,7
+
+        sut.ToArray().Should().Equal(5, 6, 7);
+
+        int[] buffer = new int[3];
+        sut.CopyTo(buffer, 0);
+        buffer.Should().Equal(5, 6, 7);
+    }
+
+    [TestMethod]
+    public void Clear_ResetsCountAndHead()
+    {
+        PruningList<int> sut = [];
+
+        for (int i = 0; i < 5; i++)
+        {
+            sut.Add(i);
+        }
+
+        sut.RemoveRange(0, 2);
+        sut.Clear();
+
+        sut.Count.Should().Be(0);
+
+        sut.Add(42);
+        sut[0].Should().Be(42);
+    }
+
+    [TestMethod]
+    public void Indexer_OutOfRange_Throws()
+    {
+        PruningList<int> sut = [];
+        sut.Add(1);
+        sut.RemoveRange(0, 1); // empty live window, head active
+
+        Action read = () => _ = sut[0];
+        read.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [TestMethod]
+    public void RemoveRange_BeyondLiveWindow_Throws()
+    {
+        PruningList<int> sut = [];
+
+        for (int i = 0; i < 3; i++)
+        {
+            sut.Add(i);
+        }
+
+        Action act = () => sut.RemoveRange(0, 5);
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [TestMethod]
+    public void Enumerate_WhenModified_Throws()
+    {
+        PruningList<int> sut = [];
+
+        for (int i = 0; i < 5; i++)
+        {
+            sut.Add(i);
+        }
+
+        Action act = () => {
+            foreach (int _ in sut)
+            {
+                sut.Add(100);
+            }
+        };
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [TestMethod]
+    public void AsReadOnly_ReflectsLiveWindowAndIsImmutable()
+    {
+        PruningList<int> sut = [];
+
+        for (int i = 0; i < 6; i++)
+        {
+            sut.Add(i);
+        }
+
+        IReadOnlyList<int> view = ((IList<int>)sut).AsReadOnly();
+
+        // not castable to mutable list
+        (view is List<int>).Should().BeFalse();
+
+        // reflects live window after pruning
+        sut.RemoveRange(0, 4);
+        view.Should().ContainInOrder(4, 5);
+        view.Count.Should().Be(2);
+    }
+
+    [TestMethod]
+    public void StreamingPrune_AtSteadyState_MatchesSlidingWindowOracle()
+    {
+        const int cap = 500;
+        const int total = 50_000;
+
+        PruningList<int> sut = [];
+
+        for (int i = 0; i < total; i++)
+        {
+            sut.Add(i);
+
+            if (sut.Count > cap)
+            {
+                sut.RemoveRange(0, sut.Count - cap);
+            }
+        }
+
+        // exact-count semantics preserved
+        sut.Count.Should().Be(cap);
+
+        // live window is the most recent `cap` values, in order
+        IEnumerable<int> expected = Enumerable.Range(total - cap, cap);
+        sut.Should().ContainInOrder(expected);
+        sut[0].Should().Be(total - cap);
+        sut[cap - 1].Should().Be(total - 1);
+    }
+}


### PR DESCRIPTION
Once `BufferList<T>` and `StreamHub` reach their size caps (`MaxListSize`/`MaxCacheSize`, default 100k), every subsequent add prunes one item from the front of a backing `List<T>`. Front removal shifts the entire array, so steady-state streaming degrades to **O(n²)** — measured at ~7.5s for ADL over 500k periods.

### Changes

- **New `PruningList<T>`** (`src/_common/Generics/PruningList.cs`) — `IList<T>` + `IReadOnlyList<T>` backed by a `List<T>` with a logical head offset. Front removals advance the offset in **O(1)**; the dead prefix is physically reclaimed only when it reaches the live-window size, keeping amortized removal O(1) and storage bounded to ~2x the cap. Index/count/enumeration/mutation semantics match `List<T>` over the live window, so it drops in wherever only retained (post-prune) elements are observed.
- **`BufferList<T>._internalList`** now a `PruningList<TResult>` — `PruneList`'s `RemoveRange(0, overflow)` becomes O(1) amortized; derived `PruneList` overrides are untouched.
- **`StreamHub<TIn,TOut>.Cache`** now a `PruningList<TOut>` — `PruneCache` and the `OnPrune` observer cascade become O(1) amortized.
- **Tests** for `PruningList<T>` covering live-window semantics under an active head (insert/remove/index/enumerate/`AsReadOnly`) plus a steady-state sliding-window oracle.

Exact-count semantics are preserved — caches still settle to exactly `MaxListSize`/`MaxCacheSize` — so no existing pruning tests changed.

### Impact (ADL, 500,000 periods)

| Style | Before | After |
|---|---|---|
| BufferList | ~7,555 ms | ~69 ms |
| StreamHub | ~7,645 ms | ~353 ms |