### PR TITLE
Split Candlesticks into CandlesticksExtensions (#2146)

### DIFF
--- a/docs/plans/file-reorg.plan.md
+++ b/docs/plans/file-reorg.plan.md
@@ -17,12 +17,13 @@ The **non-breaking** portion of this plan is implemented (see #1810 for the trac
 - **Multi-type files split**: `BetaType`, `PivotPointType`, `PivotTrend`, `TradeTicks`, `IndicatorConfigExtensions`, `IInertProvider` each moved to their own file.
 - **Internal-only class renames**: `internal static class StreamHub` → `StreamHubUtilities` (resolves the Task 4.2 conflict without touching public API).
 - **Test classes standardized** (Task 4.11): `{Ind}SeriesTests`, `{Ind}BufferListTests`, `{Ind}HubTests`, `{Ind}CatalogTests`, `{Ind}RegressionTests`, with files renamed to match class names.
+- **Extension-method holder classes introduced** ([#2146](https://github.com/facioquo/stock-indicators-dotnet/issues/2146), Tasks 2.2–2.4): `ReusableExtensions`, `PruningExtensions`, `SeekingExtensions`, `SortingExtensions`, `StringOutExtensions`, `CandlesticksExtensions` added; the legacy `Reusable`, `Pruning`, `Seeking`, `Sorting`, `StringOut`, `Candlesticks` holders now delegate to them via `[Obsolete]` non-extension members, consolidated into `src/Obsolete.V4.cs` (binary- and source-compatible, per the `Obsolete.V3.*` deprecate-then-remove pattern). `IndicatorConfigExtensions.ToBuilder(this IndicatorConfig)` (permanently shadowed by the `IndicatorConfig.ToBuilder()` instance method) is also `[Obsolete]`. `BarIntervals` and `NullMath` were audited and kept as-is (see Task 2.1/2.4).
 
 The **breaking** remainder ("completely perfect" file/type alignment) is tracked in v4-milestone sub-issues of #1810:
 
 - [#2137](https://github.com/facioquo/stock-indicators-dotnet/issues/2137) — Add `Series` suffix to indicator series classes (Tasks 4.8/4.9)
 - [#2138](https://github.com/facioquo/stock-indicators-dotnet/issues/2138) — Unify McGinley Dynamic type family naming (Task 4.10)
-- [#2139](https://github.com/facioquo/stock-indicators-dotnet/issues/2139) — Rename public extension-method holder classes to `*Extensions` (Tasks 2.2–2.4, 4.1)
+- [#2139](https://github.com/facioquo/stock-indicators-dotnet/issues/2139) — Delete the deprecated legacy holder classes now that #2146 has landed (Tasks 2.2–2.4, 4.1)
 - [#2140](https://github.com/facioquo/stock-indicators-dotnet/issues/2140) — Align result record names with indicator family names (`CorrResult`, `HtlResult`, `MaEnvelopeResult`, `WilliamsResult`)
 
 ---
@@ -206,27 +207,38 @@ Follow these conventions for all file naming:
 
 **Priority**: Medium - Most files already follow conventions; verify and fix inconsistencies
 
-- [ ] Task 2.1: Audit static utility classes (no `this` parameters)
-  - Verify `Pruning.cs`, `Seeking.cs`, `Sorting.cs` follow BCL patterns (like `Math.cs`, `File.cs`)
-  - Rename class `Seeking` → match file name if needed
-  - Keep descriptive functional names per Microsoft guidelines
+- [x] Task 2.1: Audit static utility classes (no `this` parameters)
+  - `BarIntervals` kept as-is: its primary API (`TryToBarInterval`) is a non-extension
+    lookup, matching the enum-companion/BCL pattern (like `Enum.TryParse`); the two
+    `this`-parameter convenience methods (`ToCode`, `ToBarInterval`) don't outweigh that.
+  - `Numerical` kept as-is (no `this` parameters; out of scope per issue #2146).
 
-- [ ] Task 2.2: Audit extension method classes (have `this` parameters)
-  - Verify classes with extension methods use `{Type}Extensions` or `{Area}Extensions` pattern
-  - Examples: `StringExtensions.cs`, `ReusableExtensions.cs`, `EnumerableExtensions.cs`
-  - Rename `Reusable.Utilities.cs` → `ReusableExtensions.cs` if it contains extension methods
+- [x] Task 2.2: Audit extension method classes (have `this` parameters) — v3.1, issue #2146
+  - `Reusable` → `ReusableExtensions` (`Common/Reusable/ReusableExtensions.cs`).
+  - `Pruning` → `PruningExtensions` (`Common/Pruning/PruningExtensions.cs`).
+  - `Seeking` → `SeekingExtensions` (`Common/SeekSort/SeekingExtensions.cs`).
+  - `Sorting` → `SortingExtensions` (`Common/SeekSort/SortingExtensions.cs`).
+  - Legacy `Reusable`, `Pruning`, `Seeking`, `Sorting` members converted to `[Obsolete]`
+    non-extension delegates, consolidated into `src/Obsolete.V4.cs`.
 
-- [ ] Task 2.3: Review `StringOut` partial classes
-  - Determine if `StringOut` contains extension methods or static utilities
-  - Keep as `StringOut.cs` if static utility (like `Convert.cs`)
-  - Rename to `StringExtensions.cs` if primarily extension methods
+- [x] Task 2.3: Review `StringOut` partial classes — v3.1, issue #2146
+  - `StringOut` is primarily extension methods: added `StringOutExtensions`
+    (`Common/StringFormatters/StringOutExtensions.List.cs`/`.Type.cs`); legacy `StringOut`
+    members (including `ColloquialTypeName`) converted to `[Obsolete]` delegates in
+    `src/Obsolete.V4.cs`.
 
-- [ ] Task 2.4: Review math utility classes
-  - Keep `NullMath.cs`, `Numerical.cs` as static utilities (follow `Math.cs` pattern)
-  - Verify `DeMath.cs` naming aligns with function
-  - Only use `*Extensions` suffix if they contain extension methods
+- [x] Task 2.4: Review math utility classes — v3.1, issue #2146
+  - `NullMath` kept as-is (maintainer decision, PR #2149 review): despite its members
+    using `this` parameters, `NullMath` stays named for parity with `System.Math`
+    rather than splitting into `NullMathExtensions`.
+  - `Candlesticks`: all-extension-method, so added `CandlesticksExtensions`
+    (`Common/Candles/CandlesticksExtensions.cs`); legacy `Candlesticks` converted to
+    `[Obsolete]` delegates in `src/Obsolete.V4.cs`.
+  - `Numerical`, `DeMath` unaffected (no `this` parameters).
 
-- [ ] Task 2.5: Run targeted tests for affected areas
+- [x] Task 2.5: Run targeted tests for affected areas
+  - Full `Tests.Indicators` and `Tests.PublicApi` suites pass (net10.0) with the new
+    `*Extensions` classes and `[Obsolete]` legacy delegates in place.
 
 ### Phase 3: Directory reorganization
 

--- a/src/Common/Candles/CandlesticksExtensions.cs
+++ b/src/Common/Candles/CandlesticksExtensions.cs
@@ -1,9 +1,9 @@
 namespace FacioQuo.Stock.Indicators;
 
 /// <summary>
-/// Utility for candlestick data.
+/// Provides extension methods for candlestick data.
 /// </summary>
-public static class Candlesticks
+public static class CandlesticksExtensions
 {
     /// <summary>
     /// Condenses the list of candle results by filtering out those with no match.

--- a/src/Obsolete.V4.cs
+++ b/src/Obsolete.V4.cs
@@ -221,6 +221,31 @@ public static class StringOut
         => StringOutExtensions.ColloquialTypeName(type);
 }
 
+/// <summary>Obsolete. Use <see cref="CandlesticksExtensions"/> instead.</summary>
+public static class Candlesticks
+{
+    /// <summary>Obsolete. Use <see cref="CandlesticksExtensions.Condense(IReadOnlyList{CandleResult})"/> instead.</summary>
+    [ExcludeFromCodeCoverage]
+    [Obsolete($"Use `{nameof(CandlesticksExtensions)}.{nameof(CandlesticksExtensions.Condense)}` instead.", false)]
+    public static IReadOnlyList<CandleResult> Condense(
+        IReadOnlyList<CandleResult> candleResults) => candleResults.Condense();
+
+    /// <summary>Obsolete. Use <see cref="CandlesticksExtensions.ToCandle{TBar}(TBar)"/> instead.</summary>
+    [ExcludeFromCodeCoverage]
+    [Obsolete($"Use `{nameof(CandlesticksExtensions)}.{nameof(CandlesticksExtensions.ToCandle)}` instead.", false)]
+    public static CandleProperties ToCandle<TBar>(
+        TBar bar)
+        where TBar : IBar
+        => bar.ToCandle();
+
+    /// <summary>Obsolete. Use <see cref="CandlesticksExtensions.ToCandles(IReadOnlyList{IBar})"/> instead.</summary>
+    [ExcludeFromCodeCoverage]
+    [Obsolete($"Use `{nameof(CandlesticksExtensions)}.{nameof(CandlesticksExtensions.ToCandles)}` instead.", false)]
+    public static IReadOnlyList<CandleProperties> ToCandles(
+        IReadOnlyList<IBar> bars)
+        => bars.ToCandles();
+}
+
 public static partial class IndicatorConfigExtensions
 {
     /// <summary>


### PR DESCRIPTION
## Summary

#2147 merged the core #2146 scope (`Reusable`, `Pruning`, `Seeking`, `Sorting`, `StringOut`, `IndicatorConfigExtensions`) into `refactor-renames`, along with a further directory reorg (`Extensions/Generics`/`Extensions/Math` split into `Pruning/`, `SeekSort/`, `StringFormatters/`, `Math/`). This PR is rebuilt on top of that and adds the remaining #2146 audit item that #2147 left unchanged:

- `Candlesticks` → `CandlesticksExtensions` (`src/Common/Candles/`)

`Candlesticks` is 100% `this`-parameter extension methods, so per plan Rule 4 (`docs/plans/file-reorg.plan.md`) it gets the same deprecate-then-remove split as the other holders: `CandlesticksExtensions` carries the real methods, and the legacy class's members become non-extension static delegates marked `[Obsolete]` that forward to it, added to the existing `src/Obsolete.V4.cs` consolidation.

**`NullMath` is kept as-is** per review feedback: despite having `this`-parameter members, it stays named for parity with `System.Math` rather than splitting into `NullMathExtensions`.

`BarIntervals` was audited and kept as-is: its primary API (`TryToBarInterval`) is a non-extension lookup matching the enum-companion/BCL pattern (like `Enum.TryParse`).

Also updates `docs/plans/file-reorg.plan.md` Phase 2 checklist to record the audit outcome for all classes.

### Why this is safe (binary- and source-compatible)

- Extension-syntax call sites bind to the new class — no ambiguity, since only one class carries the `this` modifier.
- Explicit static call sites keep compiling (with a deprecation warning) — dropping `this` only removes `ExtensionAttribute`, which doesn't change the method signature.
- Compiled consumers keep binding — the legacy methods still exist with identical IL signatures.

The breaking removal of the legacy holder classes remains tracked in #2139 (v4).

## Test plan

- [x] `dotnet build src/Indicators.csproj` (net10.0) — 0 warnings/errors
- [x] `dotnet tool run roslynator analyze src/Indicators.csproj --severity-level hidden` — 0 diagnostics
- [x] `dotnet test tests/Library/Tests.Indicators.csproj` (net10.0) — 2491 passed, 12 skipped (baseline), 0 failed
- [x] `dotnet test tests/PublicApi/Tests.PublicApi.csproj` (net10.0) — 76 passed, 0 failed

Closes #2146.
