### PR TITLE
docs: Lean on indy-charts client-side resilience for charts

### DIFF
--- a/docs/.vitepress/components/LandingCharts.vue
+++ b/docs/.vitepress/components/LandingCharts.vue
@@ -12,8 +12,8 @@ import {
 } from '@facioquo/indy-charts'
 
 import { DARK_SURFACE, LIGHT_SURFACE } from '../theme/chart-theme'
+import { CHART_API_BASE_URL, CHART_API_RESILIENCE } from '../theme/chart-api'
 
-const API_BASE = 'https://stock-charts-api.azurewebsites.net'
 const BAR_COUNT = 250
 const EMA_FAST_COLOR = '#ff4d8d'
 const EMA_SLOW_COLOR = '#26c6da'
@@ -111,7 +111,7 @@ async function renderCharts(): Promise<void> {
 
     setupIndyCharts()
 
-    const client = createApiClient({ baseUrl: API_BASE })
+    const client = createApiClient({ baseUrl: CHART_API_BASE_URL, ...CHART_API_RESILIENCE })
     const [quotes, listings] = await Promise.all([client.getQuotes(), client.getListings()])
     if (disposed || token !== loadToken) return
 

--- a/docs/.vitepress/theme/chart-api.ts
+++ b/docs/.vitepress/theme/chart-api.ts
@@ -1,0 +1,31 @@
+// Shared chart-API connection settings. Single source of truth so the VitePress
+// theme (every <StockIndicatorChart> instance) and the landing overlay talk to
+// the same endpoint with identical resilience — mirrors chart-theme.ts.
+//
+// indy-charts 0.8.0 added client-side resilience (facioquo/stock-charts#522):
+//   • retry — transient network / 5xx / 429 failures are retried with backoff.
+//     On by default (3 attempts, 500 ms base), so it is intentionally unset here.
+//   • staleCache — each successful response is cached in sessionStorage; if a
+//     later refetch exhausts its retries, the last-good value is served instead
+//     of erroring. Opt-in, enabled below.
+//
+// This lets the docs charts self-heal from a market-open API hiccup with no user
+// interaction, replacing the compensating fetch logic the docs used to carry.
+
+import type { ApiClientConfig } from '@facioquo/indy-charts'
+
+export const CHART_API_BASE_URL = 'https://stock-charts-api.azurewebsites.net'
+
+/** Note in the dev console when a chart falls back to the last-good cache. */
+function handleStale(context: string): void {
+  console.warn(`[stock-charts] Live "${context}" request failed; showing recent cached data.`)
+}
+
+/**
+ * Resilience options shared by every chart-API client. Spread into the
+ * `createApiClient` / `setupIndyChartsForVue` config alongside `baseUrl`.
+ */
+export const CHART_API_RESILIENCE: Pick<ApiClientConfig, 'staleCache' | 'onStale'> = {
+  staleCache: true,
+  onStale: handleStale
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -5,21 +5,19 @@ import './custom.scss'
 import Contributors from '../components/Contributors.vue'
 import { setupIndyChartsForVue } from '@facioquo/indy-charts/vue'
 import { DARK_SURFACE, LIGHT_SURFACE } from './chart-theme'
+import { CHART_API_BASE_URL, CHART_API_RESILIENCE } from './chart-api'
 
-const STOCK_CHARTS_API_BASE_URL = 'https://stock-charts-api.azurewebsites.net'
-const STOCK_CHARTS_API_HOST = new URL(STOCK_CHARTS_API_BASE_URL).hostname
+const CHART_API_HOST = new URL(CHART_API_BASE_URL).hostname
 const DEV_PROXY_PATH = '/chart-api-proxy'
 
 // In local development only, rewrite chart-API requests to Vite's
 // `/chart-api-proxy` (see config.mts) so they are forwarded server-side,
-// avoiding CORS — `localhost` is not in the API's allow-list.
+// avoiding CORS — `localhost` is not in the API's allow-list. In production the
+// docs origin IS allow-listed, so requests go straight to the API.
 //
-// In production the docs origin IS allow-listed, so requests go straight to the
-// API. When the API has a transient failure we deliberately do NOTHING here:
-// indy-charts surfaces its own "Chart data is currently unavailable… Retry"
-// state and recovers on reload. Substituting static fixtures or empty arrays
-// (the previous behaviour) masked outages as a misleading, sticky
-// "No chart data is available." empty state.
+// This is purely a dev CORS shim. Transient-failure handling now lives inside
+// indy-charts (auto-retry with backoff + last-good stale cache, configured in
+// chart-api.ts), so the docs no longer compensate for API blips here.
 function installDevApiProxy(): void {
   if (!import.meta.env.DEV) return
   if (typeof window === 'undefined' || typeof window.fetch !== 'function') return
@@ -31,7 +29,7 @@ function installDevApiProxy(): void {
       input instanceof Request ? input.url : String(input),
       window.location.href
     )
-    if (requestUrl.hostname !== STOCK_CHARTS_API_HOST) {
+    if (requestUrl.hostname !== CHART_API_HOST) {
       return originalFetch(input, init)
     }
     return originalFetch(`${DEV_PROXY_PATH}${requestUrl.pathname}${requestUrl.search}`, init)
@@ -49,7 +47,7 @@ export default {
     installDevApiProxy()
 
     setupIndyChartsForVue(app, {
-      api: { baseUrl: STOCK_CHARTS_API_BASE_URL },
+      api: { baseUrl: CHART_API_BASE_URL, ...CHART_API_RESILIENCE },
       defaults: {
         barCount: 250,
         quoteCount: 250,

--- a/docs/examples/UseQuoteApi/UseQuoteApi.csproj
+++ b/docs/examples/UseQuoteApi/UseQuoteApi.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Alpaca.Markets" Version="7.2.0" />
+    <PackageReference Include="Alpaca.Markets" Version="7.2.2" />
     <PackageReference Include="FacioQuo.Stock.Indicators" Version="3.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Stock Indicators for .NET documentation",
   "type": "module",
-  "packageManager": "pnpm@11.9.0",
+  "packageManager": "pnpm@11.13.0",
   "engines": {
     "node": ">=24"
   },
@@ -23,7 +23,7 @@
     "vue": "^3.5.39"
   },
   "dependencies": {
-    "@facioquo/indy-charts": "^0.7.0",
+    "@facioquo/indy-charts": "^0.8.0",
     "chart.js": "^4.5.1",
     "chartjs-plugin-annotation": "^3.1.0"
   }

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@facioquo/indy-charts':
-        specifier: ^0.7.0
-        version: 0.7.0(chart.js@4.5.1)(chartjs-plugin-annotation@3.1.0(chart.js@4.5.1))(vue@3.5.39)
+        specifier: ^0.8.0
+        version: 0.8.0(chart.js@4.5.1)(chartjs-plugin-annotation@3.1.0(chart.js@4.5.1))(vue@3.5.39)
       chart.js:
         specifier: ^4.5.1
         version: 4.5.1
@@ -224,8 +224,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@facioquo/indy-charts@0.7.0':
-    resolution: {integrity: sha512-v2Xh6DE8TdEHfN5QKxwwEetnMw2qK3G4CDgaZrR+PM/jh6YkDnNWe/ATRK5OlVINLayTlseZpQQT4vHmaAbOeQ==, tarball: https://npm.pkg.github.com/download/@facioquo/indy-charts/0.7.0/231ceca4500ddc5947d9385f42806c5744580509}
+  '@facioquo/indy-charts@0.8.0':
+    resolution: {integrity: sha512-5fRHPgfmOaY+gO7flSeP9cRHTaefsNuO19XdzRvUxo2L1S/6wlpsb9d0svV22EwHij+f1NKubm69nTdN0fg/Ig==, tarball: https://npm.pkg.github.com/download/@facioquo/indy-charts/0.8.0/485dbd879d57ba3882abb46a3805c0a0a1d164a4}
     engines: {node: '>=22'}
     peerDependencies:
       chart.js: ^4.5.1
@@ -1255,7 +1255,7 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@facioquo/indy-charts@0.7.0(chart.js@4.5.1)(chartjs-plugin-annotation@3.1.0(chart.js@4.5.1))(vue@3.5.39)':
+  '@facioquo/indy-charts@0.8.0(chart.js@4.5.1)(chartjs-plugin-annotation@3.1.0(chart.js@4.5.1))(vue@3.5.39)':
     dependencies:
       chart.js: 4.5.1
       chartjs-adapter-date-fns: 3.0.0(chart.js@4.5.1)(date-fns@4.4.0)

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -16,14 +16,14 @@
     </PackageReference>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <PackageVersion Include="Alpaca.Markets" Version="7.2.0" />
+    <PackageVersion Include="Alpaca.Markets" Version="7.2.2" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <!-- FluentAssertions pinned to v7.x to avoid licensing changes in v8+ -->
     <PackageVersion Include="FluentAssertions" Version="7.2.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Microsoft.VisualStudio.TestTools.Analyzers" Version="2.0.0" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="4.2.3" />
-    <PackageVersion Include="MSTest.TestFramework" Version="4.2.3" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="4.3.2" />
+    <PackageVersion Include="MSTest.TestFramework" Version="4.3.2" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
   </ItemGroup>
 </Project>

--- a/tests/Integration/packages.lock.json
+++ b/tests/Integration/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Alpaca.Markets": {
         "type": "Direct",
-        "requested": "[7.2.0, )",
-        "resolved": "7.2.0",
-        "contentHash": "XlrIrXXkcZG9EK9bERIzwsXb08BcKYDMP3S93znYadOK+xlQOr9Jfp4E/dVNORnmevCIyP5cy/nReOMmoIPXkA==",
+        "requested": "[7.2.2, )",
+        "resolved": "7.2.2",
+        "contentHash": "xjSc/xbPj1dcr32cpwGaA6rqofGZIYe5F0s0UohH0rkqMlXhNH6sgTJ+UwkQDD1BcqfqIzLmW265uNXfcc4aRw==",
         "dependencies": {
           "Newtonsoft.Json": "13.0.3",
           "Polly": "8.5.0"
@@ -33,22 +33,22 @@
       },
       "MSTest.TestAdapter": {
         "type": "Direct",
-        "requested": "[4.2.3, )",
-        "resolved": "4.2.3",
-        "contentHash": "oVV/luk0bBghnVvLaw8MwFlD7It0Cx9P2nKobeqIafmTQqFFWY69Wo801dxjeNaLzO/o9WQ84WSK84gXJuubhg==",
+        "requested": "[4.3.2, )",
+        "resolved": "4.3.2",
+        "contentHash": "uqpjJqQ3ws5z7Pq6BfMFpuqdrN2YIfe0Gfww91LRVXwxBdLqUaJd4JbHUImOSQvmK5m3PqW285kPjKbb69QFoA==",
         "dependencies": {
-          "MSTest.TestFramework": "4.2.3",
-          "Microsoft.Testing.Extensions.VSTestBridge": "2.2.3",
-          "Microsoft.Testing.Platform.MSBuild": "2.2.3"
+          "MSTest.TestFramework": "4.3.2",
+          "Microsoft.Testing.Extensions.VSTestBridge": "2.3.2",
+          "Microsoft.Testing.Platform.MSBuild": "2.3.2"
         }
       },
       "MSTest.TestFramework": {
         "type": "Direct",
-        "requested": "[4.2.3, )",
-        "resolved": "4.2.3",
-        "contentHash": "9zzij59YLh+tf+FRLNqhzHjmdspR91bol+jdQxLlxxTGMAML6LDbvuyXKMGdcrE84+QpKkk6KjTVBC5PBGrDeA==",
+        "requested": "[4.3.2, )",
+        "resolved": "4.3.2",
+        "contentHash": "Vlj3THt/BcOV/93k0Cdq29RNEsrY3TvUV6mF13rOuY8Gx7Ltd+LrOYId8AYu0cH9ioCYY/Sx1hppfI9p/vP+aw==",
         "dependencies": {
-          "MSTest.Analyzers": "4.2.3"
+          "MSTest.Analyzers": "4.3.2"
         }
       },
       "Roslynator.Analyzers": {
@@ -69,43 +69,43 @@
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
-        "resolved": "2.2.3",
-        "contentHash": "mLdW+JOR3kXYGTdgR/qc/UZBA0r+eCR2k6bUxTcuDj5w9WdIQ7Lol5MBUU7YOSGd9bs9bvhSYWAptgz0YtQqCA==",
+        "resolved": "2.3.2",
+        "contentHash": "Q1iapTk1DwFFT9aPtv4wxJHe22++NLxsg7IekEujac9RDAugxGQdCN0SQ1b9ryF78cdidhSBB17pHdCANurOyQ==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
-          "Microsoft.Testing.Platform": "2.2.3"
+          "Microsoft.Testing.Platform": "2.3.2"
         }
       },
       "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.2.3",
-        "contentHash": "hntvxJEkmUAx6C2xXc/PO38DqEQl4rimzOgSvTR1hAMruMid7R4RcXOrzzF33J66gKaN7jRaQ0TMW/nNfaV9jw==",
+        "resolved": "2.3.2",
+        "contentHash": "frw+Qa6gUxOZSw2Mw6SPtJT9gPzcP4nS9TfQhS0cHXKL6Rcp/CqLG+o4Psc1bHAhxW04rpzTBhjpNMnw2L7BuQ==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.2.3"
+          "Microsoft.Testing.Platform": "2.3.2"
         }
       },
       "Microsoft.Testing.Extensions.VSTestBridge": {
         "type": "Transitive",
-        "resolved": "2.2.3",
-        "contentHash": "7WlJISO8QKUK+d+WhgnANwy4ACwUrvICnviY/mthPwjZ2gVeDaSUAeBnMy2cxfzZgm8VATtGUDbYzUxsgV2CyQ==",
+        "resolved": "2.3.2",
+        "contentHash": "DXJIaLlwt+6GnPurlf7eVMI0wAZV5KCZrgGPibhx9i9LNxAkwEOK2jVzdVjLvvZ/SX9MUUaGJB9yXuF/VoT4/w==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.3.0",
-          "Microsoft.Testing.Extensions.Telemetry": "2.2.3",
-          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.2.3",
-          "Microsoft.Testing.Platform": "2.2.3"
+          "Microsoft.TestPlatform.ObjectModel": "18.4.0",
+          "Microsoft.Testing.Extensions.Telemetry": "2.3.2",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.3.2",
+          "Microsoft.Testing.Platform": "2.3.2"
         }
       },
       "Microsoft.Testing.Platform": {
         "type": "Transitive",
-        "resolved": "2.2.3",
-        "contentHash": "LhM1/Qoi8Ams5QcD4r3f09CSOono9iQr3NEJQItFtyzWB55nWTgEOsVqXqMWWWIwk3nkPqc+XfnlJmp8xUI5fg=="
+        "resolved": "2.3.2",
+        "contentHash": "FuJgIEfNU+rFHJYGhuqA8uup+3cryJ1N67Tijqo01Jd5xAr28ptz0aXkFfSqK3MhAUmGsrPpgQ92+3+0oXv8AA=="
       },
       "Microsoft.Testing.Platform.MSBuild": {
         "type": "Transitive",
-        "resolved": "2.2.3",
-        "contentHash": "Q22jJYJLx4srTinsAuoCskqmzjrBJC8YeGJMHHIcrf1dQeHoEZ7wsqDzTlENkMoke2qfufF7U+9u58nlZunH/Q==",
+        "resolved": "2.3.2",
+        "contentHash": "guFvvaE8FGUlB6h24jN+P+NBz/P5x4On9sk4n5UapUAPq4fr0y1AgUe4sXmItp7r2NMe3rhZYLE1teP9T9sVbg==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.2.3"
+          "Microsoft.Testing.Platform": "2.3.2"
         }
       },
       "Microsoft.TestPlatform.ObjectModel": {
@@ -129,8 +129,8 @@
       },
       "MSTest.Analyzers": {
         "type": "Transitive",
-        "resolved": "4.2.3",
-        "contentHash": "dxOZt8/LWuiox7rugInJoIa5Mmu3pBmXdfaoZOx/mxx8+sUFFpjBXPlWXQXGeWzpkVPNC3x1Jf7rt2h2Zjyvvg=="
+        "resolved": "4.3.2",
+        "contentHash": "GNvrVI6/Y5pNoKnK1/VELBls3XiHNZaj+zh14LtwlCqFI8zXTW3vuBe0Jv2qEr9wxHlOAQQBTJPRoNRjneGrKQ=="
       },
       "Newtonsoft.Json": {
         "type": "Transitive",

--- a/tests/Library/packages.lock.json
+++ b/tests/Library/packages.lock.json
@@ -29,22 +29,22 @@
       },
       "MSTest.TestAdapter": {
         "type": "Direct",
-        "requested": "[4.2.3, )",
-        "resolved": "4.2.3",
-        "contentHash": "oVV/luk0bBghnVvLaw8MwFlD7It0Cx9P2nKobeqIafmTQqFFWY69Wo801dxjeNaLzO/o9WQ84WSK84gXJuubhg==",
+        "requested": "[4.3.2, )",
+        "resolved": "4.3.2",
+        "contentHash": "uqpjJqQ3ws5z7Pq6BfMFpuqdrN2YIfe0Gfww91LRVXwxBdLqUaJd4JbHUImOSQvmK5m3PqW285kPjKbb69QFoA==",
         "dependencies": {
-          "MSTest.TestFramework": "4.2.3",
-          "Microsoft.Testing.Extensions.VSTestBridge": "2.2.3",
-          "Microsoft.Testing.Platform.MSBuild": "2.2.3"
+          "MSTest.TestFramework": "4.3.2",
+          "Microsoft.Testing.Extensions.VSTestBridge": "2.3.2",
+          "Microsoft.Testing.Platform.MSBuild": "2.3.2"
         }
       },
       "MSTest.TestFramework": {
         "type": "Direct",
-        "requested": "[4.2.3, )",
-        "resolved": "4.2.3",
-        "contentHash": "9zzij59YLh+tf+FRLNqhzHjmdspR91bol+jdQxLlxxTGMAML6LDbvuyXKMGdcrE84+QpKkk6KjTVBC5PBGrDeA==",
+        "requested": "[4.3.2, )",
+        "resolved": "4.3.2",
+        "contentHash": "Vlj3THt/BcOV/93k0Cdq29RNEsrY3TvUV6mF13rOuY8Gx7Ltd+LrOYId8AYu0cH9ioCYY/Sx1hppfI9p/vP+aw==",
         "dependencies": {
-          "MSTest.Analyzers": "4.2.3"
+          "MSTest.Analyzers": "4.3.2"
         }
       },
       "Roslynator.Analyzers": {
@@ -65,43 +65,43 @@
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
-        "resolved": "2.2.3",
-        "contentHash": "mLdW+JOR3kXYGTdgR/qc/UZBA0r+eCR2k6bUxTcuDj5w9WdIQ7Lol5MBUU7YOSGd9bs9bvhSYWAptgz0YtQqCA==",
+        "resolved": "2.3.2",
+        "contentHash": "Q1iapTk1DwFFT9aPtv4wxJHe22++NLxsg7IekEujac9RDAugxGQdCN0SQ1b9ryF78cdidhSBB17pHdCANurOyQ==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
-          "Microsoft.Testing.Platform": "2.2.3"
+          "Microsoft.Testing.Platform": "2.3.2"
         }
       },
       "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.2.3",
-        "contentHash": "hntvxJEkmUAx6C2xXc/PO38DqEQl4rimzOgSvTR1hAMruMid7R4RcXOrzzF33J66gKaN7jRaQ0TMW/nNfaV9jw==",
+        "resolved": "2.3.2",
+        "contentHash": "frw+Qa6gUxOZSw2Mw6SPtJT9gPzcP4nS9TfQhS0cHXKL6Rcp/CqLG+o4Psc1bHAhxW04rpzTBhjpNMnw2L7BuQ==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.2.3"
+          "Microsoft.Testing.Platform": "2.3.2"
         }
       },
       "Microsoft.Testing.Extensions.VSTestBridge": {
         "type": "Transitive",
-        "resolved": "2.2.3",
-        "contentHash": "7WlJISO8QKUK+d+WhgnANwy4ACwUrvICnviY/mthPwjZ2gVeDaSUAeBnMy2cxfzZgm8VATtGUDbYzUxsgV2CyQ==",
+        "resolved": "2.3.2",
+        "contentHash": "DXJIaLlwt+6GnPurlf7eVMI0wAZV5KCZrgGPibhx9i9LNxAkwEOK2jVzdVjLvvZ/SX9MUUaGJB9yXuF/VoT4/w==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.3.0",
-          "Microsoft.Testing.Extensions.Telemetry": "2.2.3",
-          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.2.3",
-          "Microsoft.Testing.Platform": "2.2.3"
+          "Microsoft.TestPlatform.ObjectModel": "18.4.0",
+          "Microsoft.Testing.Extensions.Telemetry": "2.3.2",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.3.2",
+          "Microsoft.Testing.Platform": "2.3.2"
         }
       },
       "Microsoft.Testing.Platform": {
         "type": "Transitive",
-        "resolved": "2.2.3",
-        "contentHash": "LhM1/Qoi8Ams5QcD4r3f09CSOono9iQr3NEJQItFtyzWB55nWTgEOsVqXqMWWWIwk3nkPqc+XfnlJmp8xUI5fg=="
+        "resolved": "2.3.2",
+        "contentHash": "FuJgIEfNU+rFHJYGhuqA8uup+3cryJ1N67Tijqo01Jd5xAr28ptz0aXkFfSqK3MhAUmGsrPpgQ92+3+0oXv8AA=="
       },
       "Microsoft.Testing.Platform.MSBuild": {
         "type": "Transitive",
-        "resolved": "2.2.3",
-        "contentHash": "Q22jJYJLx4srTinsAuoCskqmzjrBJC8YeGJMHHIcrf1dQeHoEZ7wsqDzTlENkMoke2qfufF7U+9u58nlZunH/Q==",
+        "resolved": "2.3.2",
+        "contentHash": "guFvvaE8FGUlB6h24jN+P+NBz/P5x4On9sk4n5UapUAPq4fr0y1AgUe4sXmItp7r2NMe3rhZYLE1teP9T9sVbg==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.2.3"
+          "Microsoft.Testing.Platform": "2.3.2"
         }
       },
       "Microsoft.TestPlatform.ObjectModel": {
@@ -125,8 +125,8 @@
       },
       "MSTest.Analyzers": {
         "type": "Transitive",
-        "resolved": "4.2.3",
-        "contentHash": "dxOZt8/LWuiox7rugInJoIa5Mmu3pBmXdfaoZOx/mxx8+sUFFpjBXPlWXQXGeWzpkVPNC3x1Jf7rt2h2Zjyvvg=="
+        "resolved": "4.3.2",
+        "contentHash": "GNvrVI6/Y5pNoKnK1/VELBls3XiHNZaj+zh14LtwlCqFI8zXTW3vuBe0Jv2qEr9wxHlOAQQBTJPRoNRjneGrKQ=="
       },
       "Newtonsoft.Json": {
         "type": "Transitive",

--- a/tests/PublicApi/packages.lock.json
+++ b/tests/PublicApi/packages.lock.json
@@ -23,22 +23,22 @@
       },
       "MSTest.TestAdapter": {
         "type": "Direct",
-        "requested": "[4.2.3, )",
-        "resolved": "4.2.3",
-        "contentHash": "oVV/luk0bBghnVvLaw8MwFlD7It0Cx9P2nKobeqIafmTQqFFWY69Wo801dxjeNaLzO/o9WQ84WSK84gXJuubhg==",
+        "requested": "[4.3.2, )",
+        "resolved": "4.3.2",
+        "contentHash": "uqpjJqQ3ws5z7Pq6BfMFpuqdrN2YIfe0Gfww91LRVXwxBdLqUaJd4JbHUImOSQvmK5m3PqW285kPjKbb69QFoA==",
         "dependencies": {
-          "MSTest.TestFramework": "4.2.3",
-          "Microsoft.Testing.Extensions.VSTestBridge": "2.2.3",
-          "Microsoft.Testing.Platform.MSBuild": "2.2.3"
+          "MSTest.TestFramework": "4.3.2",
+          "Microsoft.Testing.Extensions.VSTestBridge": "2.3.2",
+          "Microsoft.Testing.Platform.MSBuild": "2.3.2"
         }
       },
       "MSTest.TestFramework": {
         "type": "Direct",
-        "requested": "[4.2.3, )",
-        "resolved": "4.2.3",
-        "contentHash": "9zzij59YLh+tf+FRLNqhzHjmdspR91bol+jdQxLlxxTGMAML6LDbvuyXKMGdcrE84+QpKkk6KjTVBC5PBGrDeA==",
+        "requested": "[4.3.2, )",
+        "resolved": "4.3.2",
+        "contentHash": "Vlj3THt/BcOV/93k0Cdq29RNEsrY3TvUV6mF13rOuY8Gx7Ltd+LrOYId8AYu0cH9ioCYY/Sx1hppfI9p/vP+aw==",
         "dependencies": {
-          "MSTest.Analyzers": "4.2.3"
+          "MSTest.Analyzers": "4.3.2"
         }
       },
       "Roslynator.Analyzers": {
@@ -59,43 +59,43 @@
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
-        "resolved": "2.2.3",
-        "contentHash": "mLdW+JOR3kXYGTdgR/qc/UZBA0r+eCR2k6bUxTcuDj5w9WdIQ7Lol5MBUU7YOSGd9bs9bvhSYWAptgz0YtQqCA==",
+        "resolved": "2.3.2",
+        "contentHash": "Q1iapTk1DwFFT9aPtv4wxJHe22++NLxsg7IekEujac9RDAugxGQdCN0SQ1b9ryF78cdidhSBB17pHdCANurOyQ==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
-          "Microsoft.Testing.Platform": "2.2.3"
+          "Microsoft.Testing.Platform": "2.3.2"
         }
       },
       "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
         "type": "Transitive",
-        "resolved": "2.2.3",
-        "contentHash": "hntvxJEkmUAx6C2xXc/PO38DqEQl4rimzOgSvTR1hAMruMid7R4RcXOrzzF33J66gKaN7jRaQ0TMW/nNfaV9jw==",
+        "resolved": "2.3.2",
+        "contentHash": "frw+Qa6gUxOZSw2Mw6SPtJT9gPzcP4nS9TfQhS0cHXKL6Rcp/CqLG+o4Psc1bHAhxW04rpzTBhjpNMnw2L7BuQ==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.2.3"
+          "Microsoft.Testing.Platform": "2.3.2"
         }
       },
       "Microsoft.Testing.Extensions.VSTestBridge": {
         "type": "Transitive",
-        "resolved": "2.2.3",
-        "contentHash": "7WlJISO8QKUK+d+WhgnANwy4ACwUrvICnviY/mthPwjZ2gVeDaSUAeBnMy2cxfzZgm8VATtGUDbYzUxsgV2CyQ==",
+        "resolved": "2.3.2",
+        "contentHash": "DXJIaLlwt+6GnPurlf7eVMI0wAZV5KCZrgGPibhx9i9LNxAkwEOK2jVzdVjLvvZ/SX9MUUaGJB9yXuF/VoT4/w==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.3.0",
-          "Microsoft.Testing.Extensions.Telemetry": "2.2.3",
-          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.2.3",
-          "Microsoft.Testing.Platform": "2.2.3"
+          "Microsoft.TestPlatform.ObjectModel": "18.4.0",
+          "Microsoft.Testing.Extensions.Telemetry": "2.3.2",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.3.2",
+          "Microsoft.Testing.Platform": "2.3.2"
         }
       },
       "Microsoft.Testing.Platform": {
         "type": "Transitive",
-        "resolved": "2.2.3",
-        "contentHash": "LhM1/Qoi8Ams5QcD4r3f09CSOono9iQr3NEJQItFtyzWB55nWTgEOsVqXqMWWWIwk3nkPqc+XfnlJmp8xUI5fg=="
+        "resolved": "2.3.2",
+        "contentHash": "FuJgIEfNU+rFHJYGhuqA8uup+3cryJ1N67Tijqo01Jd5xAr28ptz0aXkFfSqK3MhAUmGsrPpgQ92+3+0oXv8AA=="
       },
       "Microsoft.Testing.Platform.MSBuild": {
         "type": "Transitive",
-        "resolved": "2.2.3",
-        "contentHash": "Q22jJYJLx4srTinsAuoCskqmzjrBJC8YeGJMHHIcrf1dQeHoEZ7wsqDzTlENkMoke2qfufF7U+9u58nlZunH/Q==",
+        "resolved": "2.3.2",
+        "contentHash": "guFvvaE8FGUlB6h24jN+P+NBz/P5x4On9sk4n5UapUAPq4fr0y1AgUe4sXmItp7r2NMe3rhZYLE1teP9T9sVbg==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "2.2.3"
+          "Microsoft.Testing.Platform": "2.3.2"
         }
       },
       "Microsoft.TestPlatform.ObjectModel": {
@@ -119,8 +119,8 @@
       },
       "MSTest.Analyzers": {
         "type": "Transitive",
-        "resolved": "4.2.3",
-        "contentHash": "dxOZt8/LWuiox7rugInJoIa5Mmu3pBmXdfaoZOx/mxx8+sUFFpjBXPlWXQXGeWzpkVPNC3x1Jf7rt2h2Zjyvvg=="
+        "resolved": "4.3.2",
+        "contentHash": "GNvrVI6/Y5pNoKnK1/VELBls3XiHNZaj+zh14LtwlCqFI8zXTW3vuBe0Jv2qEr9wxHlOAQQBTJPRoNRjneGrKQ=="
       },
       "Newtonsoft.Json": {
         "type": "Transitive",

--- a/tools/Directory.Packages.props
+++ b/tools/Directory.Packages.props
@@ -18,11 +18,10 @@
   <ItemGroup>
     <PackageVersion Include="Alpaca.Markets" Version="7.2.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="JKorf.Coinbase.Net" Version="3.11.0" />
+    <PackageVersion Include="JKorf.Coinbase.Net" Version="4.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="10.0.9" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
-
     <!-- temp pin for vulnerability in Microsoft.AspNetCore.OpenApi v10.0.9 dependency
          see https://github.com/advisories/GHSA-v5pm-xwqc-g5wc for details -->
     <PackageVersion Include="Microsoft.OpenApi" Version="2.8.0" />

--- a/tools/simulate/CoinbaseStrategy.cs
+++ b/tools/simulate/CoinbaseStrategy.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Coinbase.Net.Clients;
 using Coinbase.Net.Objects.Models;
+using CryptoExchange.Net.Objects;
 using CryptoExchange.Net.Objects.Sockets;
 using FacioQuo.Stock.Indicators;
 
@@ -61,7 +62,7 @@ internal sealed class CoinbaseStrategy : IDisposable
             Console.WriteLine($"[CoinbaseStrategy] Connecting to Coinbase WebSocket for {_symbol}");
 
             TaskCompletionSource<bool> completionSource = new();
-            CryptoExchange.Net.Objects.CallResult<UpdateSubscription> subscription;
+            WebSocketResult<UpdateSubscription> subscription;
 
             if (_mode == CoinbaseMode.Ticker)
             {

--- a/tools/simulate/HubStressTest.cs
+++ b/tools/simulate/HubStressTest.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Coinbase.Net.Clients;
 using Coinbase.Net.Objects.Models;
+using CryptoExchange.Net.Objects;
 using CryptoExchange.Net.Objects.Sockets;
 using FacioQuo.Stock.Indicators;
 
@@ -81,7 +82,7 @@ internal sealed class HubStressTest : IDisposable
         try
         {
             Console.WriteLine("==========================================");
-            Console.WriteLine("  HUB STRESS TEST - PR #1927 / Issue #1925");
+            Console.WriteLine("  HUB STRESS TEST ");
             Console.WriteLine("==========================================");
             Console.WriteLine($"Symbol: {_symbol}");
             Console.WriteLine($"Target bars: {_targetCount}");
@@ -104,7 +105,7 @@ internal sealed class HubStressTest : IDisposable
             Console.WriteLine("[HubStressTest] ⚠️  Trades arrive every few seconds - this tests real async concurrency");
             Console.WriteLine();
 
-            CryptoExchange.Net.Objects.CallResult<UpdateSubscription> subscription =
+            WebSocketResult<UpdateSubscription> subscription =
                 await _socketClient.AdvancedTradeApi
                     .SubscribeToTradeUpdatesAsync(
                         _symbol,

--- a/tools/simulate/packages.lock.json
+++ b/tools/simulate/packages.lock.json
@@ -4,11 +4,11 @@
     "net10.0": {
       "JKorf.Coinbase.Net": {
         "type": "Direct",
-        "requested": "[3.11.0, )",
-        "resolved": "3.11.0",
-        "contentHash": "EPYvBzATYdAlx8YzeisY/JMRwG4kI6L19l/6RZurIMBVlb7uGq7R0qxpmnnaxRCa4UXhtIdfBsr41QPDMhA66w==",
+        "requested": "[4.1.0, )",
+        "resolved": "4.1.0",
+        "contentHash": "bZL1Rat8Q0/I+qrBodU2O+h+M6uD31nSIQIQFT63nmuRi1yuZCR9TVIjGWc3OB4f+bTi+tFnQ/OtC6hc/LcReQ==",
         "dependencies": {
-          "CryptoExchange.Net": "11.2.2",
+          "CryptoExchange.Net": "12.1.0",
           "Microsoft.IdentityModel.JsonWebTokens": "8.15.0"
         }
       },
@@ -20,8 +20,8 @@
       },
       "CryptoExchange.Net": {
         "type": "Transitive",
-        "resolved": "11.2.2",
-        "contentHash": "rEaHoC6qgcFFmZD7n0R0NG0cSYWCwX45dKiEn8M01EtuVSwGTNuziuhtFxGgKdPMc1+/evS2M98cXzpyUu5KCA==",
+        "resolved": "12.1.0",
+        "contentHash": "MfCJv60TgzFzLwCl8u45P3xUPt4J/dTTmNoQfR+K1QG9fS5MoUZEIC9dx1nYAUALZRgz+8C3rljcj6vtrFzOWQ==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Binder": "10.0.1",
           "Microsoft.Extensions.Http": "10.0.1",


### PR DESCRIPTION
Closes #2124.

## Summary

`@facioquo/indy-charts@0.8.0` (facioquo/stock-charts#522) added **client-side resilience** to `createApiClient`:

- **retry** — transient failures (network / `5xx` / `429`) are retried with exponential backoff + jitter. **On by default** (`3` attempts, `500 ms` base).
- **staleCache** — each successful response is cached in `sessionStorage`; if a later refetch exhausts its retries, the last-good value is served instead of erroring. Opt-in.
- **onStale** — callback fired when stale data is served.

With that shipped, the docs charts no longer need to carry compensating logic. This PR wires the docs into the library's resilience.

## Changes

- **New `docs/.vitepress/theme/chart-api.ts`** — single source of truth for the chart-API base URL and the shared resilience options (`staleCache: true` + an `onStale` dev-console hook). Mirrors the existing `chart-theme.ts` lockstep pattern. `retry` is intentionally unset — it's on by default in 0.8.0 (and its type is `RetryConfig | false`, so a bare `true` wouldn't type-check).
- **`theme/index.ts`** — the `setupIndyChartsForVue` `api` config now spreads the shared resilience options; the duplicated hardcoded API base URL is gone; the now-outdated dev-proxy comment (describing the removed pre-#2123 fallback) is trimmed.
- **`LandingCharts.vue`** — its hand-rolled `createApiClient` gets the same base URL + resilience, so the home-page overlay self-heals too.
- The dev `window.fetch` → `/chart-api-proxy` shim **stays** — it's purely a local-dev CORS workaround (indicator endpoints are absolute API URLs), unrelated to resilience.

## Behavior

Equal-or-better than #2123: a market-open API blip now auto-retries and, after a first successful load, falls back to slightly-stale cached data rather than surfacing an error. The library's Retry/error UI remains the final fallback when all retries are exhausted with no cache.

## Testing

- `Test: Website charts (playwright)` — **84 passed** locally.
- `docs:build` succeeds (VitePress SSG).
- Links (htmlproofer) and a11y (pa11y) tasks are unaffected — changes are client-side chart-API wiring only; no markup, links, or ARIA changed.

## Notes on test scaffolding

The Playwright fixtures in `docs/.vitepress/public/data/chart-api/*.json` and the `mockStockChartsApi` route stubs are **kept**: 0.8.0's stale path is `sessionStorage`-based, not a first-class static/offline data source, so the hermetic mocks are still required for deterministic, offline tests.