### PR TITLE
chore: Rename CLOUDFLARE_API_KEY secret to CLOUDFLARE_API_TOKEN

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -77,7 +77,7 @@ jobs:
         id: deploy
         uses: cloudflare/wrangler-action@v4
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_KEY }}
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: >
             pages deploy docs/.vitepress/dist


### PR DESCRIPTION
The org secret was renamed `CLOUDFLARE_API_KEY` → `CLOUDFLARE_API_TOKEN` (rotated, aligned to the wrangler-conventional name). The old secret is deleted, so this reference was orphaned — update to the new name so the website deploy keeps working. Already on `cloudflare/wrangler-action@v4`; no behavior change.