### PR TITLE
fix: Bind catalog result and parameter names to real members

### DIFF
--- a/.agents/skills/indicator-catalog/SKILL.md
+++ b/.agents/skills/indicator-catalog/SKILL.md
@@ -74,6 +74,8 @@ public static partial class Ema
 - `AddDateParameter()` — DateTime
 - `AddSeriesParameter()` — `IReadOnlyList<T> where T : IReusable`
 - `minimum` and `maximum` required for all numeric parameters
+- `parameterName` must match the bound method's parameter name exactly — a mismatch makes a catalog-bound caller silently receive the default instead of the value it supplied
+- Declare parameters in the same order the method's signature declares them; `ListingExecutor` binds them positionally
 
 ## Result patterns
 
@@ -128,6 +130,7 @@ listings.Add(Beta.SeriesListing);
 - Wrong indicator method name
 - `isReusable: true` for `ISeries` models
 - Multiple `isReusable: true` results per indicator
+- A `dataName` or `parameterName` that names a member the library does not have
 
 ## Testing
 
@@ -147,3 +150,9 @@ public class EmaCatalogTests : TestBase
     }
 }
 ```
+
+`tests/Library/Common/Catalog/Catalog.Binding.Tests.cs` additionally enforces, for every
+listing in the catalog, that `MethodName` resolves to a real method, that each
+`dataName` resolves to a property on that method's result record, and that each
+`parameterName` resolves to a method parameter in signature order. A new listing that
+names a member the library does not have fails there — no per-indicator test needed.

--- a/src/Common/Catalog/ListingExecutor.cs
+++ b/src/Common/Catalog/ListingExecutor.cs
@@ -56,7 +56,27 @@ internal static class ListingExecutor
 
         if (methods.Count == 0)
         {
-            throw new InvalidOperationException($"Method {methodName} not found");
+            throw new InvalidOperationException($"Method '{methodName}' not found");
+        }
+
+        // Reject overrides that name no catalog parameter. Ignoring them would fall
+        // through to the default below, so the caller would receive a value it did not
+        // ask for, with no indication that its argument was discarded.
+        if (parameters is not null)
+        {
+            foreach (string providedName in parameters.Keys)
+            {
+                if (listing.Parameters?.Any(p => p.ParameterName == providedName) != true)
+                {
+                    string expected = listing.Parameters is { Count: > 0 }
+                        ? string.Join(", ", listing.Parameters.Select(static p => p.ParameterName))
+                        : "(none - this indicator takes no parameters)";
+
+                    throw new InvalidOperationException(
+                        $"Parameter '{providedName}' is not defined for indicator '{listing.Uiid}'. "
+                      + $"Expected one of: {expected}");
+                }
+            }
         }
 
         // Build parameter array using catalog metadata and user overrides
@@ -96,7 +116,7 @@ internal static class ListingExecutor
         }
 
         // Find the method that matches our parameter count
-        MethodInfo? targetMethod = methods.FirstOrDefault(m => m.GetParameters().Length == parameterList.Count) ?? throw new InvalidOperationException($"No {methodName} method found with {parameterList.Count} parameters");
+        MethodInfo? targetMethod = methods.FirstOrDefault(m => m.GetParameters().Length == parameterList.Count) ?? throw new InvalidOperationException($"No '{methodName}' method found with {parameterList.Count} parameters");
 
         // If the method is generic, make it specific for the IBar interface type.
         // Indicator methods that are generic use IBar as the constraint.

--- a/src/Indicators/k-q/Pmo/Pmo.Catalog.cs
+++ b/src/Indicators/k-q/Pmo/Pmo.Catalog.cs
@@ -11,7 +11,7 @@ public static partial class Pmo
             .WithId("PMO")
             .WithCategory(Category.Oscillator)
             .AddParameter<int>("timePeriods", "Time Periods", description: "Number of periods for the time frame", isRequired: false, defaultValue: 35, minimum: 1, maximum: 250)
-            .AddParameter<int>("smoothingPeriods", "Smoothing Periods", description: "Number of periods for smoothing", isRequired: false, defaultValue: 20, minimum: 1, maximum: 100)
+            .AddParameter<int>("smoothPeriods", "Smoothing Periods", description: "Number of periods for smoothing", isRequired: false, defaultValue: 20, minimum: 1, maximum: 100)
             .AddParameter<int>("signalPeriods", "Signal Periods", description: "Number of periods for the signal line", isRequired: false, defaultValue: 10, minimum: 1, maximum: 50)
             .AddResult("Pmo", "PMO", ResultType.Default, isReusable: true)
             .AddResult("Signal", "Signal", ResultType.Default)

--- a/src/Indicators/k-q/Prs/Prs.Catalog.cs
+++ b/src/Indicators/k-q/Prs/Prs.Catalog.cs
@@ -15,7 +15,6 @@ public static partial class Prs
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", description: "Number of periods for the PRS calculation", isRequired: false, defaultValue: 20, minimum: 1, maximum: 250)
             .AddResult("Prs", "PRS", ResultType.Default, isReusable: true)
             .AddResult("PrsPercent", "PRS %", ResultType.Default)
-            .AddResult("Sma", "SMA", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/t-z/Vwap/Vwap.Catalog.cs
+++ b/src/Indicators/t-z/Vwap/Vwap.Catalog.cs
@@ -12,8 +12,6 @@ public static partial class Vwap
             .WithCategory(Category.PriceChannel)
             .AddDateParameter("startDate", "Start Date", description: "Starting date for VWAP calculation", isRequired: false)
             .AddResult("Vwap", "VWAP", ResultType.Default, isReusable: true)
-            .AddResult("UpperBand", "Upper Band", ResultType.Default)
-            .AddResult("LowerBand", "Lower Band", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/tests/Library/Common/Catalog/Catalog.Binding.Tests.cs
+++ b/tests/Library/Common/Catalog/Catalog.Binding.Tests.cs
@@ -1,0 +1,175 @@
+using System.Reflection;
+
+namespace Catalogging;
+
+/// <summary>
+/// Catalog binding tests asserting that every listing names members that exist:
+/// - <c>MethodName</c> resolves to a public static indicator method
+/// - each <c>Results[].DataName</c> resolves to a property on the result record
+/// - each <c>Parameters[].ParameterName</c> resolves to a method parameter, in order
+/// </summary>
+/// <remarks>
+/// These names are plain strings in the <c>*.Catalog.cs</c> definitions, so the
+/// compiler cannot catch a rename or removal on the library side. Catalog-driven
+/// consumers — codegen, chart binding, tool wrappers — bind by these names, and a
+/// stale one either advertises a field that is never populated or, for a parameter,
+/// silently supplies the default instead of the requested value. Every listing is
+/// checked so drift fails here rather than downstream.
+/// </remarks>
+[TestClass]
+public class CatalogBindingTests : TestBase
+{
+    [TestMethod]
+    public void EveryListingBindsToAnIndicatorMethod()
+    {
+        List<string> violations = [];
+
+        foreach (IndicatorListing listing in Catalog.Get())
+        {
+            string identity = CatalogReflection.Describe(listing);
+
+            if (string.IsNullOrWhiteSpace(listing.MethodName))
+            {
+                violations.Add($"{identity}: MethodName is not set");
+                continue;
+            }
+
+            IReadOnlyList<MethodInfo> overloads
+                = CatalogReflection.GetOverloads(listing.MethodName);
+
+            if (overloads.Count == 0)
+            {
+                violations.Add($"{identity}: method '{listing.MethodName}' does not exist");
+                continue;
+            }
+
+            if (overloads.Any(static m => CatalogReflection.GetResultType(m) is null))
+            {
+                violations.Add(
+                    $"{identity}: result record type of '{listing.MethodName}' cannot be resolved");
+            }
+        }
+
+        string.Join(Environment.NewLine, violations).Should().BeEmpty(
+            "every catalog listing must name an indicator method that exists and returns a resolvable result record");
+    }
+
+    [TestMethod]
+    public void EveryResultDataNameExistsOnResultRecord()
+    {
+        List<string> violations = [];
+
+        foreach (IndicatorListing listing in Catalog.Get())
+        {
+            string identity = CatalogReflection.Describe(listing);
+
+            IReadOnlyList<MethodInfo> overloads
+                = CatalogReflection.GetOverloads(listing.MethodName);
+
+            List<Type> resultTypes = overloads
+                .Select(CatalogReflection.GetResultType)
+                .Where(static t => t != null)
+                .Distinct()
+                .ToList();
+
+            if (resultTypes.Count == 0)
+            {
+                continue; // reported by EveryListingBindsToAnIndicatorMethod
+            }
+
+            foreach (Type resultType in resultTypes)
+            {
+                ISet<string> properties = CatalogReflection.GetPropertyNames(resultType);
+
+                foreach (IndicatorResult result in listing.Results)
+                {
+                    if (!properties.Contains(result.DataName))
+                    {
+                        violations.Add(
+                            $"{identity}: DataName '{result.DataName}' is not a property on {resultType.Name} "
+                          + $"(has: {string.Join(", ", properties.Order(StringComparer.Ordinal))})");
+                    }
+                }
+            }
+        }
+
+        string.Join(Environment.NewLine, violations).Should().BeEmpty(
+            "every catalog result must name a property that exists on the indicator's result record");
+    }
+
+    [TestMethod]
+    public void EveryParameterNameMatchesMethodSignature()
+    {
+        List<string> violations = [];
+
+        foreach (IndicatorListing listing in Catalog.Get())
+        {
+            if (listing.Parameters is null or { Count: 0 })
+            {
+                continue;
+            }
+
+            string identity = CatalogReflection.Describe(listing);
+
+            IReadOnlyList<MethodInfo> overloads
+                = CatalogReflection.GetOverloads(listing.MethodName);
+
+            if (overloads.Count == 0)
+            {
+                continue; // reported by EveryListingBindsToAnIndicatorMethod
+            }
+
+            string[] catalogNames = listing.Parameters
+                .Select(static p => p.ParameterName)
+                .ToArray();
+
+            bool bound = overloads.Any(m => CatalogReflection.IsContiguousRun(
+                catalogNames,
+                m.GetParameters().Select(static p => p.Name).ToArray()));
+
+            if (!bound)
+            {
+                IEnumerable<string> signatures = overloads.Select(static m
+                    => $"({string.Join(", ", m.GetParameters().Select(static p => p.Name))})");
+
+                violations.Add(
+                    $"{identity}: parameters [{string.Join(", ", catalogNames)}] are not a contiguous, "
+                  + $"in-order run in any overload of '{listing.MethodName}' {string.Join(" | ", signatures)}");
+            }
+        }
+
+        string.Join(Environment.NewLine, violations).Should().BeEmpty(
+            "every catalog parameter must name a method parameter, in the contiguous order the executor binds them positionally");
+    }
+
+    [TestMethod]
+    public void EveryListingBindsToMethodOfItsOwnStyle()
+    {
+        List<string> violations = [];
+
+        foreach (IndicatorListing listing in Catalog.Get())
+        {
+            IReadOnlyList<MethodInfo> overloads
+                = CatalogReflection.GetOverloads(listing.MethodName);
+
+            if (overloads.Count == 0)
+            {
+                continue; // reported by EveryListingBindsToAnIndicatorMethod
+            }
+
+            if (!overloads.Any(m => CatalogReflection.GetImpliedStyle(m) == listing.Style))
+            {
+                IEnumerable<string> shapes = overloads
+                    .Select(static m => CatalogReflection.GetImpliedStyle(m)?.ToString() ?? "unrecognized")
+                    .Distinct(StringComparer.Ordinal);
+
+                violations.Add(
+                    $"{CatalogReflection.Describe(listing)}: '{listing.MethodName}' returns "
+                  + $"{string.Join(" or ", shapes)} shape, not {listing.Style}");
+            }
+        }
+
+        string.Join(Environment.NewLine, violations).Should().BeEmpty(
+            "a listing must bind to a method of its own style; all three styles share a result record, so the record alone cannot reveal a cross-style mistake");
+    }
+}

--- a/tests/Library/Common/Catalog/Catalog.Execution.Tests.cs
+++ b/tests/Library/Common/Catalog/Catalog.Execution.Tests.cs
@@ -236,4 +236,48 @@ public class CatalogExecutionTests : TestBase
         Action act = () => bars.ExecuteFromJson<RsiResult>(json);
         act.Should().Throw<InvalidOperationException>().WithMessage("*not found in catalog*");
     }
+
+    [TestMethod]
+    public void ExecuteRejectsUnknownParameterName()
+    {
+        // Arrange
+        IndicatorListing listing = Catalog.Get("EMA", Style.Series);
+        IReadOnlyList<Bar> bars = Bars.Take(50).ToList();
+
+        // Act — a name the listing does not define, e.g. one left over from a
+        // renamed catalog parameter
+        Action act = () => listing
+            .WithParams(new Dictionary<string, object> { ["lookbackPeriodz"] = 10 })
+            .FromSource((IEnumerable<IBar>)bars)
+            .Execute<EmaResult>();
+
+        // Assert — must fail loudly rather than silently substituting the default,
+        // and name the parameters it would have accepted
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*lookbackPeriodz*is not defined*")
+            .WithMessage("*Expected one of: lookbackPeriods*");
+    }
+
+    [TestMethod]
+    public void ExecuteRejectsUnknownParameterNameOnParameterlessListing()
+    {
+        // Arrange — a listing that declares no parameters at all
+        IndicatorListing listing = Catalog.Get("GATOR", Style.Series);
+        listing.Should().NotBeNull();
+        listing.Parameters.Should().BeNull("this listing declares no parameters");
+
+        IReadOnlyList<Bar> bars = Bars.Take(50).ToList();
+
+        // Act
+        Action act = () => listing
+            .WithParams(new Dictionary<string, object> { ["lookbackPeriods"] = 10 })
+            .FromSource((IEnumerable<IBar>)bars)
+            .Execute<GatorResult>();
+
+        // Assert — the message must say the indicator takes none, not trail off
+        // with an empty list
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*lookbackPeriods*is not defined*")
+            .WithMessage("*this indicator takes no parameters*");
+    }
 }

--- a/tests/Library/Common/Catalog/Catalog.Reflection.cs
+++ b/tests/Library/Common/Catalog/Catalog.Reflection.cs
@@ -1,0 +1,155 @@
+using System.Reflection;
+
+namespace Catalogging;
+
+/// <summary>
+/// Resolves the compiled members that a catalog listing claims to describe.
+/// </summary>
+/// <remarks>
+/// A listing carries only names: <see cref="IndicatorListing.MethodName"/>,
+/// <see cref="IndicatorResult.DataName"/>, and <see cref="IndicatorParam.ParameterName"/>.
+/// Nothing in the compiler binds those strings to the members they name, so this
+/// helper resolves them by reflection and lets the binding tests assert the
+/// catalog and the library still agree.
+/// </remarks>
+internal static class CatalogReflection
+{
+    private static readonly Assembly IndicatorsAssembly = typeof(Catalog).Assembly;
+
+    /// <summary>
+    /// Static classes that host the public indicator extension methods.
+    /// </summary>
+    private static readonly Type[] StaticHosts = IndicatorsAssembly
+        .GetTypes()
+        .Where(static t => t.IsClass && t.IsAbstract && t.IsSealed)
+        .ToArray();
+
+    /// <summary>
+    /// Gets every public static overload with the given method name.
+    /// </summary>
+    /// <param name="methodName">Method name from a catalog listing.</param>
+    /// <returns>All matching overloads; empty when the name resolves to nothing.</returns>
+    internal static IReadOnlyList<MethodInfo> GetOverloads(string methodName)
+        => StaticHosts
+            .SelectMany(static t => t.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly))
+            .Where(m => m.Name == methodName)
+            .ToList();
+
+    /// <summary>
+    /// Gets the result record type produced by an indicator method, for any style.
+    /// </summary>
+    /// <param name="method">Indicator method bound to a catalog listing.</param>
+    /// <returns>
+    /// Result record type — <c>EmaResult</c> for all three of
+    /// <c>IReadOnlyList&lt;EmaResult&gt;</c> (Series), <c>EmaList</c> (Buffer),
+    /// and <c>EmaHub</c> (Stream) — or <c>null</c> when it cannot be determined.
+    /// </returns>
+    internal static Type GetResultType(MethodInfo method)
+    {
+        Type returnType = method.ReturnType;
+
+        // Series: IReadOnlyList<TResult>
+        if (returnType.IsGenericType
+         && returnType.GetGenericTypeDefinition() == typeof(IReadOnlyList<>))
+        {
+            return returnType.GetGenericArguments()[0];
+        }
+
+        // Buffer: a BufferList implementing IReadOnlyList<TResult>
+        Type listInterface = returnType
+            .GetInterfaces()
+            .FirstOrDefault(static i => i.IsGenericType
+                                     && i.GetGenericTypeDefinition() == typeof(IReadOnlyList<>));
+
+        if (listInterface != null)
+        {
+            return listInterface.GetGenericArguments()[0];
+        }
+
+        // Stream: a hub deriving from StreamHub<TIn, TOut>
+        for (Type baseType = returnType; baseType != null; baseType = baseType.BaseType)
+        {
+            if (baseType.IsGenericType
+             && baseType.GetGenericTypeDefinition() == typeof(StreamHub<,>))
+            {
+                return baseType.GetGenericArguments()[1]; // TOut
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Gets the indicator style implied by a method's return shape.
+    /// </summary>
+    /// <remarks>
+    /// The three styles return three distinct shapes — <c>IReadOnlyList&lt;TResult&gt;</c>,
+    /// a <c>BufferList</c>, and a <c>StreamHub</c>. Comparing the implied style against
+    /// the listing's declared <see cref="IndicatorListing.Style"/> catches a listing bound
+    /// to a real method of the wrong style, which the result record alone cannot reveal
+    /// because all three styles share it.
+    /// </remarks>
+    /// <param name="method">Indicator method bound to a catalog listing.</param>
+    /// <returns>The implied style, or <c>null</c> when the shape is unrecognized.</returns>
+    internal static Style? GetImpliedStyle(MethodInfo method)
+    {
+        Type returnType = method.ReturnType;
+
+        if (returnType.IsGenericType
+         && returnType.GetGenericTypeDefinition() == typeof(IReadOnlyList<>))
+        {
+            return Style.Series;
+        }
+
+        for (Type baseType = returnType; baseType != null; baseType = baseType.BaseType)
+        {
+            if (baseType.IsGenericType
+             && baseType.GetGenericTypeDefinition() == typeof(StreamHub<,>))
+            {
+                return Style.Stream;
+            }
+        }
+
+        return returnType.GetInterfaces().Any(static i => i.IsGenericType
+                                                       && i.GetGenericTypeDefinition() == typeof(IReadOnlyList<>))
+            ? Style.Buffer
+            : null;
+    }
+
+    /// <summary>
+    /// Gets the public instance property names on a result record.
+    /// </summary>
+    /// <param name="resultType">Result record type.</param>
+    /// <returns>Property names available to a catalog-driven consumer.</returns>
+    internal static ISet<string> GetPropertyNames(Type resultType)
+        => resultType
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Select(static p => p.Name)
+            .ToHashSet(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Determines whether the catalog parameter names appear as an unbroken run,
+    /// in order, within a method's parameter list.
+    /// </summary>
+    /// <remarks>
+    /// The run must be contiguous, not merely ordered. <c>ListingExecutor</c> builds one
+    /// argument per catalog parameter, in listing order, and selects an overload by
+    /// argument count — so a catalog that skips a parameter in the middle still binds,
+    /// and every later argument lands one slot early. Allowing a gapped match would let
+    /// that silent misbinding pass. The run may start at any offset, because some
+    /// listings declare the source parameter and most do not.
+    /// </remarks>
+    /// <param name="catalogNames">Catalog parameter names, in listing order.</param>
+    /// <param name="methodNames">Method parameter names, in signature order.</param>
+    /// <returns><c>true</c> when the catalog names form a contiguous run.</returns>
+    internal static bool IsContiguousRun(string[] catalogNames, string[] methodNames)
+        => methodNames.AsSpan().IndexOf(catalogNames.AsSpan()) >= 0;
+
+    /// <summary>
+    /// Gets a short identity for a listing, for use in failure messages.
+    /// </summary>
+    /// <param name="listing">Indicator listing.</param>
+    /// <returns>Identity in the form <c>UIID/Style</c>.</returns>
+    internal static string Describe(IndicatorListing listing)
+        => $"{listing.Uiid}/{listing.Style}";
+}

--- a/tests/Library/Indicators/k-q/Pmo/PmoCatalogTests.cs
+++ b/tests/Library/Indicators/k-q/Pmo/PmoCatalogTests.cs
@@ -25,8 +25,8 @@ public class PmoCatalogTests : TestBase
 
         IndicatorParam timePeriodsParam = listing.Parameters.SingleOrDefault(static p => p.ParameterName == "timePeriods");
         timePeriodsParam.Should().NotBeNull();
-        IndicatorParam smoothingPeriodsParam1 = listing.Parameters.SingleOrDefault(static p => p.ParameterName == "smoothingPeriods");
-        smoothingPeriodsParam1.Should().NotBeNull();
+        IndicatorParam smoothPeriodsParam1 = listing.Parameters.SingleOrDefault(static p => p.ParameterName == "smoothPeriods");
+        smoothPeriodsParam1.Should().NotBeNull();
         IndicatorParam signalPeriodsParam2 = listing.Parameters.SingleOrDefault(static p => p.ParameterName == "signalPeriods");
         signalPeriodsParam2.Should().NotBeNull();
 
@@ -62,8 +62,8 @@ public class PmoCatalogTests : TestBase
 
         IndicatorParam timePeriodsParam = listing.Parameters.SingleOrDefault(static p => p.ParameterName == "timePeriods");
         timePeriodsParam.Should().NotBeNull();
-        IndicatorParam smoothingPeriodsParam1 = listing.Parameters.SingleOrDefault(static p => p.ParameterName == "smoothingPeriods");
-        smoothingPeriodsParam1.Should().NotBeNull();
+        IndicatorParam smoothPeriodsParam1 = listing.Parameters.SingleOrDefault(static p => p.ParameterName == "smoothPeriods");
+        smoothPeriodsParam1.Should().NotBeNull();
         IndicatorParam signalPeriodsParam2 = listing.Parameters.SingleOrDefault(static p => p.ParameterName == "signalPeriods");
         signalPeriodsParam2.Should().NotBeNull();
 

--- a/tests/Library/Indicators/k-q/Prs/PrsCatalogTests.cs
+++ b/tests/Library/Indicators/k-q/Prs/PrsCatalogTests.cs
@@ -27,7 +27,7 @@ public class PrsCatalogTests : TestBase
         lookbackPeriodsParam.Should().NotBeNull();
 
         listing.Results.Should().NotBeNull();
-        listing.Results.Should().HaveCount(3);
+        listing.Results.Should().HaveCount(2);
 
         IndicatorResult prsResult = listing.Results.SingleOrDefault(static r => r.DataName == "Prs");
         prsResult.Should().NotBeNull();
@@ -37,9 +37,5 @@ public class PrsCatalogTests : TestBase
         prspercentResult1.Should().NotBeNull();
         prspercentResult1?.DisplayName.Should().Be("PRS %");
         prspercentResult1.IsReusable.Should().Be(false);
-        IndicatorResult smaResult2 = listing.Results.SingleOrDefault(static r => r.DataName == "Sma");
-        smaResult2.Should().NotBeNull();
-        smaResult2?.DisplayName.Should().Be("SMA");
-        smaResult2.IsReusable.Should().Be(false);
     }
 }

--- a/tests/Library/Indicators/t-z/Vwap/VwapCatalogTests.cs
+++ b/tests/Library/Indicators/t-z/Vwap/VwapCatalogTests.cs
@@ -24,20 +24,12 @@ public class VwapCatalogTests : TestBase
         // No parameters for this indicator
 
         listing.Results.Should().NotBeNull();
-        listing.Results.Should().HaveCount(3);
+        listing.Results.Should().HaveCount(1);
 
         IndicatorResult vwapResult = listing.Results.SingleOrDefault(static r => r.DataName == "Vwap");
         vwapResult.Should().NotBeNull();
         vwapResult?.DisplayName.Should().Be("VWAP");
         vwapResult.IsReusable.Should().Be(true);
-        IndicatorResult upperbandResult1 = listing.Results.SingleOrDefault(static r => r.DataName == "UpperBand");
-        upperbandResult1.Should().NotBeNull();
-        upperbandResult1?.DisplayName.Should().Be("Upper Band");
-        upperbandResult1.IsReusable.Should().Be(false);
-        IndicatorResult lowerbandResult2 = listing.Results.SingleOrDefault(static r => r.DataName == "LowerBand");
-        lowerbandResult2.Should().NotBeNull();
-        lowerbandResult2?.DisplayName.Should().Be("Lower Band");
-        lowerbandResult2.IsReusable.Should().Be(false);
     }
 
     [TestMethod]
@@ -57,7 +49,7 @@ public class VwapCatalogTests : TestBase
         listing.Parameters?.Count.Should().Be(1);
 
         listing.Results.Should().NotBeNull();
-        listing.Results.Should().HaveCount(3);
+        listing.Results.Should().HaveCount(1);
     }
 
     [TestMethod]
@@ -77,6 +69,6 @@ public class VwapCatalogTests : TestBase
         listing.Parameters?.Count.Should().Be(1);
 
         listing.Results.Should().NotBeNull();
-        listing.Results.Should().HaveCount(3);
+        listing.Results.Should().HaveCount(1);
     }
 }


### PR DESCRIPTION
Fixes #2187

## Problem

Catalog listings carry member names as plain strings, so nothing in the compiler ties them to the members they name. Four had drifted:

| Listing | Names | Reality |
| --- | --- | --- |
| `PRS` | result `Sma` | `PrsResult` has no such property |
| `VWAP` | results `UpperBand`, `LowerBand` | `VwapResult` has neither |
| `PMO` | parameter `smoothingPeriods` | `ToPmo` takes `smoothPeriods` |

The parameter mismatch was the damaging one. A catalog-bound caller supplies the name the catalog advertises, it matches nothing, and `ListingExecutor` falls through to the default — so the caller silently receives numbers it did not ask for.

## Approach

Correcting the four names alone would leave the same drift free to recur, so this adds `Catalog.Binding.Tests`, which checks **all 243 listings** across all three styles:

- `MethodName` resolves to a real method **of the listing's own style**. All three styles share one result record, so the record alone cannot reveal a listing bound to a real method of the wrong style.
- Each `Results[].DataName` is a property on that method's result record.
- Each `Parameters[].ParameterName` forms a **contiguous, in-order run** in the signature. `ListingExecutor` builds one argument per catalog parameter and selects an overload by argument count, so a catalog that skips a parameter in the middle still binds and every later argument lands one slot early. An "ordered but gapped" check would let that through.

It also closes the silent-default path itself: `ListingExecutor` now rejects an override naming no catalog parameter instead of discarding it. `WithParamValue` already threw on an unknown name; `WithParams` did not, so the same mistake was loud on one public path and silent on the other. Any future rename now fails loudly rather than returning wrong numbers.

The per-indicator catalog tests had asserted the wrong names — which is why the drift survived — and now assert the corrected ones.

## Verification

Guards were mutation-tested in both directions, not just observed passing.

Reverting each fix makes the intended test fail with an actionable message:

```
PRS/Series: DataName 'Sma' is not a property on PrsResult (has: Prs, PrsPercent, Timestamp, Value)
PMO/Buffer: parameters [timePeriods, smoothingPeriods, signalPeriods] are not a contiguous,
  in-order run in any overload of 'ToPmoList' (source, timePeriods, smoothPeriods, signalPeriods)
```

Two mutations that passed an earlier, weaker version of these tests now fail:

```
STOCH/Buffer: parameters [lookbackPeriods, signalPeriods, kFactor] are not a contiguous, in-order run ...
EMA/Buffer: 'ToEma' returns Series shape, not Buffer
```

A survey across all 243 listings confirmed the four defects in the issue were the only ones of this class — no hidden drift.

Quality gates on this branch:

```
Build:      0 Warning(s), 0 Error(s)
Unit:       Failed: 0, Passed: 2511, Skipped: 12
PublicApi:  Failed: 0, Passed: 76
Integration:Failed: 0, Passed: 4, Skipped: 1
markdownlint-cli2: 0 issues in 183 files
dotnet format --severity info: clean
```

## Notes for review

- No public API member is added, renamed, or removed. The changes are data values inside the public `Catalog` collections.
- `Results` shrinks for two indicators: VWAP 3 → 1, PRS 3 → 2. Those entries advertised properties that do not exist, so no consumer could ever read a value from them — but a chart config keyed off three VWAP bands will visibly render fewer series. Worth a release note.
- `ListingExecutor` rejecting unknown override names is a deliberate behavior change: a caller passing a stale name now gets an exception instead of silently wrong numbers.
