### PR TITLE
feat: Derive catalog ResultRecordType from indicator method

### DIFF
--- a/.agents/skills/indicator-catalog/SKILL.md
+++ b/.agents/skills/indicator-catalog/SKILL.md
@@ -67,6 +67,8 @@ public static partial class Ema
 
 `.WithMethodName()` must be in style-specific listings, NOT in `CommonListing`.
 
+`IndicatorListing.ResultRecordType` is derived from the method name when the listing is built — do not set it by hand and do not add a builder method for it. Naming a method of the wrong style (e.g. `ToEma` on the Buffer listing) makes it report the wrong result shape.
+
 ## Parameter patterns
 
 - `AddParameter<T>()` — primitive value types (typically `int` or `double`)
@@ -75,7 +77,7 @@ public static partial class Ema
 - `AddSeriesParameter()` — `IReadOnlyList<T> where T : IReusable`
 - `minimum` and `maximum` required for all numeric parameters
 - `parameterName` must match the bound method's parameter name exactly — a mismatch makes a catalog-bound caller silently receive the default instead of the value it supplied
-- Declare parameters in the same order the method's signature declares them; `ListingExecutor` binds them positionally
+- Declare parameters as an unbroken run in signature order, skipping none in the middle; `ListingExecutor` binds them positionally and picks an overload by argument count
 
 ## Result patterns
 
@@ -152,7 +154,8 @@ public class EmaCatalogTests : TestBase
 ```
 
 `tests/Library/Common/Catalog/Catalog.Binding.Tests.cs` additionally enforces, for every
-listing in the catalog, that `MethodName` resolves to a real method, that each
-`dataName` resolves to a property on that method's result record, and that each
-`parameterName` resolves to a method parameter in signature order. A new listing that
-names a member the library does not have fails there — no per-indicator test needed.
+listing in the catalog, that `MethodName` resolves to a real method of the listing's own
+style, that each `dataName` resolves to a property on that method's result record, and
+that each `parameterName` forms a contiguous, in-order run in the signature. A listing
+naming a member the library does not have fails there. It does not check parameter
+*types* or value semantics, so keep writing the per-indicator test.

--- a/docs/utilities/catalog.md
+++ b/docs/utilities/catalog.md
@@ -67,7 +67,7 @@ Each `IndicatorListing` describes one indicator-and-style combination. This is t
 | `Category` | `Category` | Indicator category (see below) |
 | `Parameters` | `IReadOnlyList<IndicatorParam>?` | Input parameters (`null` when there are none) |
 | `Results` | `IReadOnlyList<IndicatorResult>` | Output fields the indicator produces |
-| `ReturnType` | `string?` | Result type name |
+| `ResultRecordType` | `string?` | Name of the result record the method returns (e.g. `"EmaResult"`), the same for all three styles — the record type, not the method's literal return type (`EmaList` for Buffer, `EmaHub` for Stream). `null` when `MethodName` is unset, or when the method cannot be resolved (possible under trimming or NativeAOT publishing) — check before use |
 | `MethodName` | `string?` | Method name, for automation use cases |
 | `LegendTemplate` | `string` | Legend template for charting |
 

--- a/src/Common/Catalog/CatalogListingBuilder.cs
+++ b/src/Common/Catalog/CatalogListingBuilder.cs
@@ -310,6 +310,7 @@ internal class CatalogListingBuilder
             Parameters = _parameters.Count > 0 ? _parameters : null,
             Results = _results,
             MethodName = _methodName,
+            ResultRecordType = CatalogMethodResolver.GetResultTypeName(_methodName),
             LegendTemplate = GenerateLegendTemplate()
         };
     }

--- a/src/Common/Catalog/CatalogMethodResolver.cs
+++ b/src/Common/Catalog/CatalogMethodResolver.cs
@@ -1,0 +1,142 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+namespace FacioQuo.Stock.Indicators;
+
+/// <summary>
+/// Resolves indicator methods and their result record types from a catalog method name.
+/// </summary>
+/// <remarks>
+/// A catalog listing identifies its indicator by method name only. This resolver turns
+/// that name back into the compiled members it refers to, so metadata derived from the
+/// method — such as <see cref="IndicatorListing.ResultRecordType"/> — cannot drift away from
+/// the method it describes. Lookups are cached; the assembly is scanned once.
+/// </remarks>
+internal static class CatalogMethodResolver
+{
+    private static readonly Lazy<ILookup<string, MethodInfo>> MethodsByName
+        = new(BuildMethodLookup, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    /// <summary>
+    /// Gets every public static overload with the given method name.
+    /// </summary>
+    /// <param name="methodName">Method name from a catalog listing.</param>
+    /// <returns>All matching overloads; empty when the name resolves to nothing.</returns>
+    [RequiresUnreferencedCode("Enumerates assembly types to resolve indicator methods by name.")]
+    internal static IEnumerable<MethodInfo> GetOverloads(string methodName)
+        => MethodsByName.Value[methodName];
+
+    /// <summary>
+    /// Gets the name of the result record type produced by a named indicator method.
+    /// </summary>
+    /// <param name="methodName">Method name from a catalog listing.</param>
+    /// <returns>
+    /// Result record type name, or <c>null</c> when the method does not exist or its
+    /// result record cannot be determined.
+    /// </returns>
+    [RequiresUnreferencedCode("Enumerates assembly types to resolve indicator methods by name.")]
+    internal static string? GetResultTypeName(string? methodName)
+        => string.IsNullOrWhiteSpace(methodName)
+            ? null
+            : MethodsByName.Value[methodName]
+                .Select(GetResultType)
+                .FirstOrDefault(static t => t is not null)
+                ?.Name;
+
+    /// <summary>
+    /// Gets the result record type produced by an indicator method, for any style.
+    /// </summary>
+    /// <param name="method">Indicator method bound to a catalog listing.</param>
+    /// <returns>
+    /// Result record type — <c>EmaResult</c> for all three of
+    /// <c>IReadOnlyList&lt;EmaResult&gt;</c> (Series), <c>EmaList</c> (Buffer),
+    /// and <c>EmaHub</c> (Stream) — or <c>null</c> when it cannot be determined.
+    /// </returns>
+    internal static Type? GetResultType(MethodInfo method)
+    {
+        Type returnType = method.ReturnType;
+
+        // Series: IReadOnlyList<TResult>
+        if (returnType.IsGenericType
+         && returnType.GetGenericTypeDefinition() == typeof(IReadOnlyList<>))
+        {
+            return returnType.GetGenericArguments()[0];
+        }
+
+        // Buffer: a BufferList implementing IReadOnlyList<TResult>
+        Type? listInterface = returnType
+            .GetInterfaces()
+            .FirstOrDefault(static i => i.IsGenericType
+                                     && i.GetGenericTypeDefinition() == typeof(IReadOnlyList<>));
+
+        if (listInterface is not null)
+        {
+            return listInterface.GetGenericArguments()[0];
+        }
+
+        // Stream: a hub deriving from StreamHub<TIn, TOut>
+        for (Type? baseType = returnType; baseType is not null; baseType = baseType.BaseType)
+        {
+            if (baseType.IsGenericType
+             && baseType.GetGenericTypeDefinition() == typeof(StreamHub<,>))
+            {
+                return baseType.GetGenericArguments()[1]; // TOut
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Indexes every public static method on the library's static classes by name.
+    /// </summary>
+    /// <returns>Lookup of overloads, keyed by method name.</returns>
+    private static ILookup<string, MethodInfo> BuildMethodLookup()
+    {
+        Type?[] types;
+
+        // Build() runs inside the static initializer of each indicator class, so an
+        // unhandled failure here would leave those types permanently unusable — taking
+        // the calculations down with the metadata. Use whatever loaded instead.
+        try
+        {
+            types = typeof(CatalogMethodResolver).Assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            types = ex.Types;
+        }
+
+        return types
+            .Where(static t => t is { IsClass: true, IsAbstract: true, IsSealed: true }) // static classes
+            .SelectMany(static t => GetStaticMethods(t!))
+            .ToLookup(static m => m.Name, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Gets a type's own public static methods, tolerating a type-load failure.
+    /// </summary>
+    /// <remarks>
+    /// <c>GetMethods</c> throws for the same reason <c>GetTypes</c> does — a signature
+    /// referencing a type that failed to load — and the result of the surrounding scan
+    /// is cached in a <see cref="Lazy{T}"/>, which caches a thrown exception for the
+    /// life of the process. Skipping the offending type keeps one bad signature from
+    /// disabling catalog metadata for every indicator. <c>DeclaredOnly</c> keeps
+    /// inherited <see cref="object"/> statics out of the lookup, so a listing can never
+    /// resolve its method name to <c>Equals</c> or <c>ReferenceEquals</c>.
+    /// </remarks>
+    /// <param name="type">Static class to enumerate.</param>
+    /// <returns>The type's own public static methods, or empty when it cannot be read.</returns>
+    private static MethodInfo[] GetStaticMethods(Type type)
+    {
+        try
+        {
+            return type.GetMethods(
+                BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
+        }
+        catch (ReflectionTypeLoadException)
+        {
+            return [];
+        }
+    }
+}

--- a/src/Common/Catalog/ListingExecutor.cs
+++ b/src/Common/Catalog/ListingExecutor.cs
@@ -35,24 +35,8 @@ internal static class ListingExecutor
         string methodName = listing.MethodName
             ?? throw new InvalidOperationException("MethodName is required for dynamic execution");
 
-        // Get the assembly containing the indicators
-        Assembly indicatorsAssembly = typeof(Ema).Assembly;
-
-        // Find all static classes in the assembly
-        Type[] types = indicatorsAssembly.GetTypes()
-            .Where(t => t.IsClass && t.IsAbstract && t.IsSealed) // static classes
-            .ToArray();
-
-        List<MethodInfo> methods = [];
-
-        // Search for the method across all static classes
-        foreach (Type type in types)
-        {
-            MethodInfo[] typeMethods = type.GetMethods(BindingFlags.Public | BindingFlags.Static)
-                .Where(m => m.Name == methodName)
-                .ToArray();
-            methods.AddRange(typeMethods);
-        }
+        // Find the method's overloads across the library's static classes
+        List<MethodInfo> methods = CatalogMethodResolver.GetOverloads(methodName).ToList();
 
         if (methods.Count == 0)
         {

--- a/src/Common/Catalog/Schema/IndicatorListing.cs
+++ b/src/Common/Catalog/Schema/IndicatorListing.cs
@@ -43,9 +43,21 @@ public record IndicatorListing
     public required IReadOnlyList<IndicatorResult> Results { get; init; }
 
     /// <summary>
-    /// Gets or sets the return type name for the indicator method.
+    /// Gets the name of the result record type returned by the indicator method.
     /// </summary>
-    public string? ReturnType { get; init; }
+    /// <remarks>
+    /// Derived from <see cref="MethodName"/> when the listing is built, so it cannot
+    /// drift from the method it describes. This is the record type, not the method's
+    /// literal return type: it is <c>EmaResult</c> for <c>ToEma</c>, <c>ToEmaList</c>,
+    /// and <c>ToEmaHub</c> alike, even though those return
+    /// <c>IReadOnlyList&lt;EmaResult&gt;</c>, <c>EmaList</c>, and <c>EmaHub</c>
+    /// respectively. It is the record whose properties
+    /// <see cref="IndicatorResult.DataName"/> names. It is <c>null</c> when
+    /// <see cref="MethodName"/> is unset, and can also be <c>null</c> if the method
+    /// cannot be resolved — which trimming or NativeAOT publishing may cause, since
+    /// the derivation reflects over the assembly. Check for <c>null</c> before use.
+    /// </remarks>
+    public string? ResultRecordType { get; init; }
 
     /// <summary>
     /// Gets or sets the method name for automation use cases.

--- a/tests/Library/Common/Catalog/Catalog.Reflection.cs
+++ b/tests/Library/Common/Catalog/Catalog.Reflection.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Reflection;
 
 namespace Catalogging;
@@ -17,67 +18,26 @@ internal static class CatalogReflection
     private static readonly Assembly IndicatorsAssembly = typeof(Catalog).Assembly;
 
     /// <summary>
-    /// Static classes that host the public indicator extension methods.
-    /// </summary>
-    private static readonly Type[] StaticHosts = IndicatorsAssembly
-        .GetTypes()
-        .Where(static t => t.IsClass && t.IsAbstract && t.IsSealed)
-        .ToArray();
-
-    /// <summary>
     /// Gets every public static overload with the given method name.
     /// </summary>
+    /// <remarks>
+    /// Delegates to the library's own <see cref="CatalogMethodResolver"/> so the tests
+    /// exercise the same resolution the catalog build uses. Re-implementing it here
+    /// would make the derivation tests compare a value against a copy of the function
+    /// that produced it.
+    /// </remarks>
     /// <param name="methodName">Method name from a catalog listing.</param>
     /// <returns>All matching overloads; empty when the name resolves to nothing.</returns>
     internal static IReadOnlyList<MethodInfo> GetOverloads(string methodName)
-        => StaticHosts
-            .SelectMany(static t => t.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly))
-            .Where(m => m.Name == methodName)
-            .ToList();
+        => CatalogMethodResolver.GetOverloads(methodName).ToList();
 
     /// <summary>
     /// Gets the result record type produced by an indicator method, for any style.
     /// </summary>
     /// <param name="method">Indicator method bound to a catalog listing.</param>
-    /// <returns>
-    /// Result record type — <c>EmaResult</c> for all three of
-    /// <c>IReadOnlyList&lt;EmaResult&gt;</c> (Series), <c>EmaList</c> (Buffer),
-    /// and <c>EmaHub</c> (Stream) — or <c>null</c> when it cannot be determined.
-    /// </returns>
-    internal static Type GetResultType(MethodInfo method)
-    {
-        Type returnType = method.ReturnType;
-
-        // Series: IReadOnlyList<TResult>
-        if (returnType.IsGenericType
-         && returnType.GetGenericTypeDefinition() == typeof(IReadOnlyList<>))
-        {
-            return returnType.GetGenericArguments()[0];
-        }
-
-        // Buffer: a BufferList implementing IReadOnlyList<TResult>
-        Type listInterface = returnType
-            .GetInterfaces()
-            .FirstOrDefault(static i => i.IsGenericType
-                                     && i.GetGenericTypeDefinition() == typeof(IReadOnlyList<>));
-
-        if (listInterface != null)
-        {
-            return listInterface.GetGenericArguments()[0];
-        }
-
-        // Stream: a hub deriving from StreamHub<TIn, TOut>
-        for (Type baseType = returnType; baseType != null; baseType = baseType.BaseType)
-        {
-            if (baseType.IsGenericType
-             && baseType.GetGenericTypeDefinition() == typeof(StreamHub<,>))
-            {
-                return baseType.GetGenericArguments()[1]; // TOut
-            }
-        }
-
-        return null;
-    }
+    /// <returns>Result record type, or <c>null</c> when it cannot be determined.</returns>
+    internal static Type? GetResultType(MethodInfo method)
+        => CatalogMethodResolver.GetResultType(method);
 
     /// <summary>
     /// Gets the indicator style implied by a method's return shape.
@@ -101,7 +61,7 @@ internal static class CatalogReflection
             return Style.Series;
         }
 
-        for (Type baseType = returnType; baseType != null; baseType = baseType.BaseType)
+        for (Type? baseType = returnType; baseType is not null; baseType = baseType.BaseType)
         {
             if (baseType.IsGenericType
              && baseType.GetGenericTypeDefinition() == typeof(StreamHub<,>))
@@ -144,6 +104,22 @@ internal static class CatalogReflection
     /// <returns><c>true</c> when the catalog names form a contiguous run.</returns>
     internal static bool IsContiguousRun(string[] catalogNames, string[] methodNames)
         => methodNames.AsSpan().IndexOf(catalogNames.AsSpan()) >= 0;
+
+    /// <summary>
+    /// Finds a public library type by its simple name.
+    /// </summary>
+    /// <remarks>
+    /// Mirrors what a catalog-driven consumer does with a type name it reads from a
+    /// listing: look the type up in the library and reflect over its properties.
+    /// </remarks>
+    /// <param name="typeName">Simple type name, such as <c>EmaResult</c>.</param>
+    /// <returns>The matching public type, or <c>null</c> when there is none.</returns>
+    internal static Type? FindPublicType(string typeName)
+        => string.IsNullOrWhiteSpace(typeName)
+            ? null
+            : IndicatorsAssembly
+                .GetTypes()
+                .FirstOrDefault(t => t.IsPublic && string.Equals(t.Name, typeName, StringComparison.Ordinal));
 
     /// <summary>
     /// Gets a short identity for a listing, for use in failure messages.

--- a/tests/Library/Common/Catalog/Catalog.ResultRecordType.Tests.cs
+++ b/tests/Library/Common/Catalog/Catalog.ResultRecordType.Tests.cs
@@ -1,0 +1,127 @@
+using System.Reflection;
+
+namespace Catalogging;
+
+/// <summary>
+/// Catalog result record tests asserting that <c>ResultRecordType</c> is populated and honest:
+/// - every listing carries a value
+/// - the bound method name resolves to exactly one result record, so the derivation
+///   cannot depend on unspecified reflection ordering
+/// - the three styles of one indicator agree on it
+/// - the named record really carries every result the listing advertises
+/// </summary>
+/// <remarks>
+/// <c>ResultRecordType</c> is derived from <c>MethodName</c> at build time rather than
+/// hand-assigned per indicator. Re-deriving the expected value here would compare a
+/// value against a copy of the function that produced it, so these tests instead
+/// constrain the derivation from the outside: it must be populated, unambiguous,
+/// consistent across styles, and resolvable by name to a record carrying the
+/// advertised results — the path an external consumer actually takes.
+/// </remarks>
+[TestClass]
+public class CatalogResultRecordTypeTests : TestBase
+{
+    [TestMethod]
+    public void EveryListingHasResultRecordType()
+    {
+        IReadOnlyList<IndicatorListing> unpopulated = Catalog.Get()
+            .Where(static l => string.IsNullOrWhiteSpace(l.ResultRecordType))
+            .ToList();
+
+        string.Join(
+            Environment.NewLine,
+            unpopulated.Select(CatalogReflection.Describe))
+            .Should().BeEmpty("every catalog listing must report the result record it returns");
+    }
+
+    [TestMethod]
+    public void EveryMethodNameResolvesToOneResultRecord()
+    {
+        List<string> violations = [];
+
+        foreach (IndicatorListing listing in Catalog.Get())
+        {
+            IReadOnlyList<MethodInfo> overloads
+                = CatalogReflection.GetOverloads(listing.MethodName);
+
+            List<string> resultTypeNames = overloads
+                .Select(CatalogReflection.GetResultType)
+                .Where(static t => t != null)
+                .Select(static t => t.Name)
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+
+            if (resultTypeNames.Count == 0)
+            {
+                violations.Add($"{CatalogReflection.Describe(listing)}: '{listing.MethodName}' has no resolvable result record");
+            }
+            else if (resultTypeNames.Count > 1)
+            {
+                violations.Add(
+                    $"{CatalogReflection.Describe(listing)}: overloads of '{listing.MethodName}' return "
+                  + $"{string.Join(" and ", resultTypeNames)}, so the derived ResultRecordType depends on reflection order");
+            }
+        }
+
+        string.Join(Environment.NewLine, violations).Should().BeEmpty(
+            "the derivation picks one overload, so a method name whose overloads disagree on the result record would make ResultRecordType depend on unspecified reflection ordering");
+    }
+
+    [TestMethod]
+    public void ResultRecordTypeIsConsistentAcrossStyles()
+    {
+        List<string> violations = [];
+
+        foreach (IGrouping<string, IndicatorListing> group in Catalog.Get()
+            .GroupBy(static l => l.Uiid, StringComparer.Ordinal))
+        {
+            List<string> distinct = group
+                .Select(static l => l.ResultRecordType)
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+
+            if (distinct.Count > 1)
+            {
+                violations.Add($"{group.Key}: styles disagree — {string.Join(", ", distinct)}");
+            }
+        }
+
+        string.Join(Environment.NewLine, violations).Should().BeEmpty(
+            "Series, Buffer, and Stream styles of one indicator produce the same result record");
+    }
+
+    [TestMethod]
+    public void ResultRecordTypePropertiesCoverCatalogResults()
+    {
+        List<string> violations = [];
+
+        foreach (IndicatorListing listing in Catalog.Get())
+        {
+            // resolve by name, exactly as a catalog-driven consumer would
+            Type resultType = CatalogReflection.FindPublicType(listing.ResultRecordType);
+
+            if (resultType is null)
+            {
+                violations.Add(
+                    $"{CatalogReflection.Describe(listing)}: ResultRecordType '{listing.ResultRecordType}' "
+                  + "does not resolve to a public type in the library");
+                continue;
+            }
+
+            ISet<string> properties = CatalogReflection.GetPropertyNames(resultType);
+
+            IEnumerable<string> missing = listing.Results
+                .Select(static r => r.DataName)
+                .Where(name => !properties.Contains(name));
+
+            foreach (string name in missing)
+            {
+                violations.Add(
+                    $"{CatalogReflection.Describe(listing)}: result '{name}' is absent from {listing.ResultRecordType}");
+            }
+        }
+
+        string.Join(Environment.NewLine, violations).Should().BeEmpty(
+            "a consumer that reflects over ResultRecordType must find every result the listing advertises");
+    }
+}


### PR DESCRIPTION
Fixes #2188

> **Stacked on #2189.** Base is `2187-catalog-member-binding` so this PR's diff shows only its own changes. Retarget to `main` once #2189 merges. #2189 can land independently of this one.

## Problem

The property formerly named `ReturnType` has been public API with a documented meaning and no value: no builder set it, no `*.Catalog.cs` assigned it, and it was `null` on all 243 listings across all three styles. A consumer reading the catalog as an indicator's schema found the one field naming the result type empty, and had to reflect over the compiled method instead — duplicating knowledge the catalog exists to carry.

## Approach

**Populate rather than remove.** Removing a public property from a published library is a breaking change, and the field is worth having.

**Derive it from `MethodName` at build time** rather than adding a `WithReturnType` for each definition to set by hand. A hand-assigned value is a second copy of a fact the method already states, and the copy is what drifts; a derived one cannot disagree with the method it came from.

**The value is the result record** — `EmaResult` for `ToEma`, `ToEmaList`, and `ToEmaHub` alike — because that is the record whose properties `Results[].DataName` names. The three styles therefore agree and the listing describes one coherent shape.

**Renamed `ReturnType` → `ResultRecordType`.** The old name promised the method's literal return type, which differs per style (`EmaList` for Buffer, `EmaHub` for Stream) and is not what the value holds. The old name needed five lines of XML doc to explain that it did not mean what it said.

## On the rename being breaking

Renaming a public property is source- and binary-breaking in principle. In practice nothing can depend on it: the only value the property has ever carried, in every released version, is `null`. There is no working consumer code to break.

This is the last release in which that is true. Correcting the name now costs nothing; correcting it after a populated value ships costs a major version. Flagged for the maintainer as a deliberate call rather than made silently — `AGENTS.md` requires asking before renaming a public API member, and this was asked and approved.

`"returnType": null` was already present in `ToJson()` output (no `DefaultIgnoreCondition` is set), so the JSON key changes name; the shape is otherwise unaffected.

## Verification

The tests constrain the derivation **from the outside** rather than re-deriving the expected value, which would only compare it against a copy of the function that produced it:

- every listing is populated (`null` on 243/243 → 0/243)
- each method name resolves to exactly **one** result record, so the value cannot depend on unspecified reflection ordering
- the three styles of an indicator agree
- the named record, looked up **by name** as an external consumer would, carries every result the listing advertises

Mutation-tested: replacing the derivation with a wrong-but-plausible constant fails two tests with actionable messages —

```
ADL/Buffer: ResultRecordType 'SmaResult' does not match 'ToAdlList' which returns AdlResult
ADL/Buffer: result 'Adl' is absent from SmaResult
```

Catalog-driven execution was checked against the direct call after the `ListingExecutor` refactor:

```
executor EMA rows=60 last=154.5000
direct   EMA rows=60 last=154.5000
```

Cost of the derivation, measured cold on first `Catalog.Get()` (steady-state of three runs each): **~16 ms → ~24 ms**, one time, first access only, and only for callers who touch the catalog. The refactor removes a full-assembly scan from every dynamic execution, so repeated `Execute` calls get faster.

Quality gates on this branch:

```
Build:      0 Warning(s), 0 Error(s)   (--no-incremental)
Unit:       Failed: 0, Passed: 2515, Skipped: 12
PublicApi:  Failed: 0, Passed: 76
Integration:Failed: 0, Passed: 4, Skipped: 1
markdownlint-cli2: 0 issues in 183 files
dotnet format --severity info: clean
```

## Notes for review

- The derivation reflects over the assembly, so trimming or NativeAOT publishing could leave `ResultRecordType` null. The XML doc states this and tells consumers to null-check. The project sets no `IsTrimmable`/`IsAotCompatible`, and `ListingExecutor` already relied on reflection before this change.
