### PR TITLE
fix: Make catalog listings executable for optional and decimal params

### DIFF
--- a/src/Common/Catalog/ListingExecutionBuilder.cs
+++ b/src/Common/Catalog/ListingExecutionBuilder.cs
@@ -157,6 +157,12 @@ public class ListingExecutionBuilder
             throw new ArgumentException(
                 $"Parameter '{parameterName}' expects a double value, but received {value.GetType().Name}", nameof(value));
         }
+        else if (param.DataType == "Decimal" && value is not decimal)
+        {
+            throw new ArgumentException(
+                $"Parameter '{parameterName}' expects a decimal value, but received {value?.GetType().Name ?? "null"}. "
+              + "Use a decimal literal (for example 2.5m); a double cannot be bound to a decimal parameter.", nameof(value));
+        }
         else if (param.DataType == "Boolean" && value is not bool)
         {
             throw new ArgumentException(

--- a/src/Common/Catalog/ListingExecutor.cs
+++ b/src/Common/Catalog/ListingExecutor.cs
@@ -64,7 +64,7 @@ internal static class ListingExecutor
         }
 
         // Build parameter array using catalog metadata and user overrides
-        List<object> parameterList = [bars];
+        List<object?> parameterList = [bars];
 
         // Add parameters based on catalog metadata
         if (listing.Parameters != null)
@@ -99,8 +99,28 @@ internal static class ListingExecutor
             }
         }
 
-        // Find the method that matches our parameter count
-        MethodInfo? targetMethod = methods.FirstOrDefault(m => m.GetParameters().Length == parameterList.Count) ?? throw new InvalidOperationException($"No '{methodName}' method found with {parameterList.Count} parameters");
+        // Find the method that matches our parameter count. Failing an exact match,
+        // accept an overload whose extra trailing parameters are all optional and
+        // supply their declared defaults: a catalog need not enumerate every optional
+        // parameter a method offers, and refusing to bind would make such a listing
+        // permanently unexecutable. Prefer the fewest extra parameters so the choice
+        // does not depend on reflection order.
+        MethodInfo? targetMethod = methods.FirstOrDefault(m => m.GetParameters().Length == parameterList.Count);
+
+        if (targetMethod is null)
+        {
+            targetMethod = methods
+                .Where(m => m.GetParameters().Length > parameterList.Count
+                         && m.GetParameters().Skip(parameterList.Count).All(static p => p.IsOptional))
+                .OrderBy(static m => m.GetParameters().Length)
+                .FirstOrDefault()
+                ?? throw new InvalidOperationException($"No '{methodName}' method found with {parameterList.Count} parameters");
+
+            foreach (ParameterInfo optional in targetMethod.GetParameters().Skip(parameterList.Count))
+            {
+                parameterList.Add(optional.DefaultValue);
+            }
+        }
 
         // If the method is generic, make it specific for the IBar interface type.
         // Indicator methods that are generic use IBar as the constraint.

--- a/src/Indicators/r-s/Renko/Renko.Catalog.cs
+++ b/src/Indicators/r-s/Renko/Renko.Catalog.cs
@@ -10,7 +10,7 @@ public static partial class Renko
             .WithName("Renko Chart")
             .WithId("RENKO")
             .WithCategory(Category.PriceTransform)
-            .AddParameter<double>("brickSize", "Brick Size", description: "The size of each Renko brick", isRequired: true, defaultValue: 1.0, minimum: 0.001, maximum: 1000000.0)
+            .AddParameter<decimal>("brickSize", "Brick Size", description: "The size of each Renko brick", isRequired: true, defaultValue: 1.0m, minimum: 0.001, maximum: 1000000.0)
             .AddEnumParameter<EndType>("endType", "End Type", description: "The price candle end type to use as the brick threshold", isRequired: false, defaultValue: EndType.Close)
             .AddResult("Open", "Open", ResultType.Default)
             .AddResult("High", "High", ResultType.Default)

--- a/src/Indicators/t-z/ZigZag/ZigZag.Catalog.cs
+++ b/src/Indicators/t-z/ZigZag/ZigZag.Catalog.cs
@@ -11,7 +11,7 @@ public static partial class ZigZag
             .WithId("ZIGZAG")
             .WithCategory(Category.PriceTransform)
             .AddEnumParameter<EndType>("endType", "End Type", description: "Type of price to use for the calculation", isRequired: false, defaultValue: EndType.Close)
-            .AddParameter<double>("percentChange", "Percent Change", description: "Minimum percent change required for a new direction", isRequired: false, defaultValue: 5.0, minimum: 1.0, maximum: 200.0)
+            .AddParameter<decimal>("percentChange", "Percent Change", description: "Minimum percent change required for a new direction", isRequired: false, defaultValue: 5.0m, minimum: 1.0, maximum: 200.0)
             .AddResult("ZigZag", "Zig Zag", ResultType.Default, isReusable: true)
             .AddResult("PointType", "Point Type", ResultType.Default)
             .AddResult("RetraceHigh", "Retrace High", ResultType.Default)

--- a/tests/Library/Common/Catalog/Catalog.Executability.Tests.cs
+++ b/tests/Library/Common/Catalog/Catalog.Executability.Tests.cs
@@ -1,0 +1,151 @@
+using System.Reflection;
+
+namespace Catalogging;
+
+/// <summary>
+/// Catalog executability tests covering listings that could not be run at all:
+/// - a listing whose method declares optional parameters the catalog does not enumerate
+/// - listings whose parameters are <c>decimal</c> rather than <c>double</c>
+/// </summary>
+/// <remarks>
+/// The binding tests check that names resolve. These check that a listing can actually
+/// be invoked, which is a separate failure mode: a name can be correct while the
+/// argument list the executor assembles matches no overload, or carries the wrong CLR
+/// type. Both classes produced listings that threw for every caller.
+/// </remarks>
+[TestClass]
+public class CatalogExecutabilityTests : TestBase
+{
+    [TestMethod]
+    public void ListingExecutesWhenMethodHasUndeclaredOptionalParameters()
+    {
+        // ICHIMOKU's Buffer method takes senkouOffset and chikouOffset, which the
+        // listing does not declare. The executor must supply their defaults rather
+        // than fail to find a matching overload.
+        IndicatorListing listing = Catalog.Get("ICHIMOKU", Style.Buffer);
+        listing.Should().NotBeNull();
+
+        IReadOnlyList<IchimokuResult> results = listing.Execute<IchimokuResult>(Bars);
+
+        results.Should().NotBeNullOrEmpty();
+        results.Should().HaveCount(Bars.Count);
+    }
+
+    [TestMethod]
+    public void ListingExecutesWhenParametersAreDecimal()
+    {
+        IndicatorListing renko = Catalog.Get("RENKO", Style.Series);
+        renko.Should().NotBeNull();
+        renko.Parameters.Single(static p => p.ParameterName == "brickSize")
+            .DataType.Should().Be("Decimal", "the bound method takes a decimal brick size");
+
+        IReadOnlyList<RenkoResult> renkoResults = renko.Execute<RenkoResult>(Bars);
+        renkoResults.Should().NotBeNullOrEmpty();
+
+        IndicatorListing zigZag = Catalog.Get("ZIGZAG", Style.Series);
+        zigZag.Should().NotBeNull();
+        zigZag.Parameters.Single(static p => p.ParameterName == "percentChange")
+            .DataType.Should().Be("Decimal", "the bound method takes a decimal percent change");
+
+        IReadOnlyList<ZigZagResult> zigZagResults = zigZag.Execute<ZigZagResult>(Bars);
+        zigZagResults.Should().NotBeNullOrEmpty();
+    }
+
+    [TestMethod]
+    public void DecimalParameterRejectsDoubleOverride()
+    {
+        IndicatorListing renko = Catalog.Get("RENKO", Style.Series);
+
+        // a double cannot bind to a decimal parameter; fail with a usable message
+        // rather than at reflection-invoke time
+        Action act = () => renko.WithParamValue("brickSize", 2.5);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*expects a decimal value*2.5m*");
+    }
+
+    [TestMethod]
+    public void DecimalParameterAcceptsDecimalOverride()
+    {
+        IndicatorListing renko = Catalog.Get("RENKO", Style.Series);
+
+        IReadOnlyList<RenkoResult> results = renko
+            .WithParamValue("brickSize", 2.5m)
+            .FromSource((IEnumerable<IBar>)Bars)
+            .Execute<RenkoResult>();
+
+        results.Should().NotBeNullOrEmpty();
+    }
+
+    /// <summary>
+    /// Indicators that need a second input series, which the executor cannot supply.
+    /// </summary>
+    /// <remarks>
+    /// <c>ListingExecutor</c> binds exactly one bars source, so a listing that also
+    /// declares a source series always assembles one argument too many. That is a
+    /// capability the executor does not have rather than a defect in these listings,
+    /// and it is tracked separately. Excluded by name so the count below stays a real
+    /// assertion instead of a moving target.
+    /// </remarks>
+    private static readonly HashSet<string> TwoSeriesIndicators
+        = new(StringComparer.Ordinal) { "BETA", "CORR", "PRS" };
+
+    [TestMethod]
+    public void EverySeriesAndBufferListingExecutes()
+    {
+        MethodInfo executeDefinition = typeof(ListingExecutionBuilderExtensions)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(static m => m.Name == "Execute"
+                             && m.IsGenericMethodDefinition
+                             && m.GetParameters().Length == 2
+                             && m.GetParameters()[0].ParameterType == typeof(IndicatorListing));
+
+        List<IndicatorListing> executable = Catalog.Get()
+            .Where(static l => l.Style is Style.Series or Style.Buffer && !TwoSeriesIndicators.Contains(l.Uiid))
+            .ToList();
+
+        List<string> failures = [];
+
+        foreach (IndicatorListing listing in executable)
+        {
+            // resolve the result record from the listing's own metadata, so this
+            // exercises ResultRecordType on the same path a consumer would use
+            Type resultType = CatalogReflection.FindPublicType(listing.ResultRecordType);
+
+            if (resultType is null)
+            {
+                failures.Add($"{CatalogReflection.Describe(listing)}: ResultRecordType "
+                           + $"'{listing.ResultRecordType}' does not resolve to a public type");
+                continue;
+            }
+
+            try
+            {
+                object results = executeDefinition
+                    .MakeGenericMethod(resultType)
+                    .Invoke(null, [listing, Bars]);
+
+                if (results is null)
+                {
+                    failures.Add($"{CatalogReflection.Describe(listing)}: returned null");
+                }
+            }
+            catch (TargetInvocationException ex)
+            {
+                failures.Add($"{CatalogReflection.Describe(listing)} ({listing.MethodName}): "
+                           + $"{ex.InnerException?.Message ?? ex.Message}");
+            }
+        }
+
+        string.Join(Environment.NewLine, failures).Should().BeEmpty(
+            "every Series and Buffer listing must be executable from its own catalog metadata; "
+          + "a listing that cannot run is metadata describing something a consumer cannot invoke");
+
+        // guard the exclusion list itself: if the executor gains multi-series support,
+        // this count changes and the exclusion should be revisited rather than kept
+        executable.Should().HaveCount(
+            Catalog.Get().Count(static l => l.Style is Style.Series or Style.Buffer)
+          - TwoSeriesIndicators.Count,
+            "exactly the known two-series indicators are excluded");
+    }
+}

--- a/tests/Library/Common/Catalog/Catalog.Metadata.Tests.cs
+++ b/tests/Library/Common/Catalog/Catalog.Metadata.Tests.cs
@@ -155,7 +155,7 @@ public class CatalogMetadataTests : TestBase
                 parameter.DataType.Should().NotBeNullOrWhiteSpace();
                 string[] supportedTypes =
                 [
-                    "Int32", "Double", "Boolean", "DateTime", "String", "enum", "Nullable",
+                    "Int32", "Double", "Decimal", "Boolean", "DateTime", "String", "enum", "Nullable",
                     "IEnumerable", "IReadOnlyList<T> where T : IReusable",
                     "BetaType", "ChandExitType", "PivotPointType", "MaType", "CandlePartType", "EndType"
                 ];


### PR DESCRIPTION
Fixes #2197

## Problem

Five catalog listings could not be executed at all. Both causes are invisible to inspection — the metadata reads correctly and only fails when a consumer tries to run it.

**Arity mismatch.** `ListingExecutor` matched an overload by exact argument count, so a listing whose method declares optional parameters the catalog does not enumerate found no match:

```text
ICHIMOKU/Buffer -> No 'ToIchimokuList' method found with 4 parameters
```

`ToIchimokuList` takes `senkouOffset` and `chikouOffset` beyond the three periods the listing declares. `VWAP/Stream` fails the same way — its `startDate` default is `null`, so it is skipped and the executor builds one argument where `ToVwapHub` takes two.

**Wrong CLR type.** `RENKO` declared `brickSize` as `double` on all three styles while every bound method takes `decimal`; `ZIGZAG/Series` the same on `percentChange`:

```text
RENKO/Series -> Object of type 'System.Double' cannot be converted to type 'System.Decimal'
```

## Approach

Fall back to an overload whose extra trailing parameters are all optional and supply their declared defaults. A catalog describes the parameters worth surfacing, not every optional a signature offers, so refusing to bind the rest left those listings permanently dead. Exact matches still win, and the fallback prefers the fewest extra parameters so the choice cannot depend on reflection order.

Declare the two parameters as `decimal` to match their methods, and reject a `double` override in the builder with a message naming the decimal literal rather than letting it fail later inside `Invoke`.

No public API is added or changed — both fixes are internal to the execution path plus two catalog data corrections.

## The publish-readiness guard

`EverySeriesAndBufferListingExecutes` runs **every** Series and Buffer listing through the public `Execute<TResult>` extension, resolving the result type from the listing's own `ResultRecordType` — so it exercises that metadata on the same path an external consumer takes.

**161 of 161 executable.** The three two-series indicators (`BETA`, `CORR`, `PRS`) are excluded by name: `ListingExecutor` binds exactly one bars source, so an indicator needing a second series always assembles one argument too many. That is a capability the executor lacks rather than a defect in those listings — tracked in #2196. The test asserts the exclusion count too, so if the executor ever gains multi-series support the exclusion must be revisited rather than silently kept.

## Verification

Mutation-tested, not just observed passing. Removing the optional-parameter fallback fails the guard with the original defect:

```text
ICHIMOKU/Buffer (ToIchimokuList): No 'ToIchimokuList' method found with 4 parameters
```

Reverting the `decimal` change fails all four executability tests.

Quality gates on this branch:

```
Build:       0 Warning(s), 0 Error(s)   (--no-incremental, net10.0/net9.0/net8.0)
Unit:        Failed: 0, Passed: 2521, Skipped: 12
PublicApi:   Failed: 0, Passed: 76
Integration: Failed: 0, Passed: 4, Skipped: 1
markdownlint-cli2: 0 issues in 183 files
dotnet format --severity info: clean
```

## Not in this change

`BETA`, `CORR` and `PRS` remain unexecutable, deliberately. Fixing them is a design fork — either drop the source parameters from the catalog, losing a UI's ability to discover the second series, or change how the executor binds. Both alter observable behavior, so it is its own change: #2196.
