### PR TITLE
fix: Bind catalog execution deterministically and keep builder state

### DIFF
--- a/src/Common/Catalog/ListingExecutionBuilder.cs
+++ b/src/Common/Catalog/ListingExecutionBuilder.cs
@@ -40,7 +40,9 @@ public class ListingExecutionBuilder
             [parameterName] = value!
         };
 
-        return new ListingExecutionBuilder(BaseListing, newOverrides);
+        return new ListingExecutionBuilder(BaseListing, newOverrides) {
+            _bars = _bars
+        };
     }
 
     /// <summary>
@@ -59,7 +61,9 @@ public class ListingExecutionBuilder
             newOverrides[kvp.Key] = kvp.Value;
         }
 
-        return new ListingExecutionBuilder(BaseListing, newOverrides);
+        return new ListingExecutionBuilder(BaseListing, newOverrides) {
+            _bars = _bars
+        };
     }
 
     /// <summary>

--- a/src/Common/Catalog/ListingExecutor.cs
+++ b/src/Common/Catalog/ListingExecutor.cs
@@ -105,7 +105,7 @@ internal static class ListingExecutor
         // parameter a method offers, and refusing to bind would make such a listing
         // permanently unexecutable. Prefer the fewest extra parameters so the choice
         // does not depend on reflection order.
-        MethodInfo? targetMethod = methods.FirstOrDefault(m => m.GetParameters().Length == parameterList.Count);
+        MethodInfo? targetMethod = SelectByArity(methods, parameterList);
 
         if (targetMethod is null)
         {
@@ -142,6 +142,91 @@ internal static class ListingExecutor
             ? typedResult
             : throw new InvalidOperationException($"Result is not of expected type {typeof(IReadOnlyList<TResult>).Name}");
     }
+
+    /// <summary>
+    /// Selects the overload whose parameter count matches the assembled arguments.
+    /// </summary>
+    /// <remarks>
+    /// Two overloads can share an argument count — <c>ToGator</c> has one taking
+    /// <c>IReadOnlyList&lt;IReusable&gt;</c> and one taking
+    /// <c>IReadOnlyList&lt;AlligatorResult&gt;</c>, both arity one. Picking the first
+    /// match would let <c>Type.GetMethods</c> decide, and that order is documented as
+    /// unspecified, so the same call could bind differently across runtimes or builds.
+    /// Prefer the candidate whose parameter types actually accept the arguments; when
+    /// that still leaves a tie, order the candidates so the choice is at least
+    /// reproducible rather than incidental.
+    /// </remarks>
+    /// <param name="methods">Overloads sharing the listing's method name.</param>
+    /// <param name="arguments">Arguments assembled from the catalog metadata.</param>
+    /// <returns>The chosen overload, or <c>null</c> when none has a matching count.</returns>
+    private static MethodInfo? SelectByArity(
+        IReadOnlyList<MethodInfo> methods,
+        List<object?> arguments)
+    {
+        List<MethodInfo> candidates = methods
+            .Where(m => m.GetParameters().Length == arguments.Count)
+            .ToList();
+
+        if (candidates.Count <= 1)
+        {
+            return candidates.FirstOrDefault();
+        }
+
+        List<MethodInfo> accepting = candidates
+            .Where(m => Accepts(m, arguments))
+            .ToList();
+
+        return (accepting.Count == 1 ? accepting : Reproducible(accepting.Count > 0 ? accepting : candidates))
+            .First();
+    }
+
+    /// <summary>
+    /// Determines whether a method's parameters accept the assembled arguments.
+    /// </summary>
+    /// <param name="method">Candidate overload.</param>
+    /// <param name="arguments">Arguments assembled from the catalog metadata.</param>
+    /// <returns><c>true</c> when every argument is assignable to its parameter.</returns>
+    private static bool Accepts(MethodInfo method, List<object?> arguments)
+    {
+        // a generic definition's parameter types are still open, so they cannot be
+        // tested until the type argument is substituted further below
+        if (method.IsGenericMethodDefinition)
+        {
+            return true;
+        }
+
+        ParameterInfo[] parameters = method.GetParameters();
+
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            Type parameterType = parameters[i].ParameterType;
+
+            if (arguments[i] is null)
+            {
+                if (parameterType.IsValueType && Nullable.GetUnderlyingType(parameterType) is null)
+                {
+                    return false;
+                }
+            }
+            else if (!parameterType.IsInstanceOfType(arguments[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Orders overloads so an unavoidable tie resolves the same way every time.
+    /// </summary>
+    /// <param name="methods">Tied candidates.</param>
+    /// <returns>The candidates in a stable, declaration-independent order.</returns>
+    private static IEnumerable<MethodInfo> Reproducible(IEnumerable<MethodInfo> methods)
+        => methods
+            .OrderBy(static m => m.DeclaringType?.FullName, StringComparer.Ordinal)
+            .ThenBy(static m => string.Join(
+                ",", m.GetParameters().Select(static p => p.ParameterType.FullName)), StringComparer.Ordinal);
 
     /// <summary>
     /// Executes an indicator method dynamically using catalog metadata with parameter values.

--- a/tests/Library/Common/Catalog/Catalog.Execution.Tests.cs
+++ b/tests/Library/Common/Catalog/Catalog.Execution.Tests.cs
@@ -280,4 +280,57 @@ public class CatalogExecutionTests : TestBase
             .WithMessage("*lookbackPeriods*is not defined*")
             .WithMessage("*this indicator takes no parameters*");
     }
+
+    [TestMethod]
+    public void FluentBuilderKeepsBarsWhateverTheCallOrder()
+    {
+        IndicatorListing listing = Catalog.Get("EMA", Style.Series);
+        IReadOnlyList<Bar> bars = Bars.Take(50).ToList();
+        IReadOnlyList<EmaResult> expected = bars.ToEma(10);
+
+        // parameters first, then source
+        IReadOnlyList<EmaResult> paramsFirst = listing
+            .WithParamValue("lookbackPeriods", 10)
+            .FromSource((IEnumerable<IBar>)bars)
+            .Execute<EmaResult>();
+
+        // source first, then parameters — the natural fluent order, which used to
+        // drop the bars and throw at Execute
+        IReadOnlyList<EmaResult> sourceFirst = listing
+            .From((IEnumerable<IBar>)bars)
+            .WithParamValue("lookbackPeriods", 10)
+            .Execute<EmaResult>();
+
+        // and via the dictionary overload, which copies state the same way
+        IReadOnlyList<EmaResult> viaDictionary = listing
+            .From((IEnumerable<IBar>)bars)
+            .WithParams(new Dictionary<string, object> { ["lookbackPeriods"] = 10 })
+            .Execute<EmaResult>();
+
+        foreach (IReadOnlyList<EmaResult> actual in new[] { paramsFirst, sourceFirst, viaDictionary })
+        {
+            actual.Should().HaveCount(expected.Count);
+            actual[^1].Ema.Should().Be(expected[^1].Ema);
+        }
+    }
+
+    [TestMethod]
+    public void AmbiguousArityResolvesToTheOverloadThatAcceptsBars()
+    {
+        // ToGator has two arity-one overloads — IReadOnlyList<IReusable> and
+        // IReadOnlyList<AlligatorResult>. Only the first accepts bars, and which one
+        // reflection returns first is unspecified, so selection must not depend on it.
+        IndicatorListing listing = Catalog.Get("GATOR", Style.Series);
+        listing.Should().NotBeNull();
+        listing.Parameters.Should().BeNull("GATOR declares no catalog parameters");
+
+        IReadOnlyList<Bar> bars = Bars.Take(200).ToList();
+
+        IReadOnlyList<GatorResult> viaCatalog = listing.Execute<GatorResult>(bars);
+        IReadOnlyList<GatorResult> direct = bars.ToGator();
+
+        viaCatalog.Should().HaveCount(direct.Count);
+        viaCatalog[^1].Upper.Should().Be(direct[^1].Upper);
+        viaCatalog[^1].Lower.Should().Be(direct[^1].Lower);
+    }
 }


### PR DESCRIPTION
Fixes #2191
Fixes #2192

> **Stacked on #2198.** Base is `catalog-executable-listings` so this PR's diff shows only its own changes — both PRs touch the same overload-selection code. Retarget to `main` once #2198 merges.

## #2191 — the builder dropped the source

`ListingExecutionBuilder` is copy-on-write, but `WithParamValue` and `WithParams` rebuilt it without carrying `_bars`:

```csharp
return new ListingExecutionBuilder(BaseListing, newOverrides);   // _bars lost
```

Only one call order worked — parameters before source. The natural reading of a fluent API, *pick the source then configure it*, silently discarded the bars and threw at `Execute`:

```text
System.InvalidOperationException: Bars must be set using From() before calling Execute()
```

`docs/utilities/catalog.md` presents these methods as freely chainable and says nothing about ordering. Now the source is carried through every copy, so order stops mattering.

## #2192 — overload chosen by unspecified order

`ListingExecutor` picked by argument count alone. `ToGator` has **two** arity-one overloads — `IReadOnlyList<IReusable>` and `IReadOnlyList<AlligatorResult>` — so `Type.GetMethods` order decided which ran, and [that order is documented as unspecified](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.type.getmethods).

Worth being precise about the failure shape, because it is **not** the silent-wrong-value class of #2187. The `AlligatorResult` overload *rejects* bars, so an unfavourable ordering throws rather than miscomputing:

```text
System.ArgumentException: Object of type 'List<Bar>' cannot be converted to
type 'IReadOnlyList<AlligatorResult>'
```

It happens to bind favourably today. Nothing guarantees it keeps doing so across runtimes, target frameworks, or builds.

The fix prefers the candidate whose parameter types actually accept the assembled arguments. Generic method definitions are exempt from the check — their parameter types are still open until the type argument is substituted further down. When a genuine tie remains, candidates are ordered by declaring type and parameter types so the outcome is at least reproducible instead of incidental.

## Verification

Both tests compare catalog execution against the direct call, so they assert the right overload ran rather than merely that something ran.

Mutation-tested in both directions:

- reverting the builder change → `Bars must be set using From() before calling Execute()`
- simulating unfavourable reflection order (`LastOrDefault`) → the `AlligatorResult` conversion failure above

Quality gates:

```
Build:       0 Warning(s), 0 Error(s)   (--no-incremental, net10.0/net9.0/net8.0)
Unit:        Failed: 0, Passed: 2523, Skipped: 12
PublicApi:   Failed: 0, Passed: 76
Integration: Failed: 0, Passed: 4, Skipped: 1
markdownlint-cli2: 0 issues in 183 files
dotnet format --severity info: clean
```

## Notes for review

- No public API is added, renamed, or removed. `WithParamValue`/`WithParams` change only in what they carry forward; the ordering that already worked still works.
- `SelectByArity` short-circuits when there is one candidate, which is every listing except GATOR today — so the common path is unchanged.
