### PR TITLE
feat: Execute two-series indicators from the catalog

### DIFF
--- a/src/Common/Catalog/CatalogListingBuilder.cs
+++ b/src/Common/Catalog/CatalogListingBuilder.cs
@@ -249,7 +249,7 @@ internal class CatalogListingBuilder
             ParameterName = parameterName,
             DisplayName = displayName,
             Description = description,
-            DataType = "IReadOnlyList<T> where T : IReusable",
+            DataType = IndicatorParam.SeriesDataType,
             IsRequired = isRequired,
             DefaultValue = null,
             Minimum = null,

--- a/src/Common/Catalog/ListingExecutionBuilder.cs
+++ b/src/Common/Catalog/ListingExecutionBuilder.cs
@@ -58,7 +58,12 @@ public class ListingExecutionBuilder
         Dictionary<string, object> newOverrides = new(_parameterOverrides);
         foreach (KeyValuePair<string, object> kvp in parameters)
         {
-            newOverrides[kvp.Key] = kvp.Value;
+            if (kvp.Value != null)
+            {
+                ValidateParameterType(kvp.Key, kvp.Value);
+            }
+
+            newOverrides[kvp.Key] = kvp.Value!;
         }
 
         return new ListingExecutionBuilder(BaseListing, newOverrides) {
@@ -125,7 +130,7 @@ public class ListingExecutionBuilder
             ?? throw new ArgumentException($"Parameter '{parameterName}' not found in indicator '{BaseListing.Uiid}'", nameof(parameterName));
 
         // Validate series parameters
-        if (param.DataType == "IReadOnlyList<T> where T : IReusable")
+        if (param.DataType == IndicatorParam.SeriesDataType)
         {
             if (value is not System.Collections.IEnumerable)
             {
@@ -182,12 +187,24 @@ public class ListingExecutionBuilder
     /// <exception cref="InvalidOperationException">Thrown when no series parameter is found.</exception>
     private string FindFirstSeriesParameter()
     {
-        IndicatorParam? seriesParam
+        List<IndicatorParam> seriesParams
             = BaseListing.Parameters?
-                .FirstOrDefault(static p => p.DataType == "IReadOnlyList<T> where T : IReusable");
+                .Where(static p => p.DataType == IndicatorParam.SeriesDataType)
+                .ToList() ?? [];
 
-        return seriesParam?.ParameterName
-            ?? throw new InvalidOperationException($"No series parameter found in indicator '{BaseListing.Uiid}'");
+        // With one series parameter the intent is unambiguous. With more than one,
+        // guessing would bind the caller's series to the first slot and demote the
+        // bars source to the second — silently inverting an asymmetric calculation
+        // such as PRS or BETA. Require the name instead.
+        return seriesParams.Count switch {
+            0 => throw new InvalidOperationException(
+                $"No series parameter found in indicator '{BaseListing.Uiid}'"),
+            1 => seriesParams[0].ParameterName,
+            _ => throw new InvalidOperationException(
+                $"Indicator '{BaseListing.Uiid}' has {seriesParams.Count} series parameters "
+              + $"({string.Join(", ", seriesParams.Select(static p => p.ParameterName))}); "
+              + "name the one to bind: FromSource(series, \"parameterName\")")
+        };
     }
 
     /// <summary>

--- a/src/Common/Catalog/ListingExecutor.cs
+++ b/src/Common/Catalog/ListingExecutor.cs
@@ -63,8 +63,17 @@ internal static class ListingExecutor
             }
         }
 
-        // Build parameter array using catalog metadata and user overrides
-        List<object?> parameterList = [bars];
+        // Build parameter array using catalog metadata and user overrides.
+        //
+        // A listing that declares series parameters names its own source inputs, so
+        // bars are not prepended as an implicit first argument — they instead fill
+        // the first series parameter the caller did not supply. Every other listing
+        // keeps bars as the implicit source, as before.
+        bool declaresSeries = listing.Parameters?.Any(
+            static p => p.DataType == IndicatorParam.SeriesDataType) == true;
+
+        List<object?> parameterList = declaresSeries ? [] : [bars];
+        bool barsBound = !declaresSeries;
 
         // Add parameters based on catalog metadata
         if (listing.Parameters != null)
@@ -76,6 +85,23 @@ internal static class ListingExecutor
                 if (parameters?.TryGetValue(param.ParameterName, out object? value) == true)
                 {
                     parameterList.Add(value);
+                }
+                else if (param.DataType == IndicatorParam.SeriesDataType)
+                {
+                    // The bars source stands in for one missing series input only.
+                    // Filling a second one with the same data would compute a
+                    // degenerate result (a series compared against itself), so a
+                    // further missing series input is an error, not a default.
+                    if (barsBound)
+                    {
+                        throw new InvalidOperationException(
+                            $"Series parameter '{param.ParameterName}' must be supplied for indicator '{listing.Uiid}'. "
+                          + "The bars source fills only the first series parameter; provide the rest "
+                          + $"with WithParamValue(\"{param.ParameterName}\", series) or FromSource(series, \"{param.ParameterName}\").");
+                    }
+
+                    parameterList.Add(bars);
+                    barsBound = true;
                 }
                 else if (param.IsRequired)
                 {

--- a/src/Common/Catalog/Schema/IndicatorParam.cs
+++ b/src/Common/Catalog/Schema/IndicatorParam.cs
@@ -7,6 +7,12 @@ namespace FacioQuo.Stock.Indicators;
 public record IndicatorParam
 {
     /// <summary>
+    /// The <see cref="DataType"/> value identifying a series-input parameter.
+    /// </summary>
+    internal const string SeriesDataType = "IReadOnlyList<T> where T : IReusable";
+
+
+    /// <summary>
     /// Gets or sets the display name of the parameter.
     /// </summary>
     public required string DisplayName { get; init; }

--- a/tests/Library/Common/Catalog/Catalog.Executability.Tests.cs
+++ b/tests/Library/Common/Catalog/Catalog.Executability.Tests.cs
@@ -78,14 +78,14 @@ public class CatalogExecutabilityTests : TestBase
     }
 
     /// <summary>
-    /// Indicators that need a second input series, which the executor cannot supply.
+    /// Indicators that require a second input series and so cannot run from bars alone.
     /// </summary>
     /// <remarks>
-    /// <c>ListingExecutor</c> binds exactly one bars source, so a listing that also
-    /// declares a source series always assembles one argument too many. That is a
-    /// capability the executor does not have rather than a defect in these listings,
-    /// and it is tracked separately. Excluded by name so the count below stays a real
-    /// assertion instead of a moving target.
+    /// The executor binds bars to the first missing series parameter and rejects a
+    /// second missing one by design — comparing a series against itself is a
+    /// degenerate result, not a default. These execute with an explicit second
+    /// source (see the TwoSeriesIndicator tests in Catalog.Execution.Tests), and are
+    /// excluded here by name so the count below stays a real assertion.
     /// </remarks>
     private static readonly HashSet<string> TwoSeriesIndicators
         = new(StringComparer.Ordinal) { "BETA", "CORR", "PRS" };

--- a/tests/Library/Common/Catalog/Catalog.Execution.Tests.cs
+++ b/tests/Library/Common/Catalog/Catalog.Execution.Tests.cs
@@ -245,15 +245,25 @@ public class CatalogExecutionTests : TestBase
         IReadOnlyList<Bar> bars = Bars.Take(50).ToList();
 
         // Act — a name the listing does not define, e.g. one left over from a
-        // renamed catalog parameter
+        // renamed catalog parameter, rejected at the call that is wrong
         Action act = () => listing
-            .WithParams(new Dictionary<string, object> { ["lookbackPeriodz"] = 10 })
-            .FromSource((IEnumerable<IBar>)bars)
-            .Execute<EmaResult>();
+            .WithParams(new Dictionary<string, object> { ["lookbackPeriodz"] = 10 });
 
-        // Assert — must fail loudly rather than silently substituting the default,
-        // and name the parameters it would have accepted
-        act.Should().Throw<InvalidOperationException>()
+        // Assert — must fail loudly rather than silently substituting the default
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*lookbackPeriodz*not found in indicator*");
+
+        // A deserialized config bypasses the builder's validation, so the executor
+        // must reject the same mistake on that path too
+        IndicatorConfig config = new() {
+            Id = "EMA",
+            Style = Style.Series,
+            Parameters = new Dictionary<string, object> { ["lookbackPeriodz"] = 10 }
+        };
+
+        Action actConfig = () => config.Execute<EmaResult>(bars);
+
+        actConfig.Should().Throw<InvalidOperationException>()
             .WithMessage("*lookbackPeriodz*is not defined*")
             .WithMessage("*Expected one of: lookbackPeriods*");
     }
@@ -268,11 +278,15 @@ public class CatalogExecutionTests : TestBase
 
         IReadOnlyList<Bar> bars = Bars.Take(50).ToList();
 
-        // Act
-        Action act = () => listing
-            .WithParams(new Dictionary<string, object> { ["lookbackPeriods"] = 10 })
-            .FromSource((IEnumerable<IBar>)bars)
-            .Execute<GatorResult>();
+        // Act — via a deserialized config, which bypasses builder validation and
+        // exercises the executor's own rejection
+        IndicatorConfig config = new() {
+            Id = "GATOR",
+            Style = Style.Series,
+            Parameters = new Dictionary<string, object> { ["lookbackPeriods"] = 10 }
+        };
+
+        Action act = () => config.Execute<GatorResult>(bars);
 
         // Assert — the message must say the indicator takes none, not trail off
         // with an empty list
@@ -332,5 +346,116 @@ public class CatalogExecutionTests : TestBase
         viaCatalog.Should().HaveCount(direct.Count);
         viaCatalog[^1].Upper.Should().Be(direct[^1].Upper);
         viaCatalog[^1].Lower.Should().Be(direct[^1].Lower);
+    }
+
+    [TestMethod]
+    public void TwoSeriesIndicatorExecutesWithExplicitSources()
+    {
+        IndicatorListing listing = Catalog.Get("CORR", Style.Series);
+        listing.Should().NotBeNull();
+
+        IReadOnlyList<CorrResult> viaCatalog = listing
+            .WithParams(new Dictionary<string, object> {
+                ["sourceA"] = Bars,
+                ["sourceB"] = OtherBars
+            })
+            .FromSource((IEnumerable<IBar>)Bars)
+            .Execute<CorrResult>();
+
+        IReadOnlyList<CorrResult> direct = ((IReadOnlyList<IReusable>)Bars).ToCorrelation(OtherBars, 20);
+
+        viaCatalog.Should().HaveCount(direct.Count);
+        viaCatalog[^1].Correlation.Should().Be(direct[^1].Correlation);
+
+        // Correlation is symmetric, so it cannot detect an A/B slot swap;
+        // the per-side variances can
+        viaCatalog[^1].VarianceA.Should().Be(direct[^1].VarianceA);
+        viaCatalog[^1].VarianceB.Should().Be(direct[^1].VarianceB);
+    }
+
+    [TestMethod]
+    public void TwoSeriesIndicatorFillsFirstSourceFromBars()
+    {
+        // supplying only the second series binds bars to the first, so the natural
+        // "compare my bars against this benchmark" call needs one override, not two
+        IndicatorListing listing = Catalog.Get("PRS", Style.Series);
+        listing.Should().NotBeNull();
+
+        IReadOnlyList<PrsResult> viaCatalog = listing
+            .WithParamValue("sourceBase", OtherBars)
+            .FromSource((IEnumerable<IBar>)Bars)
+            .Execute<PrsResult>();
+
+        IReadOnlyList<PrsResult> direct = ((IReadOnlyList<IReusable>)Bars).ToPrs(OtherBars, 20);
+
+        viaCatalog.Should().HaveCount(direct.Count);
+        viaCatalog[^1].Prs.Should().Be(direct[^1].Prs);
+    }
+
+    [TestMethod]
+    public void TwoSeriesIndicatorUsesCatalogDefaultsForValueParameters()
+    {
+        IndicatorListing listing = Catalog.Get("BETA", Style.Series);
+        listing.Should().NotBeNull();
+
+        // lookbackPeriods (50) and type (Standard) come from catalog defaults;
+        // the enum default is stored as a boxed int and coerced by the binder
+        IReadOnlyList<BetaResult> viaCatalog = listing
+            .WithParamValue("sourceMrkt", OtherBars)
+            .FromSource((IEnumerable<IBar>)Bars)
+            .Execute<BetaResult>();
+
+        IReadOnlyList<BetaResult> direct = ((IReadOnlyList<IReusable>)Bars).ToBeta(OtherBars, 50);
+
+        viaCatalog.Should().HaveCount(direct.Count);
+        viaCatalog[^1].Beta.Should().Be(direct[^1].Beta);
+    }
+
+    [TestMethod]
+    public void TwoSeriesIndicatorRejectsMissingSecondSource()
+    {
+        // bars stand in for one series input only; filling a second with the same
+        // data would compute a series against itself, so it must fail loudly
+        IndicatorListing listing = Catalog.Get("CORR", Style.Series);
+
+        Action act = () => listing.Execute<CorrResult>(Bars);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*'sourceB' must be supplied*")
+            .WithMessage("*fills only the first series parameter*");
+    }
+
+    [TestMethod]
+    public void TwoSeriesIndicatorFillsSecondSourceFromBarsWhenFirstIsNamed()
+    {
+        // naming the first slot leaves bars for the second — the inverse ratio,
+        // reachable only by explicit choice
+        IndicatorListing listing = Catalog.Get("PRS", Style.Series);
+
+        IReadOnlyList<PrsResult> viaCatalog = listing
+            .WithParamValue("sourceEval", OtherBars)
+            .FromSource((IEnumerable<IBar>)Bars)
+            .Execute<PrsResult>();
+
+        IReadOnlyList<PrsResult> direct = ((IReadOnlyList<IReusable>)OtherBars).ToPrs(Bars, 20);
+
+        viaCatalog.Should().HaveCount(direct.Count);
+        viaCatalog[^1].Prs.Should().Be(direct[^1].Prs);
+    }
+
+    [TestMethod]
+    public void UnnamedSeriesSourceIsRejectedOnTwoSeriesIndicators()
+    {
+        // an unnamed FromSource(series) would bind the first slot and demote bars
+        // to the second, silently inverting an asymmetric calculation — so a
+        // listing with more than one series parameter demands the name
+        IndicatorListing listing = Catalog.Get("PRS", Style.Series);
+
+        Action act = () => listing.FromSource(OtherBars);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*2 series parameters*")
+            .WithMessage("*sourceEval, sourceBase*")
+            .WithMessage("*name the one to bind*");
     }
 }


### PR DESCRIPTION
Fixes #2196

## Problem

`BETA`, `CORR` and `PRS` could not be executed from their catalog listings at all. They declare their source series as catalog parameters — correctly, since a consumer must be able to discover that a second series is needed — but `ListingExecutor` unconditionally prepended bars as an implicit first argument, so the assembled argument list was always one longer than any overload accepts:

```text
PRS  → No 'ToPrs' method found with 4 parameters
CORR → No 'ToCorrelation' method found with 4 parameters
```

## Approach

A listing that declares series parameters now names its own source inputs: bars are not prepended, and each series parameter binds from the caller's overrides. Two deliberate semantics:

- **Bars stand in for the first missing series parameter only** — positional, not name-hardcoded — so the natural "compare my bars against this benchmark" call needs one override, not two, and naming the *first* slot instead leaves bars filling the second (the inverse ratio, reachable only by explicit choice).
- **A second missing series input is an error, not a default.** Filling it with the same bars would compute a series against itself — a degenerate result a caller almost certainly did not intend.

Listings without series parameters take the identical old path; the bars-only executability sweep over the other 240 listings pins that.

## Guards added from review

The first self-review found the change had converted a former loud arity failure into a **silent slot inversion**: unnamed `FromSource(series)` on a two-series listing bound the caller's series to `sourceEval` and demoted bars to `sourceBase` — PRS returned 0.657 where the intended ratio was 1.522, no exception. Guards now in place:

- A listing with more than one series parameter **rejects the unnamed `FromSource(series)` shorthand** and names the parameters to choose from; single-series chaining is unchanged.
- `WithParams` now runs the same value validation as `WithParamValue` (same null-value skip), so a wrong-shaped value fails at the call that is wrong rather than as a raw reflection error at `Invoke`. The executor keeps its own unknown-name rejection for deserialized `IndicatorConfig` replay, which bypasses the builder — tests exercise both layers.
- The CORR test asserts **per-side variances** as well as the coefficient, because correlation is symmetric and cannot detect an A/B slot swap on its own.

The series `DataType` marker string, previously declared in three places, is a single internal constant on `IndicatorParam`. No public API is added, renamed, or removed.

## Verification

Both catalog-execution results are compared against direct calls (values, not just counts), in both slot directions for PRS. Mutation-tested: reverting the executor change fails all four execution tests with the original `No 'ToCorrelation' method found with 4 parameters`; reverting the unnamed-source guard fails its dedicated test.

Review provenance: self-review lane (11 empirical probes) found the slot-inversion critical, fixed above; an independent pre-PR review pass then verified the fix and the binding semantics by hand-trace and by running the suites — zero blocking findings, including confirmation that the unnamed-shorthand test genuinely routes to the series overload under C#'s better-conversion rules.

```
Build:       0 Warning(s), 0 Error(s)   (--no-incremental, net10.0/net9.0/net8.0)
Unit:        Failed: 0, Passed: 2529, Skipped: 12
PublicApi:   Failed: 0, Passed: 76
Integration: Failed: 0, Passed: 4, Skipped: 1
markdownlint-cli2: 0 issues in 183 files
dotnet format --severity info: clean
```

## Notes

- **Sequencing:** merging moves `main` past `c3665278`, the commit the pending release's publish signal was verified against. If main is being held for the release, merge this after publishing.
- The bars-only publish-signal guard keeps excluding these three by name — now as a statement of design (a second source is required) rather than a missing capability, with the two-series tests as positive coverage.
- One design question surfaced and deferred to #2202 rather than decided here: PRS's two-argument "no PrsPercent" overload is unreachable through the catalog because the sentinel it uses is outside the declared parameter bounds.
