### PR TITLE
refactor: Bind catalog DataName values with nameof

### DIFF
--- a/.agents/skills/indicator-catalog/SKILL.md
+++ b/.agents/skills/indicator-catalog/SKILL.md
@@ -25,7 +25,7 @@ public static partial class Ema
             .AddParameter<int>("lookbackPeriods", "Lookback Period",
                 description: "Number of periods for the EMA calculation",
                 isRequired: true, defaultValue: 20, minimum: 2, maximum: 250)
-            .AddResult("Ema", "EMA", ResultType.Default, isReusable: true)
+            .AddResult(nameof(EmaResult.Ema), "EMA", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>
@@ -81,7 +81,8 @@ public static partial class Ema
 
 ## Result patterns
 
-- `dataName` must match property name in Models file exactly
+- `dataName` uses `nameof(TResult.Property)`, not a string literal, so a renamed result property fails the build instead of a test — e.g. `.AddResult(nameof(EmaResult.Ema), "EMA", ...)`
+- `displayName` stays a string literal; it is a human label, not a member name
 - `isReusable: true` only for the property mapping to `IReusable.Value`
 - `ISeries` models: all results must have `isReusable: false`
 - Exactly one `isReusable: true` per `IReusable` indicator
@@ -132,7 +133,8 @@ listings.Add(Beta.SeriesListing);
 - Wrong indicator method name
 - `isReusable: true` for `ISeries` models
 - Multiple `isReusable: true` results per indicator
-- A `dataName` or `parameterName` that names a member the library does not have
+- A `dataName` as a string literal where `nameof` can reach the member
+- A `parameterName` that names a member the library does not have
 
 ## Testing
 

--- a/src/Common/Catalog/CatalogListingBuilder.cs
+++ b/src/Common/Catalog/CatalogListingBuilder.cs
@@ -262,7 +262,10 @@ internal class CatalogListingBuilder
     /// <summary>
     /// Adds a result to the indicator.
     /// </summary>
-    /// <param name="dataName">Name of the data property.</param>
+    /// <param name="dataName">
+    /// Name of the data property. Pass <c>nameof(TResult.Property)</c> rather than a
+    /// literal so a renamed result property fails the build.
+    /// </param>
     /// <param name="displayName">Display name of the result.</param>
     /// <param name="dataType">Type of the result.</param>
     /// <param name="isReusable">Whether this is the reusable result.</param>

--- a/src/Common/Catalog/README.md
+++ b/src/Common/Catalog/README.md
@@ -7,7 +7,7 @@ Concise reference for building, discovering, and executing indicator listings.
 Use `IndicatorDefinitionBuilder` inside each indicator’s `*.Catalog.cs` to define metadata once per style:
 
 ```csharp
-internal static readonly IndicatorListing SeriesListing = new IndicatorDefinitionBuilder()
+internal static readonly IndicatorListing SeriesListing = new CatalogListingBuilder()
         .WithName("Exponential Moving Average")
         .WithId("EMA")
         .WithStyle(Style.Series)
@@ -16,7 +16,7 @@ internal static readonly IndicatorListing SeriesListing = new IndicatorDefinitio
         .AddParameter<int>("lookbackPeriods", "Lookback Period",
                 description: "Number of periods for the EMA calculation",
                 isRequired: true, defaultValue: 20, minimum: 2, maximum: 250)
-        .AddResult("Ema", "EMA", ResultType.Default, isReusable: true)
+        .AddResult(nameof(EmaResult.Ema), "EMA", ResultType.Default, isReusable: true)
         .Build();
 ```
 
@@ -27,6 +27,7 @@ Core builder methods: `.WithName`, `.WithId`, `.WithStyle`, `.WithCategory`, `.W
 - Use the same ID across styles (e.g., EMA)
 - Define separate listings: `SeriesListing`, `StreamListing`, `BufferListing`
 - Parameter names must exactly match method signatures
+- Result `dataName` uses `nameof(TResult.Property)` so a renamed result property fails the build
 
 ## Catalog and registry access
 

--- a/src/Indicators/a-b/Adl/Adl.Catalog.cs
+++ b/src/Indicators/a-b/Adl/Adl.Catalog.cs
@@ -10,7 +10,7 @@ public static partial class Adl
             .WithName("Accumulation Distribution Line (ADL)")
             .WithId("ADL")
             .WithCategory(Category.VolumeBased)
-            .AddResult("Adl", "Accumulation Distribution Line (ADL)", ResultType.Default, isReusable: true)
+            .AddResult(nameof(AdlResult.Adl), "Accumulation Distribution Line (ADL)", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/a-b/Adx/Adx.Catalog.cs
+++ b/src/Indicators/a-b/Adx/Adx.Catalog.cs
@@ -11,11 +11,11 @@ public static partial class Adx
             .WithId("ADX")
             .WithCategory(Category.PriceTrend)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", defaultValue: 14, minimum: 2, maximum: 250)
-            .AddResult("Pdi", "+DI", ResultType.Default)
-            .AddResult("Mdi", "-DI", ResultType.Default)
-            .AddResult("Dx", "DX", ResultType.Default)
-            .AddResult("Adx", "ADX", ResultType.Default, isReusable: true)
-            .AddResult("Adxr", "ADXR", ResultType.Default)
+            .AddResult(nameof(AdxResult.Pdi), "+DI", ResultType.Default)
+            .AddResult(nameof(AdxResult.Mdi), "-DI", ResultType.Default)
+            .AddResult(nameof(AdxResult.Dx), "DX", ResultType.Default)
+            .AddResult(nameof(AdxResult.Adx), "ADX", ResultType.Default, isReusable: true)
+            .AddResult(nameof(AdxResult.Adxr), "ADXR", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/a-b/Alligator/Alligator.Catalog.cs
+++ b/src/Indicators/a-b/Alligator/Alligator.Catalog.cs
@@ -16,9 +16,9 @@ public static partial class Alligator
             .AddParameter<int>("teethOffset", "Teeth Offset", description: "Offset periods for the Teeth line", isRequired: true, defaultValue: 5, minimum: 1, maximum: 50)
             .AddParameter<int>("lipsPeriods", "Lips Periods", description: "Lookback periods for the Lips line", isRequired: true, defaultValue: 5, minimum: 2, maximum: 250)
             .AddParameter<int>("lipsOffset", "Lips Offset", description: "Offset periods for the Lips line", isRequired: true, defaultValue: 3, minimum: 1, maximum: 50)
-            .AddResult("Jaw", "Jaw", ResultType.Default)
-            .AddResult("Teeth", "Teeth", ResultType.Default)
-            .AddResult("Lips", "Lips", ResultType.Default, isReusable: true)
+            .AddResult(nameof(AlligatorResult.Jaw), "Jaw", ResultType.Default)
+            .AddResult(nameof(AlligatorResult.Teeth), "Teeth", ResultType.Default)
+            .AddResult(nameof(AlligatorResult.Lips), "Lips", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/a-b/Alma/Alma.Catalog.cs
+++ b/src/Indicators/a-b/Alma/Alma.Catalog.cs
@@ -13,7 +13,7 @@ public static partial class Alma
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", defaultValue: 9, minimum: 2, maximum: 250)
             .AddParameter<double>("offset", "Offset", defaultValue: 0.85, minimum: 0.0, maximum: 1.0)
             .AddParameter<double>("sigma", "Sigma", defaultValue: 6.0, minimum: 0.1, maximum: 10.0)
-            .AddResult("Alma", "Arnaud Legoux Moving Average (ALMA)", ResultType.Default, isReusable: true)
+            .AddResult(nameof(AlmaResult.Alma), "Arnaud Legoux Moving Average (ALMA)", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/a-b/Aroon/Aroon.Catalog.cs
+++ b/src/Indicators/a-b/Aroon/Aroon.Catalog.cs
@@ -11,9 +11,9 @@ public static partial class Aroon
             .WithId("AROON")
             .WithCategory(Category.PriceTrend)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", defaultValue: 25, minimum: 1, maximum: 250)
-            .AddResult("AroonUp", "Aroon Up", ResultType.Default)
-            .AddResult("AroonDown", "Aroon Down", ResultType.Default)
-            .AddResult("Oscillator", "Oscillator", ResultType.Default, isReusable: true)
+            .AddResult(nameof(AroonResult.AroonUp), "Aroon Up", ResultType.Default)
+            .AddResult(nameof(AroonResult.AroonDown), "Aroon Down", ResultType.Default)
+            .AddResult(nameof(AroonResult.Oscillator), "Oscillator", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/a-b/Atr/Atr.Catalog.cs
+++ b/src/Indicators/a-b/Atr/Atr.Catalog.cs
@@ -11,9 +11,9 @@ public static partial class Atr
             .WithId("ATR")
             .WithCategory(Category.PriceCharacteristic)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", defaultValue: 14, minimum: 2, maximum: 250)
-            .AddResult("Tr", "True Range", ResultType.Default)
-            .AddResult("Atr", "ATR", ResultType.Default)
-            .AddResult("Atrp", "ATR %", ResultType.Default, isReusable: true)
+            .AddResult(nameof(AtrResult.Tr), "True Range", ResultType.Default)
+            .AddResult(nameof(AtrResult.Atr), "ATR", ResultType.Default)
+            .AddResult(nameof(AtrResult.Atrp), "ATR %", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/a-b/AtrStop/AtrStop.Catalog.cs
+++ b/src/Indicators/a-b/AtrStop/AtrStop.Catalog.cs
@@ -13,10 +13,10 @@ public static partial class AtrStop
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", defaultValue: 21, minimum: 1, maximum: 50)
             .AddParameter<double>("multiplier", "Multiplier", defaultValue: 3.0, minimum: 0.1, maximum: 10.0)
             .AddEnumParameter<EndType>("endType", "End Type", defaultValue: EndType.Close)
-            .AddResult("AtrStop", "ATR Trailing Stop", ResultType.Default, isReusable: true)
-            .AddResult("BuyStop", "Buy Stop", ResultType.Default)
-            .AddResult("SellStop", "Sell Stop", ResultType.Default)
-            .AddResult("Atr", "ATR", ResultType.Default)
+            .AddResult(nameof(AtrStopResult.AtrStop), "ATR Trailing Stop", ResultType.Default, isReusable: true)
+            .AddResult(nameof(AtrStopResult.BuyStop), "Buy Stop", ResultType.Default)
+            .AddResult(nameof(AtrStopResult.SellStop), "Sell Stop", ResultType.Default)
+            .AddResult(nameof(AtrStopResult.Atr), "ATR", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/a-b/Awesome/Awesome.Catalog.cs
+++ b/src/Indicators/a-b/Awesome/Awesome.Catalog.cs
@@ -12,8 +12,8 @@ public static partial class Awesome
             .WithCategory(Category.Oscillator)
             .AddParameter<int>("fastPeriods", "Fast Periods", defaultValue: 5, minimum: 1, maximum: 100)
             .AddParameter<int>("slowPeriods", "Slow Periods", defaultValue: 34, minimum: 1, maximum: 250)
-            .AddResult("Oscillator", "Oscillator", ResultType.Default, isReusable: true)
-            .AddResult("Normalized", "Normalized", ResultType.Default)
+            .AddResult(nameof(AwesomeResult.Oscillator), "Oscillator", ResultType.Default, isReusable: true)
+            .AddResult(nameof(AwesomeResult.Normalized), "Normalized", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/a-b/BarPart/BarParts.Catalog.cs
+++ b/src/Indicators/a-b/BarPart/BarParts.Catalog.cs
@@ -11,7 +11,7 @@ public static partial class BarParts
             .WithId("BARPART")
             .WithCategory(Category.PriceTransform)
             .AddEnumParameter<CandlePart>("candlePart", "Candle Part", defaultValue: CandlePart.Close)
-            .AddResult("Value", "Value", ResultType.Default, isReusable: true)
+            .AddResult(nameof(TimeValue.Value), "Value", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/a-b/Beta/Beta.Catalog.cs
+++ b/src/Indicators/a-b/Beta/Beta.Catalog.cs
@@ -14,13 +14,13 @@ public static partial class Beta
             .AddSeriesParameter("sourceMrkt", "Market Prices")
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", defaultValue: 50, minimum: 1, maximum: 250)
             .AddEnumParameter<BetaType>("type", "Beta Type", defaultValue: BetaType.Standard)
-            .AddResult("Beta", "Beta", ResultType.Default, isReusable: true)
-            .AddResult("BetaUp", "Beta Up", ResultType.Default)
-            .AddResult("BetaDown", "Beta Down", ResultType.Default)
-            .AddResult("Ratio", "Ratio", ResultType.Default)
-            .AddResult("Convexity", "Convexity", ResultType.Default)
-            .AddResult("ReturnsEval", "Returns Eval", ResultType.Default)
-            .AddResult("ReturnsMrkt", "Returns Mrkt", ResultType.Default)
+            .AddResult(nameof(BetaResult.Beta), "Beta", ResultType.Default, isReusable: true)
+            .AddResult(nameof(BetaResult.BetaUp), "Beta Up", ResultType.Default)
+            .AddResult(nameof(BetaResult.BetaDown), "Beta Down", ResultType.Default)
+            .AddResult(nameof(BetaResult.Ratio), "Ratio", ResultType.Default)
+            .AddResult(nameof(BetaResult.Convexity), "Convexity", ResultType.Default)
+            .AddResult(nameof(BetaResult.ReturnsEval), "Returns Eval", ResultType.Default)
+            .AddResult(nameof(BetaResult.ReturnsMrkt), "Returns Mrkt", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/a-b/BollingerBands/BollingerBands.Catalog.cs
+++ b/src/Indicators/a-b/BollingerBands/BollingerBands.Catalog.cs
@@ -12,12 +12,12 @@ public static partial class BollingerBands
             .WithCategory(Category.PriceChannel)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", defaultValue: 20, minimum: 2, maximum: 250)
             .AddParameter<double>("standardDeviations", "Standard Deviations", defaultValue: 2.0, minimum: 0.01, maximum: 10.0)
-            .AddResult("Sma", "Centerline (SMA)", ResultType.Default)
-            .AddResult("UpperBand", "Upper Band", ResultType.Default)
-            .AddResult("LowerBand", "Lower Band", ResultType.Default)
-            .AddResult("PercentB", "%B", ResultType.Default, isReusable: true)
-            .AddResult("ZScore", "Z-score", ResultType.Default)
-            .AddResult("Width", "Width", ResultType.Default)
+            .AddResult(nameof(BollingerBandsResult.Sma), "Centerline (SMA)", ResultType.Default)
+            .AddResult(nameof(BollingerBandsResult.UpperBand), "Upper Band", ResultType.Default)
+            .AddResult(nameof(BollingerBandsResult.LowerBand), "Lower Band", ResultType.Default)
+            .AddResult(nameof(BollingerBandsResult.PercentB), "%B", ResultType.Default, isReusable: true)
+            .AddResult(nameof(BollingerBandsResult.ZScore), "Z-score", ResultType.Default)
+            .AddResult(nameof(BollingerBandsResult.Width), "Width", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/a-b/Bop/Bop.Catalog.cs
+++ b/src/Indicators/a-b/Bop/Bop.Catalog.cs
@@ -11,7 +11,7 @@ public static partial class Bop
             .WithId("BOP")
             .WithCategory(Category.Oscillator)
             .AddParameter<int>("smoothPeriods", "Smooth Periods", defaultValue: 14, minimum: 1, maximum: 250)
-            .AddResult("Bop", "BOP", ResultType.Default, isReusable: true)
+            .AddResult(nameof(BopResult.Bop), "BOP", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/c-d/Cci/Cci.Catalog.cs
+++ b/src/Indicators/c-d/Cci/Cci.Catalog.cs
@@ -11,7 +11,7 @@ public static partial class Cci
             .WithId("CCI")
             .WithCategory(Category.Oscillator)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", defaultValue: 20, minimum: 1, maximum: 250)
-            .AddResult("Cci", "CCI", ResultType.Default, isReusable: true)
+            .AddResult(nameof(CciResult.Cci), "CCI", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/c-d/ChaikinOsc/ChaikinOsc.Catalog.cs
+++ b/src/Indicators/c-d/ChaikinOsc/ChaikinOsc.Catalog.cs
@@ -12,10 +12,10 @@ public static partial class ChaikinOsc
             .WithCategory(Category.VolumeBased)
             .AddParameter<int>("fastPeriods", "Fast Periods", defaultValue: 3, minimum: 1, maximum: 100)
             .AddParameter<int>("slowPeriods", "Slow Periods", defaultValue: 10, minimum: 1, maximum: 100)
-            .AddResult("MoneyFlowMultiplier", "Money Flow Multiplier", ResultType.Default)
-            .AddResult("MoneyFlowVolume", "Money Flow Volume", ResultType.Default)
-            .AddResult("Adl", "ADL", ResultType.Default)
-            .AddResult("Oscillator", "Oscillator", ResultType.Default, isReusable: true)
+            .AddResult(nameof(ChaikinOscResult.MoneyFlowMultiplier), "Money Flow Multiplier", ResultType.Default)
+            .AddResult(nameof(ChaikinOscResult.MoneyFlowVolume), "Money Flow Volume", ResultType.Default)
+            .AddResult(nameof(ChaikinOscResult.Adl), "ADL", ResultType.Default)
+            .AddResult(nameof(ChaikinOscResult.Oscillator), "Oscillator", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/c-d/Chandelier/Chandelier.Catalog.cs
+++ b/src/Indicators/c-d/Chandelier/Chandelier.Catalog.cs
@@ -13,7 +13,7 @@ public static partial class Chandelier
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", defaultValue: 22, minimum: 1, maximum: 250)
             .AddParameter<double>("multiplier", "Multiplier", defaultValue: 3.0, minimum: 1.0, maximum: 10.0)
             .AddEnumParameter<Direction>("type", "Direction", defaultValue: Direction.Long)
-            .AddResult("ChandelierExit", "Chandelier Exit", ResultType.Default, isReusable: true)
+            .AddResult(nameof(ChandelierResult.ChandelierExit), "Chandelier Exit", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/c-d/Chop/Chop.Catalog.cs
+++ b/src/Indicators/c-d/Chop/Chop.Catalog.cs
@@ -11,7 +11,7 @@ public static partial class Chop
             .WithId("CHOP")
             .WithCategory(Category.Oscillator)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", defaultValue: 14, minimum: 1, maximum: 250)
-            .AddResult("Chop", "CHOP", ResultType.Default, isReusable: true)
+            .AddResult(nameof(ChopResult.Chop), "CHOP", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/c-d/Cmf/Cmf.Catalog.cs
+++ b/src/Indicators/c-d/Cmf/Cmf.Catalog.cs
@@ -11,9 +11,9 @@ public static partial class Cmf
             .WithId("CMF")
             .WithCategory(Category.VolumeBased)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", defaultValue: 20, minimum: 1, maximum: 250)
-            .AddResult("MoneyFlowMultiplier", "Money Flow Multiplier", ResultType.Default)
-            .AddResult("MoneyFlowVolume", "Money Flow Volume", ResultType.Default)
-            .AddResult("Cmf", "CMF", ResultType.Default, isReusable: true)
+            .AddResult(nameof(CmfResult.MoneyFlowMultiplier), "Money Flow Multiplier", ResultType.Default)
+            .AddResult(nameof(CmfResult.MoneyFlowVolume), "Money Flow Volume", ResultType.Default)
+            .AddResult(nameof(CmfResult.Cmf), "CMF", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/c-d/Cmo/Cmo.Catalog.cs
+++ b/src/Indicators/c-d/Cmo/Cmo.Catalog.cs
@@ -11,7 +11,7 @@ public static partial class Cmo
             .WithId("CMO")
             .WithCategory(Category.Oscillator)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", defaultValue: 14, minimum: 1, maximum: 250)
-            .AddResult("Cmo", "CMO", ResultType.Default, isReusable: true)
+            .AddResult(nameof(CmoResult.Cmo), "CMO", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/c-d/ConnorsRsi/ConnorsRsi.Catalog.cs
+++ b/src/Indicators/c-d/ConnorsRsi/ConnorsRsi.Catalog.cs
@@ -13,11 +13,11 @@ public static partial class ConnorsRsi
             .AddParameter<int>("rsiPeriods", "RSI Periods", defaultValue: 3, minimum: 2, maximum: 250)
             .AddParameter<int>("streakPeriods", "Streak Periods", defaultValue: 2, minimum: 2, maximum: 50)
             .AddParameter<int>("rankPeriods", "Rank Periods", defaultValue: 100, minimum: 2, maximum: 250)
-            .AddResult("Streak", "Streak", ResultType.Default)
-            .AddResult("Rsi", "RSI", ResultType.Default)
-            .AddResult("RsiStreak", "RSI of Streak", ResultType.Default)
-            .AddResult("PercentRank", "Percent Rank", ResultType.Default)
-            .AddResult("ConnorsRsi", "ConnorsRSI", ResultType.Default, isReusable: true)
+            .AddResult(nameof(ConnorsRsiResult.Streak), "Streak", ResultType.Default)
+            .AddResult(nameof(ConnorsRsiResult.Rsi), "RSI", ResultType.Default)
+            .AddResult(nameof(ConnorsRsiResult.RsiStreak), "RSI of Streak", ResultType.Default)
+            .AddResult(nameof(ConnorsRsiResult.PercentRank), "Percent Rank", ResultType.Default)
+            .AddResult(nameof(ConnorsRsiResult.ConnorsRsi), "ConnorsRSI", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/c-d/Correlation/Correlation.Catalog.cs
+++ b/src/Indicators/c-d/Correlation/Correlation.Catalog.cs
@@ -13,11 +13,11 @@ public static partial class Correlation
             .AddSeriesParameter("sourceA", "Source A")
             .AddSeriesParameter("sourceB", "Source B")
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", defaultValue: 20, minimum: 1, maximum: 250)
-            .AddResult("VarianceA", "Variance A", ResultType.Default)
-            .AddResult("VarianceB", "Variance B", ResultType.Default)
-            .AddResult("Covariance", "Covariance", ResultType.Default)
-            .AddResult("Correlation", "Correlation", ResultType.Default, isReusable: true)
-            .AddResult("RSquared", "R-squared", ResultType.Default)
+            .AddResult(nameof(CorrResult.VarianceA), "Variance A", ResultType.Default)
+            .AddResult(nameof(CorrResult.VarianceB), "Variance B", ResultType.Default)
+            .AddResult(nameof(CorrResult.Covariance), "Covariance", ResultType.Default)
+            .AddResult(nameof(CorrResult.Correlation), "Correlation", ResultType.Default, isReusable: true)
+            .AddResult(nameof(CorrResult.RSquared), "R-squared", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/c-d/Dema/Dema.Catalog.cs
+++ b/src/Indicators/c-d/Dema/Dema.Catalog.cs
@@ -11,7 +11,7 @@ public static partial class Dema
             .WithId("DEMA")
             .WithCategory(Category.MovingAverage)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", description: "Number of periods for the DEMA calculation", isRequired: false, defaultValue: 14, minimum: 2, maximum: 250)
-            .AddResult("Dema", "DEMA", ResultType.Default, isReusable: true)
+            .AddResult(nameof(DemaResult.Dema), "DEMA", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/c-d/Doji/Doji.Catalog.cs
+++ b/src/Indicators/c-d/Doji/Doji.Catalog.cs
@@ -11,7 +11,7 @@ public static partial class Doji
             .WithId("DOJI")
             .WithCategory(Category.CandlestickPattern)
             .AddParameter<double>("maxPriceChangePercent", "Max Price Change %", defaultValue: 0.1, minimum: 0.0, maximum: 0.5)
-            .AddResult("Match", "Match", ResultType.Default, isReusable: true)
+            .AddResult(nameof(CandleResult.Match), "Match", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/c-d/Donchian/Donchian.Catalog.cs
+++ b/src/Indicators/c-d/Donchian/Donchian.Catalog.cs
@@ -11,10 +11,10 @@ public static partial class Donchian
             .WithId("DONCHIAN")
             .WithCategory(Category.PriceChannel)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", defaultValue: 20, minimum: 1, maximum: 250)
-            .AddResult("UpperBand", "Upper Band", ResultType.Default)
-            .AddResult("Centerline", "Centerline", ResultType.Default, isReusable: true)
-            .AddResult("LowerBand", "Lower Band", ResultType.Default)
-            .AddResult("Width", "Width", ResultType.Default)
+            .AddResult(nameof(DonchianResult.UpperBand), "Upper Band", ResultType.Default)
+            .AddResult(nameof(DonchianResult.Centerline), "Centerline", ResultType.Default, isReusable: true)
+            .AddResult(nameof(DonchianResult.LowerBand), "Lower Band", ResultType.Default)
+            .AddResult(nameof(DonchianResult.Width), "Width", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/c-d/Dpo/Dpo.Catalog.cs
+++ b/src/Indicators/c-d/Dpo/Dpo.Catalog.cs
@@ -11,8 +11,8 @@ public static partial class Dpo
             .WithId("DPO")
             .WithCategory(Category.Oscillator)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", defaultValue: 14, minimum: 2, maximum: 250)
-            .AddResult("Dpo", "DPO", ResultType.Default, isReusable: true)
-            .AddResult("Sma", "SMA", ResultType.Default)
+            .AddResult(nameof(DpoResult.Dpo), "DPO", ResultType.Default, isReusable: true)
+            .AddResult(nameof(DpoResult.Sma), "SMA", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/c-d/Dynamic/MgDynamic.Catalog.cs
+++ b/src/Indicators/c-d/Dynamic/MgDynamic.Catalog.cs
@@ -12,7 +12,7 @@ public static partial class MgDynamic
             .WithCategory(Category.MovingAverage)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", description: "Number of periods for the McGinley Dynamic calculation", isRequired: true, defaultValue: 14, minimum: 1, maximum: 250)
             .AddParameter<double>("kFactor", "K Factor", description: "Smoothing factor for the calculation", isRequired: false, defaultValue: 0.6, minimum: 0.1, maximum: 2.0)
-            .AddResult("Dynamic", "McGinley Dynamic", ResultType.Default, isReusable: true)
+            .AddResult(nameof(DynamicResult.Dynamic), "McGinley Dynamic", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/e-j/ElderRay/ElderRay.Catalog.cs
+++ b/src/Indicators/e-j/ElderRay/ElderRay.Catalog.cs
@@ -11,10 +11,10 @@ public static partial class ElderRay
             .WithId("ELDER-RAY")
             .WithCategory(Category.PriceTrend)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", defaultValue: 13, minimum: 1, maximum: 250)
-            .AddResult("Ema", "EMA", ResultType.Default)
-            .AddResult("BullPower", "Bull Power", ResultType.Default)
-            .AddResult("BearPower", "Bear Power", ResultType.Default)
-            .AddResult("Value", "Elder Ray", ResultType.Default, isReusable: true) // Calculated value (BullPower + BearPower) for IReusable.Value
+            .AddResult(nameof(ElderRayResult.Ema), "EMA", ResultType.Default)
+            .AddResult(nameof(ElderRayResult.BullPower), "Bull Power", ResultType.Default)
+            .AddResult(nameof(ElderRayResult.BearPower), "Bear Power", ResultType.Default)
+            .AddResult(nameof(ElderRayResult.Value), "Elder Ray", ResultType.Default, isReusable: true) // Calculated value (BullPower + BearPower) for IReusable.Value
             .Build();
 
     /// <summary>

--- a/src/Indicators/e-j/Ema/Ema.Catalog.cs
+++ b/src/Indicators/e-j/Ema/Ema.Catalog.cs
@@ -11,7 +11,7 @@ public static partial class Ema
             .WithId("EMA")
             .WithCategory(Category.MovingAverage)
             .AddParameter<int>("lookbackPeriods", "Lookback Period", description: "Number of periods for the EMA calculation", isRequired: true, defaultValue: 20, minimum: 2, maximum: 250)
-            .AddResult("Ema", "EMA", ResultType.Default, isReusable: true)
+            .AddResult(nameof(EmaResult.Ema), "EMA", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/e-j/Epma/Epma.Catalog.cs
+++ b/src/Indicators/e-j/Epma/Epma.Catalog.cs
@@ -11,7 +11,7 @@ public static partial class Epma
             .WithId("EPMA")
             .WithCategory(Category.MovingAverage)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", defaultValue: 10, minimum: 1, maximum: 250)
-            .AddResult("Epma", "EPMA", ResultType.Default, isReusable: true)
+            .AddResult(nameof(EpmaResult.Epma), "EPMA", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/e-j/Fcb/Fcb.Catalog.cs
+++ b/src/Indicators/e-j/Fcb/Fcb.Catalog.cs
@@ -11,8 +11,8 @@ public static partial class Fcb
             .WithId("FCB")
             .WithCategory(Category.PriceChannel)
             .AddParameter<int>("windowSpan", "Window Span", defaultValue: 2, minimum: 2, maximum: 30)
-            .AddResult("UpperBand", "Upper Band", ResultType.Default, isReusable: true)
-            .AddResult("LowerBand", "Lower Band", ResultType.Default)
+            .AddResult(nameof(FcbResult.UpperBand), "Upper Band", ResultType.Default, isReusable: true)
+            .AddResult(nameof(FcbResult.LowerBand), "Lower Band", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/e-j/FisherTransform/FisherTransform.Catalog.cs
+++ b/src/Indicators/e-j/FisherTransform/FisherTransform.Catalog.cs
@@ -11,8 +11,8 @@ public static partial class FisherTransform
             .WithId("FISHER")
             .WithCategory(Category.PriceTransform)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", defaultValue: 10, minimum: 1, maximum: 250)
-            .AddResult("Fisher", "Fisher", ResultType.Default, isReusable: true)
-            .AddResult("Trigger", "Trigger", ResultType.Default)
+            .AddResult(nameof(FisherTransformResult.Fisher), "Fisher", ResultType.Default, isReusable: true)
+            .AddResult(nameof(FisherTransformResult.Trigger), "Trigger", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/e-j/ForceIndex/ForceIndex.Catalog.cs
+++ b/src/Indicators/e-j/ForceIndex/ForceIndex.Catalog.cs
@@ -11,7 +11,7 @@ public static partial class ForceIndex
             .WithId("FORCE")
             .WithCategory(Category.VolumeBased)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", defaultValue: 2, minimum: 1, maximum: 250)
-            .AddResult("ForceIndex", "Force Index", ResultType.Default, isReusable: true)
+            .AddResult(nameof(ForceIndexResult.ForceIndex), "Force Index", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/e-j/Fractal/Fractal.Catalog.cs
+++ b/src/Indicators/e-j/Fractal/Fractal.Catalog.cs
@@ -12,8 +12,8 @@ public static partial class Fractal
             .WithCategory(Category.PricePattern)
             .AddParameter<int>("windowSpan", "Window Span", description: "Number of periods to look back and forward for the calculation", isRequired: false, defaultValue: 2, minimum: 1, maximum: 100)
             .AddEnumParameter<EndType>("endType", "End Type", description: "Type of price to use for the calculation", isRequired: false, defaultValue: EndType.HighLow)
-            .AddResult("FractalBear", "Bear Fractal", ResultType.Default)
-            .AddResult("FractalBull", "Bull Fractal", ResultType.Default, isReusable: true)
+            .AddResult(nameof(FractalResult.FractalBear), "Bear Fractal", ResultType.Default)
+            .AddResult(nameof(FractalResult.FractalBull), "Bull Fractal", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/e-j/Gator/Gator.Catalog.cs
+++ b/src/Indicators/e-j/Gator/Gator.Catalog.cs
@@ -10,10 +10,10 @@ public static partial class Gator
             .WithName("Gator Oscillator")
             .WithId("GATOR")
             .WithCategory(Category.Oscillator)
-            .AddResult("Upper", "Upper", ResultType.Default, false)
-            .AddResult("Lower", "Lower", ResultType.Default, false)
-            .AddResult("UpperIsExpanding", "Upper Is Expanding", ResultType.Default, false)
-            .AddResult("LowerIsExpanding", "Lower Is Expanding", ResultType.Default, false)
+            .AddResult(nameof(GatorResult.Upper), "Upper", ResultType.Default, false)
+            .AddResult(nameof(GatorResult.Lower), "Lower", ResultType.Default, false)
+            .AddResult(nameof(GatorResult.UpperIsExpanding), "Upper Is Expanding", ResultType.Default, false)
+            .AddResult(nameof(GatorResult.LowerIsExpanding), "Lower Is Expanding", ResultType.Default, false)
             .Build();
 
     /// <summary>

--- a/src/Indicators/e-j/HeikinAshi/HeikinAshi.Catalog.cs
+++ b/src/Indicators/e-j/HeikinAshi/HeikinAshi.Catalog.cs
@@ -10,11 +10,11 @@ public static partial class HeikinAshi
             .WithName("HeikinAshi")
             .WithId("HEIKINASHI")
             .WithCategory(Category.PriceTransform)
-            .AddResult("Open", "Open", ResultType.Default)
-            .AddResult("High", "High", ResultType.Default)
-            .AddResult("Low", "Low", ResultType.Default)
-            .AddResult("Close", "Close", ResultType.Default, isReusable: true)
-            .AddResult("Volume", "Volume", ResultType.Default)
+            .AddResult(nameof(HeikinAshiResult.Open), "Open", ResultType.Default)
+            .AddResult(nameof(HeikinAshiResult.High), "High", ResultType.Default)
+            .AddResult(nameof(HeikinAshiResult.Low), "Low", ResultType.Default)
+            .AddResult(nameof(HeikinAshiResult.Close), "Close", ResultType.Default, isReusable: true)
+            .AddResult(nameof(HeikinAshiResult.Volume), "Volume", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/e-j/Hma/Hma.Catalog.cs
+++ b/src/Indicators/e-j/Hma/Hma.Catalog.cs
@@ -11,7 +11,7 @@ public static partial class Hma
             .WithId("HMA")
             .WithCategory(Category.MovingAverage)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", defaultValue: 14, minimum: 2, maximum: 250)
-            .AddResult("Hma", "HMA", ResultType.Default, isReusable: true)
+            .AddResult(nameof(HmaResult.Hma), "HMA", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/e-j/HtTrendline/HtTrendline.Catalog.cs
+++ b/src/Indicators/e-j/HtTrendline/HtTrendline.Catalog.cs
@@ -10,9 +10,9 @@ public static partial class HtTrendline
             .WithName("Hilbert Transform Instantaneous Trendline")
             .WithId("HTL")
             .WithCategory(Category.MovingAverage)
-            .AddResult("DcPeriods", "Dominant Cycle Periods", ResultType.Default)
-            .AddResult("Trendline", "Trendline", ResultType.Default, isReusable: true)
-            .AddResult("SmoothPrice", "Smooth Price", ResultType.Default)
+            .AddResult(nameof(HtlResult.DcPeriods), "Dominant Cycle Periods", ResultType.Default)
+            .AddResult(nameof(HtlResult.Trendline), "Trendline", ResultType.Default, isReusable: true)
+            .AddResult(nameof(HtlResult.SmoothPrice), "Smooth Price", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/e-j/Hurst/Hurst.Catalog.cs
+++ b/src/Indicators/e-j/Hurst/Hurst.Catalog.cs
@@ -11,8 +11,8 @@ public static partial class Hurst
             .WithId("HURST")
             .WithCategory(Category.PriceCharacteristic)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", defaultValue: 100, minimum: 20, maximum: 250)
-            .AddResult("HurstExponent", "Hurst Exponent", ResultType.Default, isReusable: true)
-            .AddResult("HurstExponentAL", "Hurst Exponent AL", ResultType.Default)
+            .AddResult(nameof(HurstResult.HurstExponent), "Hurst Exponent", ResultType.Default, isReusable: true)
+            .AddResult(nameof(HurstResult.HurstExponentAL), "Hurst Exponent AL", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/e-j/Ichimoku/Ichimoku.Catalog.cs
+++ b/src/Indicators/e-j/Ichimoku/Ichimoku.Catalog.cs
@@ -13,11 +13,11 @@ public static partial class Ichimoku
             .AddParameter<int>("tenkanPeriods", "Tenkan Periods", defaultValue: 9, minimum: 1, maximum: 250)
             .AddParameter<int>("kijunPeriods", "Kijun Periods", defaultValue: 26, minimum: 2, maximum: 250)
             .AddParameter<int>("senkouBPeriods", "Senkou B Periods", defaultValue: 52, minimum: 3, maximum: 250)
-            .AddResult("TenkanSen", "Tenkan-sen", ResultType.Default, isReusable: true)
-            .AddResult("KijunSen", "Kijun-sen", ResultType.Default)
-            .AddResult("SenkouSpanA", "Senkou Span A", ResultType.Default)
-            .AddResult("SenkouSpanB", "Senkou Span B", ResultType.Default)
-            .AddResult("ChikouSpan", "Chikou Span", ResultType.Default)
+            .AddResult(nameof(IchimokuResult.TenkanSen), "Tenkan-sen", ResultType.Default, isReusable: true)
+            .AddResult(nameof(IchimokuResult.KijunSen), "Kijun-sen", ResultType.Default)
+            .AddResult(nameof(IchimokuResult.SenkouSpanA), "Senkou Span A", ResultType.Default)
+            .AddResult(nameof(IchimokuResult.SenkouSpanB), "Senkou Span B", ResultType.Default)
+            .AddResult(nameof(IchimokuResult.ChikouSpan), "Chikou Span", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/k-q/Kama/Kama.Catalog.cs
+++ b/src/Indicators/k-q/Kama/Kama.Catalog.cs
@@ -13,8 +13,8 @@ public static partial class Kama
             .AddParameter<int>("erPeriods", "ER Periods", defaultValue: 10, minimum: 2, maximum: 250)
             .AddParameter<int>("fastPeriods", "Fast Periods", defaultValue: 2, minimum: 1, maximum: 50)
             .AddParameter<int>("slowPeriods", "Slow Periods", defaultValue: 30, minimum: 1, maximum: 250)
-            .AddResult("Er", "ER", ResultType.Default)
-            .AddResult("Kama", "KAMA", ResultType.Default, isReusable: true)
+            .AddResult(nameof(KamaResult.Er), "ER", ResultType.Default)
+            .AddResult(nameof(KamaResult.Kama), "KAMA", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/k-q/Keltner/Keltner.Catalog.cs
+++ b/src/Indicators/k-q/Keltner/Keltner.Catalog.cs
@@ -13,10 +13,10 @@ public static partial class Keltner
             .AddParameter<int>("emaPeriods", "EMA Periods", defaultValue: 20, minimum: 2, maximum: 250)
             .AddParameter<double>("multiplier", "Multiplier", defaultValue: 2.0, minimum: 0.01, maximum: 10.0)
             .AddParameter<int>("atrPeriods", "ATR Periods", defaultValue: 10, minimum: 2, maximum: 250)
-            .AddResult("UpperBand", "Upper Band", ResultType.Default)
-            .AddResult("Centerline", "Centerline", ResultType.Default, isReusable: true)
-            .AddResult("LowerBand", "Lower Band", ResultType.Default)
-            .AddResult("Width", "Width", ResultType.Default)
+            .AddResult(nameof(KeltnerResult.UpperBand), "Upper Band", ResultType.Default)
+            .AddResult(nameof(KeltnerResult.Centerline), "Centerline", ResultType.Default, isReusable: true)
+            .AddResult(nameof(KeltnerResult.LowerBand), "Lower Band", ResultType.Default)
+            .AddResult(nameof(KeltnerResult.Width), "Width", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/k-q/Kvo/Kvo.Catalog.cs
+++ b/src/Indicators/k-q/Kvo/Kvo.Catalog.cs
@@ -13,8 +13,8 @@ public static partial class Kvo
             .AddParameter<int>("fastPeriods", "Fast Periods", defaultValue: 34, minimum: 3, maximum: 200)
             .AddParameter<int>("slowPeriods", "Slow Periods", defaultValue: 55, minimum: 4, maximum: 250)
             .AddParameter<int>("signalPeriods", "Signal Periods", defaultValue: 13, minimum: 1, maximum: 50)
-            .AddResult("Oscillator", "Oscillator", ResultType.Default, isReusable: true)
-            .AddResult("Signal", "Signal", ResultType.Default)
+            .AddResult(nameof(KvoResult.Oscillator), "Oscillator", ResultType.Default, isReusable: true)
+            .AddResult(nameof(KvoResult.Signal), "Signal", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/k-q/MaEnvelopes/MaEnvelopes.Catalog.cs
+++ b/src/Indicators/k-q/MaEnvelopes/MaEnvelopes.Catalog.cs
@@ -13,9 +13,9 @@ public static partial class MaEnvelopes
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", defaultValue: 20, minimum: 1, maximum: 250)
             .AddParameter<double>("percentOffset", "Percent Offset", defaultValue: 2.5, minimum: 0.1, maximum: 10.0)
             .AddEnumParameter<MaType>("movingAverageType", "Moving Average Type", defaultValue: MaType.SMA) // MaType.SMA corresponds to 7 from JSON
-            .AddResult("Centerline", "Centerline", ResultType.Default, isReusable: true)
-            .AddResult("UpperEnvelope", "Upper Envelope", ResultType.Default)
-            .AddResult("LowerEnvelope", "Lower Envelope", ResultType.Default)
+            .AddResult(nameof(MaEnvelopeResult.Centerline), "Centerline", ResultType.Default, isReusable: true)
+            .AddResult(nameof(MaEnvelopeResult.UpperEnvelope), "Upper Envelope", ResultType.Default)
+            .AddResult(nameof(MaEnvelopeResult.LowerEnvelope), "Lower Envelope", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/k-q/Macd/Macd.Catalog.cs
+++ b/src/Indicators/k-q/Macd/Macd.Catalog.cs
@@ -13,9 +13,9 @@ public static partial class Macd
             .AddParameter<int>("fastPeriods", "Fast Periods", description: "Number of periods for the fast EMA", isRequired: false, defaultValue: 12, minimum: 1, maximum: 200)
             .AddParameter<int>("slowPeriods", "Slow Periods", description: "Number of periods for the slow EMA", isRequired: false, defaultValue: 26, minimum: 1, maximum: 250)
             .AddParameter<int>("signalPeriods", "Signal Periods", description: "Number of periods for the signal line", isRequired: false, defaultValue: 9, minimum: 1, maximum: 50)
-            .AddResult("Macd", "MACD", ResultType.Default, isReusable: true)
-            .AddResult("Signal", "Signal", ResultType.Default)
-            .AddResult("Histogram", "Histogram", ResultType.Bar)
+            .AddResult(nameof(MacdResult.Macd), "MACD", ResultType.Default, isReusable: true)
+            .AddResult(nameof(MacdResult.Signal), "Signal", ResultType.Default)
+            .AddResult(nameof(MacdResult.Histogram), "Histogram", ResultType.Bar)
             .Build();
 
     /// <summary>

--- a/src/Indicators/k-q/Mama/Mama.Catalog.cs
+++ b/src/Indicators/k-q/Mama/Mama.Catalog.cs
@@ -12,8 +12,8 @@ public static partial class Mama
             .WithCategory(Category.MovingAverage)
             .AddParameter<double>("fastLimit", "Fast Limit", defaultValue: 0.5, minimum: 0.01, maximum: 0.99)
             .AddParameter<double>("slowLimit", "Slow Limit", defaultValue: 0.05, minimum: 0.01, maximum: 0.99)
-            .AddResult("Mama", "MAMA", ResultType.Default, isReusable: true)
-            .AddResult("Fama", "FAMA", ResultType.Default)
+            .AddResult(nameof(MamaResult.Mama), "MAMA", ResultType.Default, isReusable: true)
+            .AddResult(nameof(MamaResult.Fama), "FAMA", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/k-q/Marubozu/Marubozu.Catalog.cs
+++ b/src/Indicators/k-q/Marubozu/Marubozu.Catalog.cs
@@ -11,7 +11,7 @@ public static partial class Marubozu
             .WithId("MARUBOZU")
             .WithCategory(Category.CandlestickPattern)
             .AddParameter<double>("minBodyPercent", "Min Body Percent %", defaultValue: 95.0, minimum: 80.0, maximum: 100.0) // Default from C# method signature
-            .AddResult("Match", "Match", ResultType.Default, isReusable: true) // Based on CandleResult.Match
+            .AddResult(nameof(CandleResult.Match), "Match", ResultType.Default, isReusable: true) // Based on CandleResult.Match
             .Build();
 
     /// <summary>

--- a/src/Indicators/k-q/Mfi/Mfi.Catalog.cs
+++ b/src/Indicators/k-q/Mfi/Mfi.Catalog.cs
@@ -11,7 +11,7 @@ public static partial class Mfi
             .WithId("MFI")
             .WithCategory(Category.VolumeBased)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", description: "Number of periods for the MFI calculation", defaultValue: 14, minimum: 1, maximum: 250)
-            .AddResult("Mfi", "MFI", ResultType.Default, isReusable: true)
+            .AddResult(nameof(MfiResult.Mfi), "MFI", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/k-q/Obv/Obv.Catalog.cs
+++ b/src/Indicators/k-q/Obv/Obv.Catalog.cs
@@ -10,7 +10,7 @@ public static partial class Obv
             .WithName("On-Balance Volume")
             .WithId("OBV")
             .WithCategory(Category.VolumeBased)
-            .AddResult("Obv", "OBV", ResultType.Default, isReusable: true)
+            .AddResult(nameof(ObvResult.Obv), "OBV", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/k-q/ParabolicSar/ParabolicSar.Catalog.cs
+++ b/src/Indicators/k-q/ParabolicSar/ParabolicSar.Catalog.cs
@@ -12,8 +12,8 @@ public static partial class ParabolicSar
             .WithCategory(Category.StopAndReverse)
             .AddParameter<double>("accelerationStep", "Acceleration Step", description: "Acceleration step for the Parabolic SAR calculation", isRequired: false, defaultValue: 0.02, minimum: 0.01, maximum: 0.1)
             .AddParameter<double>("maxAccelerationFactor", "Max Acceleration Factor", description: "Maximum acceleration factor for the Parabolic SAR calculation", isRequired: false, defaultValue: 0.2, minimum: 0.1, maximum: 1.0)
-            .AddResult("Sar", "Parabolic SAR", ResultType.Default, isReusable: true)
-            .AddResult("IsReversal", "Is Reversal", ResultType.Default)
+            .AddResult(nameof(ParabolicSarResult.Sar), "Parabolic SAR", ResultType.Default, isReusable: true)
+            .AddResult(nameof(ParabolicSarResult.IsReversal), "Is Reversal", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/k-q/PivotPoints/PivotPoints.Catalog.cs
+++ b/src/Indicators/k-q/PivotPoints/PivotPoints.Catalog.cs
@@ -12,13 +12,13 @@ public static partial class PivotPoints
             .WithCategory(Category.PriceTrend)
             .AddEnumParameter<BarInterval>("windowSize", "Window Size", description: "Size of the window for pivot calculation", isRequired: false, defaultValue: BarInterval.Month)
             .AddEnumParameter<PivotPointType>("pointType", "Point Type", description: "Type of pivot points to calculate", isRequired: false, defaultValue: PivotPointType.Standard)
-            .AddResult("R3", "Resistance 3", ResultType.Default)
-            .AddResult("R2", "Resistance 2", ResultType.Default)
-            .AddResult("R1", "Resistance 1", ResultType.Default)
-            .AddResult("PP", "Pivot Point", ResultType.Default, isReusable: true)
-            .AddResult("S1", "Support 1", ResultType.Default)
-            .AddResult("S2", "Support 2", ResultType.Default)
-            .AddResult("S3", "Support 3", ResultType.Default)
+            .AddResult(nameof(PivotPointsResult.R3), "Resistance 3", ResultType.Default)
+            .AddResult(nameof(PivotPointsResult.R2), "Resistance 2", ResultType.Default)
+            .AddResult(nameof(PivotPointsResult.R1), "Resistance 1", ResultType.Default)
+            .AddResult(nameof(PivotPointsResult.PP), "Pivot Point", ResultType.Default, isReusable: true)
+            .AddResult(nameof(PivotPointsResult.S1), "Support 1", ResultType.Default)
+            .AddResult(nameof(PivotPointsResult.S2), "Support 2", ResultType.Default)
+            .AddResult(nameof(PivotPointsResult.S3), "Support 3", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/k-q/Pivots/Pivots.Catalog.cs
+++ b/src/Indicators/k-q/Pivots/Pivots.Catalog.cs
@@ -14,12 +14,12 @@ public static partial class Pivots
             .AddParameter<int>("rightSpan", "Right Span", description: "Number of periods to the right for pivot identification", isRequired: false, defaultValue: 2, minimum: 2, maximum: 100)
             .AddParameter<int>("maxTrendPeriods", "Max Trend Periods", description: "Maximum number of periods to track trend", isRequired: false, defaultValue: 20, minimum: 2, maximum: 1000)
             .AddEnumParameter<EndType>("endType", "End Type", description: "Type of price to use for pivot calculation", isRequired: false, defaultValue: EndType.HighLow)
-            .AddResult("HighPoint", "High Point", ResultType.Default, isReusable: false)
-            .AddResult("LowPoint", "Low Point", ResultType.Default, isReusable: false)
-            .AddResult("HighLine", "High Line", ResultType.Default, isReusable: false)
-            .AddResult("LowLine", "Low Line", ResultType.Default, isReusable: false)
-            .AddResult("HighTrend", "High Trend", ResultType.Default, isReusable: false)
-            .AddResult("LowTrend", "Low Trend", ResultType.Default, isReusable: false)
+            .AddResult(nameof(PivotsResult.HighPoint), "High Point", ResultType.Default, isReusable: false)
+            .AddResult(nameof(PivotsResult.LowPoint), "Low Point", ResultType.Default, isReusable: false)
+            .AddResult(nameof(PivotsResult.HighLine), "High Line", ResultType.Default, isReusable: false)
+            .AddResult(nameof(PivotsResult.LowLine), "Low Line", ResultType.Default, isReusable: false)
+            .AddResult(nameof(PivotsResult.HighTrend), "High Trend", ResultType.Default, isReusable: false)
+            .AddResult(nameof(PivotsResult.LowTrend), "Low Trend", ResultType.Default, isReusable: false)
             .Build();
 
     /// <summary>

--- a/src/Indicators/k-q/Pmo/Pmo.Catalog.cs
+++ b/src/Indicators/k-q/Pmo/Pmo.Catalog.cs
@@ -13,8 +13,8 @@ public static partial class Pmo
             .AddParameter<int>("timePeriods", "Time Periods", description: "Number of periods for the time frame", isRequired: false, defaultValue: 35, minimum: 1, maximum: 250)
             .AddParameter<int>("smoothPeriods", "Smoothing Periods", description: "Number of periods for smoothing", isRequired: false, defaultValue: 20, minimum: 1, maximum: 100)
             .AddParameter<int>("signalPeriods", "Signal Periods", description: "Number of periods for the signal line", isRequired: false, defaultValue: 10, minimum: 1, maximum: 50)
-            .AddResult("Pmo", "PMO", ResultType.Default, isReusable: true)
-            .AddResult("Signal", "Signal", ResultType.Default)
+            .AddResult(nameof(PmoResult.Pmo), "PMO", ResultType.Default, isReusable: true)
+            .AddResult(nameof(PmoResult.Signal), "Signal", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/k-q/Prs/Prs.Catalog.cs
+++ b/src/Indicators/k-q/Prs/Prs.Catalog.cs
@@ -13,8 +13,8 @@ public static partial class Prs
             .AddSeriesParameter("sourceEval", "Source Evaluated", description: "Source data to be evaluated")
             .AddSeriesParameter("sourceBase", "Source Base", description: "Base source data for comparison")
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", description: "Number of periods for the PRS calculation", isRequired: false, defaultValue: 20, minimum: 1, maximum: 250)
-            .AddResult("Prs", "PRS", ResultType.Default, isReusable: true)
-            .AddResult("PrsPercent", "PRS %", ResultType.Default)
+            .AddResult(nameof(PrsResult.Prs), "PRS", ResultType.Default, isReusable: true)
+            .AddResult(nameof(PrsResult.PrsPercent), "PRS %", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/k-q/Pvo/Pvo.Catalog.cs
+++ b/src/Indicators/k-q/Pvo/Pvo.Catalog.cs
@@ -13,9 +13,9 @@ public static partial class Pvo
             .AddParameter<int>("fastPeriods", "Fast Periods", description: "Number of periods for the fast EMA", isRequired: false, defaultValue: 12, minimum: 1, maximum: 100)
             .AddParameter<int>("slowPeriods", "Slow Periods", description: "Number of periods for the slow EMA", isRequired: false, defaultValue: 26, minimum: 1, maximum: 250)
             .AddParameter<int>("signalPeriods", "Signal Periods", description: "Number of periods for the signal line", isRequired: false, defaultValue: 9, minimum: 1, maximum: 50)
-            .AddResult("Pvo", "PVO", ResultType.Default, isReusable: true)
-            .AddResult("Signal", "Signal", ResultType.Default)
-            .AddResult("Histogram", "Histogram", ResultType.Default)
+            .AddResult(nameof(PvoResult.Pvo), "PVO", ResultType.Default, isReusable: true)
+            .AddResult(nameof(PvoResult.Signal), "Signal", ResultType.Default)
+            .AddResult(nameof(PvoResult.Histogram), "Histogram", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/r-s/Renko/Renko.Catalog.cs
+++ b/src/Indicators/r-s/Renko/Renko.Catalog.cs
@@ -12,12 +12,12 @@ public static partial class Renko
             .WithCategory(Category.PriceTransform)
             .AddParameter<decimal>("brickSize", "Brick Size", description: "The size of each Renko brick", isRequired: true, defaultValue: 1.0m, minimum: 0.001, maximum: 1000000.0)
             .AddEnumParameter<EndType>("endType", "End Type", description: "The price candle end type to use as the brick threshold", isRequired: false, defaultValue: EndType.Close)
-            .AddResult("Open", "Open", ResultType.Default)
-            .AddResult("High", "High", ResultType.Default)
-            .AddResult("Low", "Low", ResultType.Default)
-            .AddResult("Close", "Close", ResultType.Default, isReusable: true)
-            .AddResult("Volume", "Volume", ResultType.Default)
-            .AddResult("IsUp", "Is Up", ResultType.Default)
+            .AddResult(nameof(RenkoResult.Open), "Open", ResultType.Default)
+            .AddResult(nameof(RenkoResult.High), "High", ResultType.Default)
+            .AddResult(nameof(RenkoResult.Low), "Low", ResultType.Default)
+            .AddResult(nameof(RenkoResult.Close), "Close", ResultType.Default, isReusable: true)
+            .AddResult(nameof(RenkoResult.Volume), "Volume", ResultType.Default)
+            .AddResult(nameof(RenkoResult.IsUp), "Is Up", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/r-s/RenkoAtr/RenkoAtr.Catalog.cs
+++ b/src/Indicators/r-s/RenkoAtr/RenkoAtr.Catalog.cs
@@ -12,12 +12,12 @@ public static partial class RenkoAtr
             .WithCategory(Category.PriceTrend)
             .AddParameter<int>("atrPeriods", "ATR Periods", description: "Number of periods for the ATR calculation", isRequired: false, defaultValue: 14, minimum: 1, maximum: 100)
             .AddEnumParameter<EndType>("endType", "End Type", description: "Type of price to use for the calculation", isRequired: false, defaultValue: EndType.Close)
-            .AddResult("Open", "Open", ResultType.Default)
-            .AddResult("High", "High", ResultType.Default)
-            .AddResult("Low", "Low", ResultType.Default)
-            .AddResult("Close", "Close", ResultType.Default, isReusable: true)
-            .AddResult("Volume", "Volume", ResultType.Default)
-            .AddResult("IsUp", "Is Up", ResultType.Default)
+            .AddResult(nameof(RenkoResult.Open), "Open", ResultType.Default)
+            .AddResult(nameof(RenkoResult.High), "High", ResultType.Default)
+            .AddResult(nameof(RenkoResult.Low), "Low", ResultType.Default)
+            .AddResult(nameof(RenkoResult.Close), "Close", ResultType.Default, isReusable: true)
+            .AddResult(nameof(RenkoResult.Volume), "Volume", ResultType.Default)
+            .AddResult(nameof(RenkoResult.IsUp), "Is Up", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/r-s/Roc/Roc.Catalog.cs
+++ b/src/Indicators/r-s/Roc/Roc.Catalog.cs
@@ -11,7 +11,7 @@ public static partial class Roc
             .WithId("ROC")
             .WithCategory(Category.Oscillator)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", description: "Number of periods for the ROC calculation", isRequired: false, defaultValue: 14, minimum: 1, maximum: 250)
-            .AddResult("Roc", "ROC", ResultType.Default, isReusable: true)
+            .AddResult(nameof(RocResult.Roc), "ROC", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/r-s/RocWb/RocWb.Catalog.cs
+++ b/src/Indicators/r-s/RocWb/RocWb.Catalog.cs
@@ -13,10 +13,10 @@ public static partial class RocWb
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", description: "Number of periods for the ROC calculation", isRequired: false, defaultValue: 20, minimum: 1, maximum: 250)
             .AddParameter<int>("emaPeriods", "EMA Periods", description: "Number of periods for the EMA calculation", isRequired: false, defaultValue: 5, minimum: 1, maximum: 100)
             .AddParameter<int>("stdDevPeriods", "Standard deviation Periods", description: "Number of periods for the standard deviation calculation", isRequired: false, defaultValue: 5, minimum: 1, maximum: 100)
-            .AddResult("Roc", "ROC", ResultType.Default, isReusable: true)
-            .AddResult("RocEma", "ROC EMA", ResultType.Default)
-            .AddResult("UpperBand", "Upper Band", ResultType.Default)
-            .AddResult("LowerBand", "Lower Band", ResultType.Default)
+            .AddResult(nameof(RocWbResult.Roc), "ROC", ResultType.Default, isReusable: true)
+            .AddResult(nameof(RocWbResult.RocEma), "ROC EMA", ResultType.Default)
+            .AddResult(nameof(RocWbResult.UpperBand), "Upper Band", ResultType.Default)
+            .AddResult(nameof(RocWbResult.LowerBand), "Lower Band", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/r-s/RollingPivots/RollingPivots.Catalog.cs
+++ b/src/Indicators/r-s/RollingPivots/RollingPivots.Catalog.cs
@@ -13,13 +13,13 @@ public static partial class RollingPivots
             .AddParameter<int>("windowPeriods", "Window Periods", description: "Number of periods for the rolling window", isRequired: false, defaultValue: 20, minimum: 1, maximum: 250)
             .AddParameter<int>("offsetPeriods", "Offset Periods", description: "Number of periods to offset the pivots", isRequired: false, defaultValue: 0, minimum: 0, maximum: 100)
             .AddEnumParameter<PivotPointType>("pointType", "Point Type", description: "Type of pivot points to calculate", isRequired: false, defaultValue: PivotPointType.Standard)
-            .AddResult("R3", "Resistance 3", ResultType.Default)
-            .AddResult("R2", "Resistance 2", ResultType.Default)
-            .AddResult("R1", "Resistance 1", ResultType.Default)
-            .AddResult("PP", "Pivot Point", ResultType.Default, isReusable: true)
-            .AddResult("S1", "Support 1", ResultType.Default)
-            .AddResult("S2", "Support 2", ResultType.Default)
-            .AddResult("S3", "Support 3", ResultType.Default)
+            .AddResult(nameof(RollingPivotsResult.R3), "Resistance 3", ResultType.Default)
+            .AddResult(nameof(RollingPivotsResult.R2), "Resistance 2", ResultType.Default)
+            .AddResult(nameof(RollingPivotsResult.R1), "Resistance 1", ResultType.Default)
+            .AddResult(nameof(RollingPivotsResult.PP), "Pivot Point", ResultType.Default, isReusable: true)
+            .AddResult(nameof(RollingPivotsResult.S1), "Support 1", ResultType.Default)
+            .AddResult(nameof(RollingPivotsResult.S2), "Support 2", ResultType.Default)
+            .AddResult(nameof(RollingPivotsResult.S3), "Support 3", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/r-s/Rsi/Rsi.Catalog.cs
+++ b/src/Indicators/r-s/Rsi/Rsi.Catalog.cs
@@ -11,7 +11,7 @@ public static partial class Rsi
             .WithId("RSI")
             .WithCategory(Category.Oscillator)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", description: "Number of periods for the RSI calculation", isRequired: false, defaultValue: 14, minimum: 1, maximum: 250)
-            .AddResult("Rsi", "RSI", ResultType.Default, isReusable: true)
+            .AddResult(nameof(RsiResult.Rsi), "RSI", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/r-s/Slope/Slope.Catalog.cs
+++ b/src/Indicators/r-s/Slope/Slope.Catalog.cs
@@ -11,11 +11,11 @@ public static partial class Slope
             .WithId("SLOPE")
             .WithCategory(Category.PriceCharacteristic)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", description: "Number of periods for the slope calculation", isRequired: false, defaultValue: 14, minimum: 2, maximum: 250)
-            .AddResult("Slope", "Slope", ResultType.Default, isReusable: true)
-            .AddResult("Intercept", "Intercept", ResultType.Default)
-            .AddResult("StdDev", "Standard deviation", ResultType.Default)
-            .AddResult("RSquared", "R-squared", ResultType.Default)
-            .AddResult("Line", "Line", ResultType.Default)
+            .AddResult(nameof(SlopeResult.Slope), "Slope", ResultType.Default, isReusable: true)
+            .AddResult(nameof(SlopeResult.Intercept), "Intercept", ResultType.Default)
+            .AddResult(nameof(SlopeResult.StdDev), "Standard deviation", ResultType.Default)
+            .AddResult(nameof(SlopeResult.RSquared), "R-squared", ResultType.Default)
+            .AddResult(nameof(SlopeResult.Line), "Line", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/r-s/Sma/Sma.Catalog.cs
+++ b/src/Indicators/r-s/Sma/Sma.Catalog.cs
@@ -11,7 +11,7 @@ public static partial class Sma
             .WithId("SMA")
             .WithCategory(Category.MovingAverage)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", description: "Number of periods for the SMA calculation", isRequired: true, defaultValue: 20, minimum: 1, maximum: 250)
-            .AddResult("Sma", "SMA", ResultType.Default, isReusable: true)
+            .AddResult(nameof(SmaResult.Sma), "SMA", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/r-s/SmaAnalysis/SmaAnalysis.Catalog.cs
+++ b/src/Indicators/r-s/SmaAnalysis/SmaAnalysis.Catalog.cs
@@ -11,10 +11,10 @@ public static partial class SmaAnalysis
             .WithId("SMA-ANALYSIS")
             .WithCategory(Category.PriceCharacteristic)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", description: "Number of periods for the SMA analysis", isRequired: true, defaultValue: 20, minimum: 1, maximum: 250)
-            .AddResult("Sma", "SMA", ResultType.Default, isReusable: true)
-            .AddResult("Mad", "Mean absolute deviation", ResultType.Default)
-            .AddResult("Mse", "Mean square error", ResultType.Default)
-            .AddResult("Mape", "Mean absolute percentage error", ResultType.Default)
+            .AddResult(nameof(SmaAnalysisResult.Sma), "SMA", ResultType.Default, isReusable: true)
+            .AddResult(nameof(SmaAnalysisResult.Mad), "Mean absolute deviation", ResultType.Default)
+            .AddResult(nameof(SmaAnalysisResult.Mse), "Mean square error", ResultType.Default)
+            .AddResult(nameof(SmaAnalysisResult.Mape), "Mean absolute percentage error", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/r-s/Smi/Smi.Catalog.cs
+++ b/src/Indicators/r-s/Smi/Smi.Catalog.cs
@@ -14,8 +14,8 @@ public static partial class Smi
             .AddParameter<int>("firstSmoothPeriods", "First Smooth Periods", description: "Number of periods for the first smoothing", isRequired: false, defaultValue: 25, minimum: 1, maximum: 300)
             .AddParameter<int>("secondSmoothPeriods", "Second Smooth Periods", description: "Number of periods for the second smoothing", isRequired: false, defaultValue: 2, minimum: 1, maximum: 50)
             .AddParameter<int>("signalPeriods", "Signal Periods", description: "Number of periods for the signal line", isRequired: false, defaultValue: 3, minimum: 1, maximum: 50)
-            .AddResult("Smi", "SMI", ResultType.Default, isReusable: true)
-            .AddResult("Signal", "Signal", ResultType.Default)
+            .AddResult(nameof(SmiResult.Smi), "SMI", ResultType.Default, isReusable: true)
+            .AddResult(nameof(SmiResult.Signal), "Signal", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/r-s/Smma/Smma.Catalog.cs
+++ b/src/Indicators/r-s/Smma/Smma.Catalog.cs
@@ -11,7 +11,7 @@ public static partial class Smma
             .WithId("SMMA")
             .WithCategory(Category.MovingAverage)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", description: "Number of periods for the SMMA calculation", isRequired: false, defaultValue: 20, minimum: 1, maximum: 250)
-            .AddResult("Smma", "SMMA", ResultType.Default, isReusable: true)
+            .AddResult(nameof(SmmaResult.Smma), "SMMA", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/r-s/StarcBands/StarcBands.Catalog.cs
+++ b/src/Indicators/r-s/StarcBands/StarcBands.Catalog.cs
@@ -13,9 +13,9 @@ public static partial class StarcBands
             .AddParameter<int>("smaPeriods", "SMA Periods", description: "Number of periods for the SMA calculation", isRequired: false, defaultValue: 5, minimum: 1, maximum: 50)
             .AddParameter<double>("multiplier", "Multiplier", description: "Multiplier for the ATR calculation", isRequired: false, defaultValue: 2.0, minimum: 1.0, maximum: 10.0)
             .AddParameter<int>("atrPeriods", "ATR Periods", description: "Number of periods for the ATR calculation", isRequired: false, defaultValue: 10, minimum: 1, maximum: 50)
-            .AddResult("UpperBand", "Upper Band", ResultType.Default)
-            .AddResult("Centerline", "Centerline", ResultType.Default, isReusable: true)
-            .AddResult("LowerBand", "Lower Band", ResultType.Default)
+            .AddResult(nameof(StarcBandsResult.UpperBand), "Upper Band", ResultType.Default)
+            .AddResult(nameof(StarcBandsResult.Centerline), "Centerline", ResultType.Default, isReusable: true)
+            .AddResult(nameof(StarcBandsResult.LowerBand), "Lower Band", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/r-s/Stc/Stc.Catalog.cs
+++ b/src/Indicators/r-s/Stc/Stc.Catalog.cs
@@ -13,7 +13,7 @@ public static partial class Stc
             .AddParameter<int>("cyclePeriods", "Cycle Periods", description: "Number of periods for the cycle calculation", isRequired: false, defaultValue: 10, minimum: 1, maximum: 250)
             .AddParameter<int>("fastPeriods", "Fast Periods", description: "Number of periods for the fast MA", isRequired: false, defaultValue: 23, minimum: 1, maximum: 250)
             .AddParameter<int>("slowPeriods", "Slow Periods", description: "Number of periods for the slow MA", isRequired: false, defaultValue: 50, minimum: 1, maximum: 250)
-            .AddResult("Stc", "STC", ResultType.Default, isReusable: true)
+            .AddResult(nameof(StcResult.Stc), "STC", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/r-s/StdDev/StdDev.Catalog.cs
+++ b/src/Indicators/r-s/StdDev/StdDev.Catalog.cs
@@ -11,7 +11,7 @@ public static partial class StdDev
             .WithId("STDEV")
             .WithCategory(Category.PriceCharacteristic)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", description: "Number of periods for the standard deviation calculation", isRequired: false, defaultValue: 14, minimum: 1, maximum: 250)
-            .AddResult("StdDev", "Standard deviation", ResultType.Default, isReusable: true)
+            .AddResult(nameof(StdDevResult.StdDev), "Standard deviation", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/r-s/StdDevChannels/StdDevChannels.Catalog.cs
+++ b/src/Indicators/r-s/StdDevChannels/StdDevChannels.Catalog.cs
@@ -12,9 +12,9 @@ public static partial class StdDevChannels
             .WithCategory(Category.PriceChannel)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", description: "Number of periods for the standard deviation calculation", isRequired: false, defaultValue: 20, minimum: 1, maximum: 250)
             .AddParameter<double>("stdDeviations", "Standard Deviations", description: "Number of standard deviations for the channels", isRequired: false, defaultValue: 2.0, minimum: 0.01, maximum: 10.0)
-            .AddResult("UpperChannel", "Upper Channel", ResultType.Default)
-            .AddResult("Centerline", "Centerline", ResultType.Default, isReusable: true)
-            .AddResult("LowerChannel", "Lower Channel", ResultType.Default)
+            .AddResult(nameof(StdDevChannelsResult.UpperChannel), "Upper Channel", ResultType.Default)
+            .AddResult(nameof(StdDevChannelsResult.Centerline), "Centerline", ResultType.Default, isReusable: true)
+            .AddResult(nameof(StdDevChannelsResult.LowerChannel), "Lower Channel", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/r-s/Stoch/Stoch.Catalog.cs
+++ b/src/Indicators/r-s/Stoch/Stoch.Catalog.cs
@@ -13,8 +13,8 @@ public static partial class Stoch
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", description: "Number of periods for the stochastic calculation", isRequired: false, defaultValue: 14, minimum: 1, maximum: 250)
             .AddParameter<int>("signalPeriods", "Signal Periods", description: "Number of periods for the signal line", isRequired: false, defaultValue: 3, minimum: 1, maximum: 250)
             .AddParameter<int>("smoothPeriods", "Smooth Periods", description: "Number of periods for smoothing", isRequired: false, defaultValue: 3, minimum: 1, maximum: 50)
-            .AddResult("Oscillator", "%K", ResultType.Default, isReusable: true)
-            .AddResult("Signal", "%D", ResultType.Default)
+            .AddResult(nameof(StochResult.Oscillator), "%K", ResultType.Default, isReusable: true)
+            .AddResult(nameof(StochResult.Signal), "%D", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/r-s/StochRsi/StochRsi.Catalog.cs
+++ b/src/Indicators/r-s/StochRsi/StochRsi.Catalog.cs
@@ -14,8 +14,8 @@ public static partial class StochRsi
             .AddParameter<int>("stochPeriods", "Stochastic Periods", description: "Number of periods for the Stochastic calculation", isRequired: false, defaultValue: 14, minimum: 1, maximum: 250)
             .AddParameter<int>("signalPeriods", "Signal Periods", description: "Number of periods for the signal line", isRequired: false, defaultValue: 3, minimum: 1, maximum: 50)
             .AddParameter<int>("smoothPeriods", "Smooth Periods", description: "Number of periods for smoothing", isRequired: false, defaultValue: 1, minimum: 1, maximum: 50)
-            .AddResult("StochRsi", "%K", ResultType.Default, isReusable: true)
-            .AddResult("Signal", "%D", ResultType.Default)
+            .AddResult(nameof(StochRsiResult.StochRsi), "%K", ResultType.Default, isReusable: true)
+            .AddResult(nameof(StochRsiResult.Signal), "%D", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/r-s/SuperTrend/SuperTrend.Catalog.cs
+++ b/src/Indicators/r-s/SuperTrend/SuperTrend.Catalog.cs
@@ -12,9 +12,9 @@ public static partial class SuperTrend
             .WithCategory(Category.PriceTrend)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", description: "Number of periods for the SuperTrend calculation", isRequired: false, defaultValue: 10, minimum: 1, maximum: 50)
             .AddParameter<double>("multiplier", "Multiplier", description: "Multiplier for the ATR calculation", isRequired: false, defaultValue: 3.0, minimum: 0.1, maximum: 10.0)
-            .AddResult("SuperTrend", "SuperTrend", ResultType.Default, isReusable: false)
-            .AddResult("UpperBand", "Upper Band", ResultType.Default)
-            .AddResult("LowerBand", "Lower Band", ResultType.Default)
+            .AddResult(nameof(SuperTrendResult.SuperTrend), "SuperTrend", ResultType.Default, isReusable: false)
+            .AddResult(nameof(SuperTrendResult.UpperBand), "Upper Band", ResultType.Default)
+            .AddResult(nameof(SuperTrendResult.LowerBand), "Lower Band", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/t-z/T3/T3.Catalog.cs
+++ b/src/Indicators/t-z/T3/T3.Catalog.cs
@@ -12,7 +12,7 @@ public static partial class T3
             .WithCategory(Category.MovingAverage)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", description: "Number of periods for the T3 calculation", isRequired: false, defaultValue: 5, minimum: 1, maximum: 250)
             .AddParameter<double>("volumeFactor", "Volume Factor", description: "Volume factor for the T3 calculation", isRequired: false, defaultValue: 0.7, minimum: 0.0, maximum: 1.0)
-            .AddResult("T3", "T3", ResultType.Default, isReusable: true)
+            .AddResult(nameof(T3Result.T3), "T3", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/t-z/Tema/Tema.Catalog.cs
+++ b/src/Indicators/t-z/Tema/Tema.Catalog.cs
@@ -11,7 +11,7 @@ public static partial class Tema
             .WithId("TEMA")
             .WithCategory(Category.MovingAverage)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", description: "Number of periods for the TEMA calculation", isRequired: false, defaultValue: 20, minimum: 2, maximum: 250)
-            .AddResult("Tema", "TEMA", ResultType.Default, isReusable: true)
+            .AddResult(nameof(TemaResult.Tema), "TEMA", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/t-z/Tr/Tr.Catalog.cs
+++ b/src/Indicators/t-z/Tr/Tr.Catalog.cs
@@ -10,7 +10,7 @@ public static partial class Tr
             .WithName("True Range")
             .WithId("TR")
             .WithCategory(Category.PriceCharacteristic)
-            .AddResult("Tr", "True Range", ResultType.Default, isReusable: true)
+            .AddResult(nameof(TrResult.Tr), "True Range", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/t-z/Trix/Trix.Catalog.cs
+++ b/src/Indicators/t-z/Trix/Trix.Catalog.cs
@@ -11,7 +11,7 @@ public static partial class Trix
             .WithId("TRIX")
             .WithCategory(Category.Oscillator)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", description: "Number of periods for the TRIX calculation", isRequired: false, defaultValue: 14, minimum: 1, maximum: 250)
-            .AddResult("Trix", "TRIX", ResultType.Default, isReusable: true)
+            .AddResult(nameof(TrixResult.Trix), "TRIX", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/t-z/Tsi/Tsi.Catalog.cs
+++ b/src/Indicators/t-z/Tsi/Tsi.Catalog.cs
@@ -13,8 +13,8 @@ public static partial class Tsi
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", description: "Number of periods for the TSI calculation", isRequired: false, defaultValue: 25, minimum: 1, maximum: 250)
             .AddParameter<int>("smoothPeriods", "Smooth Periods", description: "Number of periods for smoothing", isRequired: false, defaultValue: 13, minimum: 1, maximum: 250)
             .AddParameter<int>("signalPeriods", "Signal Periods", description: "Number of periods for the signal line", isRequired: false, defaultValue: 7, minimum: 1, maximum: 50)
-            .AddResult("Tsi", "TSI", ResultType.Default, isReusable: true)
-            .AddResult("Signal", "Signal", ResultType.Default)
+            .AddResult(nameof(TsiResult.Tsi), "TSI", ResultType.Default, isReusable: true)
+            .AddResult(nameof(TsiResult.Signal), "Signal", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/t-z/UlcerIndex/UlcerIndex.Catalog.cs
+++ b/src/Indicators/t-z/UlcerIndex/UlcerIndex.Catalog.cs
@@ -11,7 +11,7 @@ public static partial class UlcerIndex
             .WithId("ULCER")
             .WithCategory(Category.PriceCharacteristic)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", description: "Number of periods for the Ulcer Index calculation", isRequired: false, defaultValue: 14, minimum: 1, maximum: 250)
-            .AddResult("UlcerIndex", "Ulcer Index", ResultType.Default, isReusable: true)
+            .AddResult(nameof(UlcerIndexResult.UlcerIndex), "Ulcer Index", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/t-z/Ultimate/Ultimate.Catalog.cs
+++ b/src/Indicators/t-z/Ultimate/Ultimate.Catalog.cs
@@ -13,7 +13,7 @@ public static partial class Ultimate
             .AddParameter<int>("shortPeriods", "Short Periods", description: "Number of short periods for the Ultimate Oscillator calculation", isRequired: false, defaultValue: 7, minimum: 1, maximum: 50)
             .AddParameter<int>("middlePeriods", "Middle Periods", description: "Number of middle periods for the Ultimate Oscillator calculation", isRequired: false, defaultValue: 14, minimum: 1, maximum: 50)
             .AddParameter<int>("longPeriods", "Long Periods", description: "Number of long periods for the Ultimate Oscillator calculation", isRequired: false, defaultValue: 28, minimum: 1, maximum: 250)
-            .AddResult("Ultimate", "Ultimate Oscillator", ResultType.Default, isReusable: true)
+            .AddResult(nameof(UltimateResult.Ultimate), "Ultimate Oscillator", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/t-z/VolatilityStop/VolatilityStop.Catalog.cs
+++ b/src/Indicators/t-z/VolatilityStop/VolatilityStop.Catalog.cs
@@ -12,8 +12,8 @@ public static partial class VolatilityStop
             .WithCategory(Category.StopAndReverse)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", description: "Number of periods for the volatility calculation", isRequired: false, defaultValue: 7, minimum: 1, maximum: 50)
             .AddParameter<double>("multiplier", "Multiplier", description: "Multiplier for the volatility calculation", isRequired: false, defaultValue: 3.0, minimum: 0.1, maximum: 10.0)
-            .AddResult("Sar", "Stop and Reverse", ResultType.Default, isReusable: true)
-            .AddResult("IsStop", "Is Stop", ResultType.Default)
+            .AddResult(nameof(VolatilityStopResult.Sar), "Stop and Reverse", ResultType.Default, isReusable: true)
+            .AddResult(nameof(VolatilityStopResult.IsStop), "Is Stop", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/t-z/Vortex/Vortex.Catalog.cs
+++ b/src/Indicators/t-z/Vortex/Vortex.Catalog.cs
@@ -11,8 +11,8 @@ public static partial class Vortex
             .WithId("VORTEX")
             .WithCategory(Category.PriceTrend)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", description: "Number of periods for the Vortex calculation", isRequired: false, defaultValue: 14, minimum: 2, maximum: 100)
-            .AddResult("Pvi", "VI+", ResultType.Default, isReusable: true)
-            .AddResult("Nvi", "VI-", ResultType.Default)
+            .AddResult(nameof(VortexResult.Pvi), "VI+", ResultType.Default, isReusable: true)
+            .AddResult(nameof(VortexResult.Nvi), "VI-", ResultType.Default)
             .Build();
 
     /// <summary>

--- a/src/Indicators/t-z/Vwap/Vwap.Catalog.cs
+++ b/src/Indicators/t-z/Vwap/Vwap.Catalog.cs
@@ -11,7 +11,7 @@ public static partial class Vwap
             .WithId("VWAP")
             .WithCategory(Category.PriceChannel)
             .AddDateParameter("startDate", "Start Date", description: "Starting date for VWAP calculation", isRequired: false)
-            .AddResult("Vwap", "VWAP", ResultType.Default, isReusable: true)
+            .AddResult(nameof(VwapResult.Vwap), "VWAP", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/t-z/Vwma/Vwma.Catalog.cs
+++ b/src/Indicators/t-z/Vwma/Vwma.Catalog.cs
@@ -11,7 +11,7 @@ public static partial class Vwma
             .WithId("VWMA")
             .WithCategory(Category.MovingAverage)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", description: "Number of periods for the VWMA calculation", isRequired: false, defaultValue: 14, minimum: 1, maximum: 250)
-            .AddResult("Vwma", "VWMA", ResultType.Default, isReusable: true)
+            .AddResult(nameof(VwmaResult.Vwma), "VWMA", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/t-z/WilliamsR/WilliamsR.Catalog.cs
+++ b/src/Indicators/t-z/WilliamsR/WilliamsR.Catalog.cs
@@ -11,7 +11,7 @@ public static partial class WilliamsR
             .WithId("WILLR")
             .WithCategory(Category.Oscillator)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", description: "Number of periods for the Williams %R calculation", isRequired: false, defaultValue: 14, minimum: 1, maximum: 250)
-            .AddResult("WilliamsR", "Williams %R", ResultType.Default, isReusable: true)
+            .AddResult(nameof(WilliamsResult.WilliamsR), "Williams %R", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/t-z/Wma/Wma.Catalog.cs
+++ b/src/Indicators/t-z/Wma/Wma.Catalog.cs
@@ -11,7 +11,7 @@ public static partial class Wma
             .WithId("WMA")
             .WithCategory(Category.MovingAverage)
             .AddParameter<int>("lookbackPeriods", "Lookback Periods", description: "Number of periods for the WMA calculation", isRequired: true, defaultValue: 14, minimum: 1, maximum: 250)
-            .AddResult("Wma", "WMA", ResultType.Default, isReusable: true)
+            .AddResult(nameof(WmaResult.Wma), "WMA", ResultType.Default, isReusable: true)
             .Build();
 
     /// <summary>

--- a/src/Indicators/t-z/ZigZag/ZigZag.Catalog.cs
+++ b/src/Indicators/t-z/ZigZag/ZigZag.Catalog.cs
@@ -12,10 +12,10 @@ public static partial class ZigZag
             .WithCategory(Category.PriceTransform)
             .AddEnumParameter<EndType>("endType", "End Type", description: "Type of price to use for the calculation", isRequired: false, defaultValue: EndType.Close)
             .AddParameter<decimal>("percentChange", "Percent Change", description: "Minimum percent change required for a new direction", isRequired: false, defaultValue: 5.0m, minimum: 1.0, maximum: 200.0)
-            .AddResult("ZigZag", "Zig Zag", ResultType.Default, isReusable: true)
-            .AddResult("PointType", "Point Type", ResultType.Default)
-            .AddResult("RetraceHigh", "Retrace High", ResultType.Default)
-            .AddResult("RetraceLow", "Retrace Low", ResultType.Default)
+            .AddResult(nameof(ZigZagResult.ZigZag), "Zig Zag", ResultType.Default, isReusable: true)
+            .AddResult(nameof(ZigZagResult.PointType), "Point Type", ResultType.Default)
+            .AddResult(nameof(ZigZagResult.RetraceHigh), "Retrace High", ResultType.Default)
+            .AddResult(nameof(ZigZagResult.RetraceLow), "Retrace Low", ResultType.Default)
             .Build();
 
     /// <summary>


### PR DESCRIPTION
Fixes #2194

## Problem

Catalog `DataName` values were string literals that had to match a property on the indicator's result record. Nothing tied them together, so a renamed or removed property left the catalog advertising a field that could never be populated — the defect class behind `PRS.Sma` and `VWAP.UpperBand` (#2187). `Catalog.Binding.Tests` (#2189) made that drift detectable at test time; this makes it impossible at compile time.

## Change

All **214 `AddResult` sites across 85 catalog files** convert from string literals to `nameof(TResult.Property)`:

```csharp
.AddResult(nameof(EmaResult.Ema), "EMA", ResultType.Default, isReusable: true)
```

Each `TResult` was derived from the listing's own runtime `ResultRecordType` — not filename convention — so the type named is the one the bound method actually returns (`BARPART` → `TimeValue`, candle patterns → `CandleResult`, `WILLR` → `WilliamsResult`, and so on). `displayName` stays a literal; it is a human label, not a member name. The `indicator-catalog` skill, the builder's XML doc, and the catalog README now teach the `nameof` form (the README example also named a builder class that does not exist — fixed).

## Zero wire effect — verified byte-for-byte

Every `DataName` already matched its property name exactly (ordinal), so `nameof` produces the identical string at all 214 sites. `Catalog.Get().ToJson()` is **byte-identical** before and after — same 288,354 bytes, same SHA-256 (`2ca9aef4…`) — re-verified against current `main` (`54118590`) after rebase. Nothing here belongs to a breaking wave; this is a refactor with no observable output change.

## Proof the guarantee moved, with a control

Renaming `EmaResult.Ema` → `EmaValue`:

| | errors from `Ema.Catalog.cs` |
|---|---|
| after this change | `CS0117: 'EmaResult' does not contain a definition for 'Ema'` — net10.0, net9.0, net8.0 |
| before (main) | **0** — the stale literal compiled fine |

## What the runtime test still covers

`Catalog.Binding.Tests` is not redundant afterward: `nameof` cannot reach a method's parameter list, so `ParameterName` keeps its runtime check — the more damaging half, since a stale parameter name silently substitutes a default. The test also catches a listing bound to a real method of the wrong style, and non-contiguous parameter order.

The one site `nameof` cannot reach — `CatalogListingBuilder.AddPriceHlcResult`, which hardcodes `"High"/"Low"/"Close"` with no result type in scope — has no catalog callers (verified; only a builder unit test uses it) and is left as-is.

## Review provenance

Self-review lane independently rebuilt the verification with its own reflection harness: all 214 sites parsed and compared against each listing's runtime `ResultRecordType` — zero wrong-but-compiling types; multiset equality of removed/added strings confirmed byte-identity by construction. Verdict 0 critical, 1 non-critical (the README example, fixed above).

```
Build:       0 Warning(s), 0 Error(s)   (--no-incremental; incl. Roslynator.Analyzers 5.0.0 post-rebase)
Unit:        Failed: 0, Passed: 2523, Skipped: 12
PublicApi:   Failed: 0, Passed: 76
Integration: Failed: 0, Passed: 4, Skipped: 1
markdownlint-cli2: 0 issues in 183 files
dotnet format --severity info: clean
```

Diff shape: 85 catalog files at exactly one changed token per `AddResult` line (214 insertions / 214 deletions), plus three doc files.
