### PR TITLE
feat: Reach shorter indicator overloads from the catalog

### DIFF
--- a/.agents/skills/indicator-catalog/SKILL.md
+++ b/.agents/skills/indicator-catalog/SKILL.md
@@ -78,6 +78,7 @@ public static partial class Ema
 - `minimum` and `maximum` required for all numeric parameters
 - `parameterName` must match the bound method's parameter name exactly — a mismatch makes a catalog-bound caller silently receive the default instead of the value it supplied
 - Declare parameters as an unbroken run in signature order, skipping none in the middle; `ListingExecutor` binds them positionally and picks an overload by argument count
+- `isRequired: false` must mean omitting the argument yields `defaultValue` — so use it only when the parameter has a C# default equal to `defaultValue`, or when the listing declares no `defaultValue` at all and promises nothing (VWAP `startDate`). When the argument can only be dropped by selecting a shorter overload that behaves differently while a `defaultValue` is advertised — `ToPrs(sourceEval, sourceBase)` computes no `PrsPercent` — use `isRequired: true`, and reach the shorter form with `WithoutParam(name)` at execution time
 
 ## Result patterns
 
@@ -135,6 +136,7 @@ listings.Add(Beta.SeriesListing);
 - Multiple `isReusable: true` results per indicator
 - A `dataName` as a string literal where `nameof` can reach the member
 - A `parameterName` that names a member the library does not have
+- `isRequired: false` with a `defaultValue` the C# signature does not apply when the argument is omitted
 
 ## Testing
 

--- a/docs/utilities/catalog.md
+++ b/docs/utilities/catalog.md
@@ -79,7 +79,7 @@ Each `IndicatorListing` describes one indicator-and-style combination. This is t
 | `ParameterName` | `string` | Method parameter name (use this with `WithParamValue`) |
 | `DataType` | `string` | Parameter type name |
 | `Description` | `string?` | Optional description |
-| `IsRequired` | `bool` | Whether the parameter must be supplied |
+| `IsRequired` | `bool` | Whether the caller must supply the parameter. `false` means omitting it yields `DefaultValue` |
 | `DefaultValue` | `object?` | Default value, if any |
 | `Minimum` / `Maximum` | `double?` | Recommended bounds, if any |
 | `EnumOptions` | `Dictionary<int, string>?` | Allowed values for enum parameters (`null` otherwise) |
@@ -155,7 +155,32 @@ IReadOnlyList<EmaResult> emaWithParams = indicatorListing
   .Execute<EmaResult>();
 ```
 
-The fluent `ListingExecutionBuilder` supports `WithParamValue(name, value)`, `WithParams(dictionary)`, `FromSource(bars)`, `FromSource(series, parameterName?)` for chaining off another indicator's results, and `Execute<TResult>()`. Parameter values are type-checked against the listing's `IndicatorParam` metadata.
+The fluent `ListingExecutionBuilder` supports `WithParamValue(name, value)`, `WithParams(dictionary)`, `WithoutParam(name)`, `FromSource(bars)`, `FromSource(series, parameterName?)` for chaining off another indicator's results, and `Execute<TResult>()`. Parameter values are type-checked against the listing's `IndicatorParam` metadata.
+
+### Leave a parameter out
+
+A few indicators have an overload that means "this argument was not given" rather than "this argument took its default". `ToPrs(sourceEval, sourceBase)` computes no `PrsPercent` at all — no value in the parameter's advertised range (`Minimum: 1`, `Maximum: 250`) produces that, and the only override that does is the `int.MinValue` sentinel the overload forwards internally, which the catalog gives you no way to discover. `WithoutParam` drops the argument instead of supplying one:
+
+```csharp
+IndicatorListing prs = Catalog.Get("PRS", Style.Series);
+
+// declared default: lookbackPeriods = 20, PrsPercent computed
+IReadOnlyList<PrsResult> withPercent = prs
+  .WithParamValue("sourceBase", benchmarkBars)
+  .FromSource((IEnumerable<IBar>)bars)
+  .Execute<PrsResult>();
+
+// no lookback argument at all: PrsPercent is null throughout
+IReadOnlyList<PrsResult> ratioOnly = prs
+  .WithParamValue("sourceBase", benchmarkBars)
+  .WithoutParam("lookbackPeriods")
+  .FromSource((IEnumerable<IBar>)bars)
+  .Execute<PrsResult>();
+```
+
+A shorter overload is selected where one exists; where none does, the method's own default for that parameter applies instead. Arguments bind positionally, so only a trailing run of parameters can be dropped — omitting one while a later one is still supplied is rejected rather than silently shifting arguments into the wrong slots. Series parameters supply the indicator's data rather than a setting, so they cannot be omitted.
+
+Omissions are part of a configuration, not a transient builder detail: `IndicatorConfig` round-trips them through `OmittedParameters` alongside `Parameters`, so a saved configuration reloads as the same indicator.
 
 ::: tip ✨ Tip: disambiguate the bars overload
 Because `Bar` implements both `IBar` and `IReusable`, a `bars` collection matches both `FromSource(bars)` and the `FromSource(series, …)` chaining overload. Cast to `(IEnumerable<IBar>)` (as above) to select the bars overload. The simpler `listing.Execute<TResult>(bars)` form needs no cast.

--- a/src/Common/Catalog/ListingExecutionBuilder.cs
+++ b/src/Common/Catalog/ListingExecutionBuilder.cs
@@ -7,14 +7,17 @@ namespace FacioQuo.Stock.Indicators;
 public class ListingExecutionBuilder
 {
     private readonly Dictionary<string, object> _parameterOverrides;
+    private readonly HashSet<string> _omittedParameters;
     private IEnumerable<IBar>? _bars;
 
     internal ListingExecutionBuilder(
         IndicatorListing baseListing,
-        Dictionary<string, object>? parameterOverrides = null)
+        Dictionary<string, object>? parameterOverrides = null,
+        HashSet<string>? omittedParameters = null)
     {
         BaseListing = baseListing ?? throw new ArgumentNullException(nameof(baseListing));
         _parameterOverrides = parameterOverrides ?? [];
+        _omittedParameters = omittedParameters ?? new HashSet<string>(StringComparer.Ordinal);
     }
 
     /// <summary>
@@ -24,6 +27,7 @@ public class ListingExecutionBuilder
     /// <param name="value">Value to set for the parameter.</param>
     /// <returns>A new <see cref="ListingExecutionBuilder"/> with the parameter override applied.</returns>
     /// <exception cref="ArgumentException">Thrown when an argument is invalid</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>.</exception>
     public ListingExecutionBuilder WithParamValue(string parameterName, object value)
     {
         if (string.IsNullOrWhiteSpace(parameterName))
@@ -31,16 +35,93 @@ public class ListingExecutionBuilder
             throw new ArgumentException("Parameter name cannot be null or empty", nameof(parameterName));
         }
 
-        if (value != null)
+        // A null argument cannot bind to the value types these parameters use, so it
+        // previously failed deep inside reflection with no indication of the cause.
+        // Leaving a parameter out is a separate, explicit request.
+        if (value is null)
         {
-            ValidateParameterType(parameterName, value);
+            throw new ArgumentNullException(
+                nameof(value),
+                $"Parameter '{parameterName}' cannot be set to null. "
+              + $"To leave it out of the call entirely, use WithoutParam(\"{parameterName}\").");
         }
 
+        ValidateParameterType(parameterName, value);
+
         Dictionary<string, object> newOverrides = new(_parameterOverrides) {
-            [parameterName] = value!
+            [parameterName] = value
         };
 
-        return new ListingExecutionBuilder(BaseListing, newOverrides) {
+        // supplying a value reverses an earlier omission, so the last call wins
+        HashSet<string> newOmitted = new(_omittedParameters, StringComparer.Ordinal);
+        newOmitted.Remove(parameterName);
+
+        return new ListingExecutionBuilder(BaseListing, newOverrides, newOmitted) {
+            _bars = _bars
+        };
+    }
+
+    /// <summary>
+    /// Leaves a parameter out of the call entirely, so overload resolution runs as if
+    /// the caller had never supplied it.
+    /// </summary>
+    /// <remarks>
+    /// Some overloads mean "this argument was not given" rather than "this argument
+    /// took its default". <c>ToPrs(sourceEval, sourceBase)</c> computes no
+    /// <c>PrsPercent</c> at all, which no value inside the listing's declared
+    /// <see cref="IndicatorParam.Minimum"/>/<see cref="IndicatorParam.Maximum"/> range
+    /// produces — it is reachable only by passing the <c>int.MinValue</c> sentinel that
+    /// overload forwards, which catalog metadata gives a caller no way to discover.
+    /// Omitting the argument expresses the same intent without the magic constant.
+    /// <para>
+    /// A shorter overload is selected where one exists. Where none does, the method's
+    /// own default for that parameter applies instead, so omitting is a request about
+    /// the call rather than a guarantee about which overload runs.
+    /// </para>
+    /// <para>
+    /// Arguments bind positionally, so only a trailing run of parameters can be
+    /// dropped. Omitting one while a later one is still supplied is rejected when
+    /// <see cref="Execute{TResult}"/> runs, rather than silently shifting arguments
+    /// into the wrong slots — it cannot be rejected here, because a later call may
+    /// still drop the parameters that follow.
+    /// </para>
+    /// </remarks>
+    /// <param name="parameterName">Name of the parameter to leave out.</param>
+    /// <returns>A new <see cref="ListingExecutionBuilder"/> with the omission applied.</returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown when the name is empty, names no parameter of this indicator, or names a
+    /// series parameter, which supplies data rather than a setting.
+    /// </exception>
+    public ListingExecutionBuilder WithoutParam(string parameterName)
+    {
+        if (string.IsNullOrWhiteSpace(parameterName))
+        {
+            throw new ArgumentException("Parameter name cannot be null or empty", nameof(parameterName));
+        }
+
+        IndicatorParam param
+            = BaseListing.Parameters?.FirstOrDefault(p => p.ParameterName == parameterName)
+            ?? throw new ArgumentException(
+                $"Parameter '{parameterName}' not found in indicator '{BaseListing.Uiid}'",
+                nameof(parameterName));
+
+        if (param.DataType == IndicatorParam.SeriesDataType)
+        {
+            throw new ArgumentException(
+                $"Series parameter '{parameterName}' cannot be omitted for indicator '{BaseListing.Uiid}'; "
+              + "it supplies the data the indicator reads, not a setting with a shorter form.",
+                nameof(parameterName));
+        }
+
+        // an omission reverses an earlier value, so the last call wins
+        Dictionary<string, object> newOverrides = new(_parameterOverrides);
+        newOverrides.Remove(parameterName);
+
+        HashSet<string> newOmitted = new(_omittedParameters, StringComparer.Ordinal) {
+            parameterName
+        };
+
+        return new ListingExecutionBuilder(BaseListing, newOverrides, newOmitted) {
             _bars = _bars
         };
     }
@@ -50,23 +131,33 @@ public class ListingExecutionBuilder
     /// </summary>
     /// <param name="parameters">Dictionary of parameter names and values.</param>
     /// <returns>A new <see cref="ListingExecutionBuilder"/> with the parameter overrides applied.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="parameters"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="parameters"/> is <c>null</c>, or any value in it is <c>null</c>.
+    /// </exception>
     public ListingExecutionBuilder WithParams(Dictionary<string, object> parameters)
     {
         ArgumentNullException.ThrowIfNull(parameters);
 
         Dictionary<string, object> newOverrides = new(_parameterOverrides);
+        HashSet<string> newOmitted = new(_omittedParameters, StringComparer.Ordinal);
+
         foreach (KeyValuePair<string, object> kvp in parameters)
         {
-            if (kvp.Value != null)
+            if (kvp.Value is null)
             {
-                ValidateParameterType(kvp.Key, kvp.Value);
+                throw new ArgumentNullException(
+                    nameof(parameters),
+                    $"Parameter '{kvp.Key}' cannot be set to null. "
+                  + $"To leave it out of the call entirely, use WithoutParam(\"{kvp.Key}\").");
             }
 
-            newOverrides[kvp.Key] = kvp.Value!;
+            ValidateParameterType(kvp.Key, kvp.Value);
+
+            newOverrides[kvp.Key] = kvp.Value;
+            newOmitted.Remove(kvp.Key);
         }
 
-        return new ListingExecutionBuilder(BaseListing, newOverrides) {
+        return new ListingExecutionBuilder(BaseListing, newOverrides, newOmitted) {
             _bars = _bars
         };
     }
@@ -81,7 +172,7 @@ public class ListingExecutionBuilder
     {
         ArgumentNullException.ThrowIfNull(bars);
 
-        return new(BaseListing, _parameterOverrides) {
+        return new(BaseListing, _parameterOverrides, _omittedParameters) {
             _bars = bars
         };
     }
@@ -112,11 +203,16 @@ public class ListingExecutionBuilder
     /// </summary>
     /// <typeparam name="TResult">Expected result type.</typeparam>
     /// <returns>Indicator results.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when bars have not been set via From().</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when bars have not been set via From(); when an omission requested by
+    /// <see cref="WithoutParam(string)"/> is not a trailing run, or names a parameter
+    /// the method has no shorter form for; or when the assembled arguments match no
+    /// overload.
+    /// </exception>
     public IReadOnlyList<TResult> Execute<TResult>()
         where TResult : class => _bars == null
             ? throw new InvalidOperationException("Bars must be set using From() before calling Execute()")
-            : ListingExecutor.Execute<TResult>(_bars, BaseListing, _parameterOverrides);
+            : ListingExecutor.Execute<TResult>(_bars, BaseListing, _parameterOverrides, _omittedParameters);
 
     /// <summary>
     /// Validates that a parameter value is compatible with the expected parameter type.
@@ -161,7 +257,7 @@ public class ListingExecutionBuilder
             throw new ArgumentException(
                 $"Parameter '{parameterName}' expects an integer value, but received {value.GetType().Name}", nameof(value));
         }
-        else if ((param.DataType == "Double" || param.DataType == "Nullable`1") && value is not double && value is not int && value is not null) // Allow int to double conversion and nullable
+        else if ((param.DataType == "Double" || param.DataType == "Nullable`1") && value is not double && value is not int) // Allow int to double conversion
         {
             throw new ArgumentException(
                 $"Parameter '{parameterName}' expects a double value, but received {value.GetType().Name}", nameof(value));
@@ -169,13 +265,13 @@ public class ListingExecutionBuilder
         else if (param.DataType == "Decimal" && value is not decimal)
         {
             throw new ArgumentException(
-                $"Parameter '{parameterName}' expects a decimal value, but received {value?.GetType().Name ?? "null"}. "
+                $"Parameter '{parameterName}' expects a decimal value, but received {value.GetType().Name}. "
               + "Use a decimal literal (for example 2.5m); a double cannot be bound to a decimal parameter.", nameof(value));
         }
         else if (param.DataType == "Boolean" && value is not bool)
         {
             throw new ArgumentException(
-                $"Parameter '{parameterName}' expects a boolean value, but received {value?.GetType().Name ?? "null"}", nameof(value));
+                $"Parameter '{parameterName}' expects a boolean value, but received {value.GetType().Name}", nameof(value));
         }
         // Additional type validations can be added here for other parameter types as needed
     }
@@ -216,6 +312,21 @@ public class ListingExecutionBuilder
     /// Gets the parameter overrides.
     /// </summary>
     public IReadOnlyDictionary<string, object> ParameterOverrides => _parameterOverrides;
+
+    /// <summary>
+    /// Gets the names of parameters that will be left out of the call entirely.
+    /// </summary>
+    /// <remarks>
+    /// These take no argument at all, selecting a shorter overload rather than the
+    /// listing's declared default. See <see cref="WithoutParam(string)"/>.
+    /// <para>
+    /// A copy, so that mutating the returned set through a downcast cannot reach this
+    /// builder or the ones derived from it — instances share the backing collection
+    /// because every configuring call copies before it changes anything.
+    /// </para>
+    /// </remarks>
+    public IReadOnlySet<string> OmittedParameters
+        => new HashSet<string>(_omittedParameters, StringComparer.Ordinal);
 
     /// <summary>
     /// Gets whether bars have been set.

--- a/src/Common/Catalog/ListingExecutionBuilderExtensions.cs
+++ b/src/Common/Catalog/ListingExecutionBuilderExtensions.cs
@@ -19,6 +19,21 @@ public static class ListingExecutionBuilderExtensions
             => new ListingExecutionBuilder(listing).WithParamValue(parameterName, value);
 
     /// <summary>
+    /// Creates a customizable indicator builder that leaves a parameter out of the call.
+    /// </summary>
+    /// <remarks>
+    /// Selects a shorter overload instead of supplying the listing's default value.
+    /// See <see cref="ListingExecutionBuilder.WithoutParam(string)"/>.
+    /// </remarks>
+    /// <param name="listing">Base indicator listing.</param>
+    /// <param name="parameterName">Name of the parameter to leave out.</param>
+    /// <returns>A <see cref="ListingExecutionBuilder"/> for fluent configuration.</returns>
+    public static ListingExecutionBuilder WithoutParam(
+        this IndicatorListing listing,
+        string parameterName)
+            => new ListingExecutionBuilder(listing).WithoutParam(parameterName);
+
+    /// <summary>
     /// Creates a customizable indicator builder from an indicator listing with multiple parameters.
     /// </summary>
     /// <param name="listing">Base indicator listing.</param>

--- a/src/Common/Catalog/ListingExecutor.cs
+++ b/src/Common/Catalog/ListingExecutor.cs
@@ -19,13 +19,22 @@ internal static class ListingExecutor
     /// The listing.Parameters metadata defines the schema (names, types, defaults),
     /// while this dictionary provides runtime override values.
     /// </param>
+    /// <param name="omitted">
+    /// Optional parameter names to leave out of the call entirely, so a shorter
+    /// overload is selected where one exists and the method's own default applies
+    /// where none does. This is how a catalog caller reaches an overload whose meaning
+    /// is "this argument was not given" — <c>ToPrs(sourceEval, sourceBase)</c>, which
+    /// computes no <c>PrsPercent</c> and is otherwise reachable only through the
+    /// <c>int.MinValue</c> sentinel it forwards.
+    /// </param>
     /// <returns>Indicator results.</returns>
     /// <exception cref="InvalidOperationException">Thrown when the indicator cannot be executed.</exception>
     /// <exception cref="ArgumentNullException"><paramref name="bars"/> is <c>null</c>.</exception>
     internal static IReadOnlyList<TResult> Execute<TResult>(
         IEnumerable<IBar> bars,
         IndicatorListing listing,
-        Dictionary<string, object>? parameters = null)
+        Dictionary<string, object>? parameters = null,
+        IReadOnlySet<string>? omitted = null)
         where TResult : class
     {
         // Validate inputs
@@ -63,6 +72,8 @@ internal static class ListingExecutor
             }
         }
 
+        ValidateOmissions(listing, omitted);
+
         // Build parameter array using catalog metadata and user overrides.
         //
         // A listing that declares series parameters names its own source inputs, so
@@ -80,6 +91,14 @@ internal static class ListingExecutor
         {
             foreach (IndicatorParam param in listing.Parameters)
             {
+                // An omitted parameter contributes no argument at all, so overload
+                // resolution below lands on a shorter form of the method rather than
+                // on the listing's default. ValidateOmissions has already established
+                // that only a trailing run is dropped.
+                if (omitted?.Contains(param.ParameterName) == true)
+                {
+                    continue;
+                }
 
                 // Check if user provided an override
                 if (parameters?.TryGetValue(param.ParameterName, out object? value) == true)
@@ -140,7 +159,15 @@ internal static class ListingExecutor
                          && m.GetParameters().Skip(parameterList.Count).All(static p => p.IsOptional))
                 .OrderBy(static m => m.GetParameters().Length)
                 .FirstOrDefault()
-                ?? throw new InvalidOperationException($"No '{methodName}' method found with {parameterList.Count} parameters");
+                // an omission the method has no shorter form for leaves an argument
+                // list nothing accepts; say which request could not be met rather than
+                // reporting a bare parameter count
+                ?? throw new InvalidOperationException(
+                    omitted is { Count: > 0 }
+                        ? $"No form of '{methodName}' omits "
+                        + $"{string.Join(", ", omitted.Select(static n => $"'{n}'"))} for indicator "
+                        + $"'{listing.Uiid}'; that parameter is mandatory, so supply a value instead."
+                        : $"No '{methodName}' method found with {parameterList.Count} parameters");
 
             foreach (ParameterInfo optional in targetMethod.GetParameters().Skip(parameterList.Count))
             {
@@ -167,6 +194,84 @@ internal static class ListingExecutor
         return result is IReadOnlyList<TResult> typedResult
             ? typedResult
             : throw new InvalidOperationException($"Result is not of expected type {typeof(IReadOnlyList<TResult>).Name}");
+    }
+
+    /// <summary>
+    /// Validates that the requested omissions can be expressed as a shorter call.
+    /// </summary>
+    /// <remarks>
+    /// Arguments bind positionally, so dropping a parameter with others still after it
+    /// would shift every later argument one slot left and bind it to the wrong
+    /// parameter — the same silent misbinding the catalog's contiguity rule prevents.
+    /// Only a trailing run can be dropped. A series parameter is the indicator's data
+    /// input rather than a setting, so it is never omittable.
+    /// <para>
+    /// The name and series checks repeat what <see cref="ListingExecutionBuilder.WithoutParam(string)"/>
+    /// already rejects, because the builder is not the only source of an omission set:
+    /// <see cref="IndicatorConfig.ToBuilder"/> carries names straight from deserialized
+    /// JSON, which never passed through that method. This is the boundary where an
+    /// untrusted set is first trusted, so it validates rather than assumes. The
+    /// trailing-run rule can only be checked here in any case — a later
+    /// <c>WithoutParam</c> call may drop the parameters that follow and make an
+    /// interior omission trailing after all.
+    /// </para>
+    /// </remarks>
+    /// <param name="listing">Indicator listing being executed.</param>
+    /// <param name="omitted">Parameter names the caller asked to leave out.</param>
+    /// <exception cref="InvalidOperationException">Thrown when an omission is not expressible.</exception>
+    private static void ValidateOmissions(
+        IndicatorListing listing,
+        IReadOnlySet<string>? omitted)
+    {
+        if (omitted is not { Count: > 0 })
+        {
+            return;
+        }
+
+        IReadOnlyList<IndicatorParam> declared = listing.Parameters ?? [];
+
+        foreach (string name in omitted)
+        {
+            IndicatorParam? param = declared.FirstOrDefault(p => p.ParameterName == name);
+
+            if (param is null)
+            {
+                string expected = declared.Count > 0
+                    ? string.Join(", ", declared.Select(static p => p.ParameterName))
+                    : "(none - this indicator takes no parameters)";
+
+                throw new InvalidOperationException(
+                    $"Cannot omit '{name}': it is not defined for indicator '{listing.Uiid}'. "
+                  + $"Expected one of: {expected}");
+            }
+
+            if (param.DataType == IndicatorParam.SeriesDataType)
+            {
+                throw new InvalidOperationException(
+                    $"Series parameter '{name}' cannot be omitted for indicator '{listing.Uiid}'; "
+                  + "it supplies the data the indicator reads, not a setting with a shorter form.");
+            }
+        }
+
+        int firstOmitted = -1;
+
+        for (int i = 0; i < declared.Count; i++)
+        {
+            if (omitted.Contains(declared[i].ParameterName))
+            {
+                if (firstOmitted < 0)
+                {
+                    firstOmitted = i;
+                }
+            }
+            else if (firstOmitted >= 0)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot omit '{declared[firstOmitted].ParameterName}' for indicator '{listing.Uiid}' "
+                  + $"while '{declared[i].ParameterName}' after it is still supplied. Arguments bind "
+                  + "positionally, so only a trailing run of parameters can be dropped.");
+            }
+        }
     }
 
     /// <summary>

--- a/src/Common/Catalog/README.md
+++ b/src/Common/Catalog/README.md
@@ -28,6 +28,7 @@ Core builder methods: `.WithName`, `.WithId`, `.WithStyle`, `.WithCategory`, `.W
 - Define separate listings: `SeriesListing`, `StreamListing`, `BufferListing`
 - Parameter names must exactly match method signatures
 - Result `dataName` uses `nameof(TResult.Property)` so a renamed result property fails the build
+- `isRequired: false` means a caller may omit the argument **and get `defaultValue`**. That holds in exactly two shapes: the parameter carries a C# default equal to `defaultValue`, or the listing declares no `defaultValue` at all and so promises nothing (VWAP's `startDate`, omittable via `ToVwap(bars)`). If the argument can only be dropped by selecting a shorter overload that behaves differently while the listing still advertises a default — as `ToPrs(sourceEval, sourceBase)` does, computing no `PrsPercent` — mark it `isRequired: true` so a catalog-driven caller does not silently get a different indicator, and reach that overload with `WithoutParam(name)` instead. `EveryParameterIsRequiredMatchesCallability` enforces all three cases.
 
 ## Catalog and registry access
 

--- a/src/Common/Catalog/Schema/IndicatorConfig.cs
+++ b/src/Common/Catalog/Schema/IndicatorConfig.cs
@@ -22,6 +22,18 @@ public class IndicatorConfig
     public Dictionary<string, object> Parameters { get; init; } = [];
 
     /// <summary>
+    /// Names of parameters to leave out of the call entirely.
+    /// </summary>
+    /// <remarks>
+    /// These take no argument at all, selecting a shorter overload rather than the
+    /// listing's declared default — see <see cref="ListingExecutionBuilder.WithoutParam(string)"/>.
+    /// Omitting is not the same as leaving a name out of <see cref="Parameters"/>, which
+    /// falls back to the declared default, so a configuration must carry both to
+    /// round-trip faithfully.
+    /// </remarks>
+    public IList<string> OmittedParameters { get; init; } = [];
+
+    /// <summary>
     /// Optional display name for this configuration.
     /// </summary>
     public string? DisplayName { get; set; }
@@ -41,7 +53,10 @@ public class IndicatorConfig
         IndicatorListing? listing = Catalog.Get(Id, Style);
         return listing == null
             ? throw new InvalidOperationException($"Indicator '{Id}' with style '{Style}' not found in catalog")
-            : new ListingExecutionBuilder(listing, Parameters);
+            : new ListingExecutionBuilder(
+                listing,
+                Parameters,
+                new HashSet<string>(OmittedParameters, StringComparer.Ordinal));
     }
 
     /// <summary>
@@ -58,6 +73,7 @@ public class IndicatorConfig
             Id = builder.BaseListing.Uiid,
             Style = builder.BaseListing.Style,
             Parameters = new Dictionary<string, object>(builder.ParameterOverrides),
+            OmittedParameters = [.. builder.OmittedParameters],
             DisplayName = builder.BaseListing.Name
         };
     }

--- a/src/Common/Catalog/Schema/IndicatorParam.cs
+++ b/src/Common/Catalog/Schema/IndicatorParam.cs
@@ -36,12 +36,21 @@ public record IndicatorParam
     /// Gets or sets whether the caller must supply this parameter.
     /// </summary>
     /// <remarks>
-    /// Tracks C# callability. <c>false</c> means some public form of
-    /// <see cref="IndicatorListing.MethodName"/> lets a caller leave the argument out —
-    /// either because the parameter carries a default value, or because a shorter
-    /// overload omits it entirely, as <c>ToVwap(bars)</c> does for <c>startDate</c>.
+    /// Tracks what a caller must pass to get the behavior this listing describes.
+    /// <c>false</c> means leaving the argument out is both legal and equivalent to
+    /// <see cref="DefaultValue"/>: either the parameter carries that value as a C#
+    /// default, or the listing declares no default at all — VWAP's <c>startDate</c>
+    /// is the latter, omittable through <c>ToVwap(bars)</c> with nothing promised.
+    /// <para>
+    /// <c>true</c> means the caller must pass a value, which includes the case where a
+    /// shorter overload exists but does something other than the declared default.
+    /// <c>ToPrs(sourceEval, sourceBase)</c> computes no <c>PrsPercent</c>, so PRS's
+    /// <c>lookbackPeriods</c> is required despite being droppable; reach that overload
+    /// deliberately with <see cref="ListingExecutionBuilder.WithoutParam(string)"/>.
+    /// </para>
     /// Catalog-driven code generation reads this to decide whether it may skip the
-    /// argument, so an understated value yields source that does not compile.
+    /// argument, so an understated value yields either source that does not compile or
+    /// an indicator that quietly differs from the one described.
     /// This is not a display hint: <see cref="DefaultValue"/> seeds an input field, and
     /// a required parameter may carry one too.
     /// </remarks>

--- a/src/Indicators/k-q/Prs/Prs.Catalog.cs
+++ b/src/Indicators/k-q/Prs/Prs.Catalog.cs
@@ -5,6 +5,15 @@ public static partial class Prs
     /// <summary>
     /// Price Relative Strength Common Base Listing
     /// </summary>
+    /// <remarks>
+    /// <c>lookbackPeriods</c> is required even though <c>ToPrs(sourceEval, sourceBase)</c>
+    /// exists, because that overload does not take the declared default — it computes no
+    /// <c>PrsPercent</c> at all. Marking the parameter optional would advertise a default
+    /// of 20 that omitting the argument does not produce, so a catalog-driven caller that
+    /// left it out would silently get a different indicator than the listing describes.
+    /// The no-<c>PrsPercent</c> form stays reachable through
+    /// <see cref="ListingExecutionBuilder.WithoutParam(string)"/>.
+    /// </remarks>
     internal static readonly IndicatorListing CommonListing =
         new CatalogListingBuilder()
             .WithName("Price Relative Strength")
@@ -12,7 +21,7 @@ public static partial class Prs
             .WithCategory(Category.PriceCharacteristic)
             .AddSeriesParameter("sourceEval", "Source Evaluated", description: "Source data to be evaluated")
             .AddSeriesParameter("sourceBase", "Source Base", description: "Base source data for comparison")
-            .AddParameter<int>("lookbackPeriods", "Lookback Periods", description: "Number of periods for the PRS calculation", isRequired: false, defaultValue: 20, minimum: 1, maximum: 250)
+            .AddParameter<int>("lookbackPeriods", "Lookback Periods", description: "Number of periods for the PRS calculation", isRequired: true, defaultValue: 20, minimum: 1, maximum: 250)
             .AddResult(nameof(PrsResult.Prs), "PRS", ResultType.Default, isReusable: true)
             .AddResult(nameof(PrsResult.PrsPercent), "PRS %", ResultType.Default)
             .Build();

--- a/tests/Library/Common/Catalog/Catalog.Binding.Tests.cs
+++ b/tests/Library/Common/Catalog/Catalog.Binding.Tests.cs
@@ -8,6 +8,7 @@ namespace Catalogging;
 /// - each <c>Results[].DataName</c> resolves to a property on the result record
 /// - each <c>Parameters[].ParameterName</c> resolves to a method parameter, in order
 /// - each <c>Parameters[].IsRequired</c> agrees with whether C# lets a caller omit it
+///   and still get the behavior the listing describes
 /// </summary>
 /// <remarks>
 /// These names are plain strings in the <c>*.Catalog.cs</c> definitions, so the
@@ -177,26 +178,65 @@ public class CatalogBindingTests : TestBase
             {
                 IndicatorParam param = listing.Parameters[i];
 
-                bool callerMustSupply
-                    = !CatalogReflection.IsOmittable(overloads, catalogNames, i);
+                bool defaulted = CatalogReflection.TryGetCSharpDefault(
+                    overloads, catalogNames, i, out object csharpDefault);
 
-                if (param.IsRequired == callerMustSupply)
+                bool shorter = CatalogReflection.HasShorterOverload(overloads, catalogNames, i);
+
+                // no form of the method leaves it out, so a caller must supply it
+                if (!defaulted && !shorter && !param.IsRequired)
                 {
-                    continue;
+                    violations.Add(
+                        $"{identity}: '{param.ParameterName}' is marked optional, but every form of "
+                      + $"'{listing.MethodName}' requires it");
                 }
 
-                violations.Add(param.IsRequired
-                    ? $"{identity}: '{param.ParameterName}' is marked required, but "
-                    + $"'{listing.MethodName}' has a form that omits it"
-                    : $"{identity}: '{param.ParameterName}' is marked optional, but every form of "
-                    + $"'{listing.MethodName}' requires it");
+                // C# already supplies a value, so demanding one over-constrains callers
+                if (defaulted && param.IsRequired)
+                {
+                    violations.Add(
+                        $"{identity}: '{param.ParameterName}' is marked required, but "
+                      + $"'{listing.MethodName}' gives it a default");
+                }
+
+                // optional plus a declared default promises that omitting yields that
+                // default; a shorter overload delivers its own behavior instead. The
+                // no-way-to-omit case is already reported above, so this speaks only
+                // where a shorter overload genuinely exists.
+                //
+                // This assumes a shorter overload never merely re-applies the declared
+                // default. That holds across the catalog today — ToPrs drops PrsPercent
+                // and ToVwap derives a start from the data — and reflection cannot tell
+                // the difference, so an overload that did forward the same constant
+                // would have to be marked required or drop its declared default.
+                if (!param.IsRequired && param.DefaultValue is not null && !defaulted && shorter)
+                {
+                    violations.Add(
+                        $"{identity}: '{param.ParameterName}' is marked optional with default "
+                      + $"'{param.DefaultValue}', but omitting it selects a shorter overload of "
+                      + $"'{listing.MethodName}' that does not apply that value");
+                }
+
+                // an advertised default that differs from the one C# applies is the
+                // silent-wrong-value case: the caller omits the argument expecting the
+                // documented number and the method uses another
+                if (defaulted
+                 && param.DefaultValue is not null
+                 && !CatalogReflection.DefaultsAgree(csharpDefault, param.DefaultValue))
+                {
+                    violations.Add(
+                        $"{identity}: '{param.ParameterName}' advertises default "
+                      + $"'{param.DefaultValue}', but '{listing.MethodName}' applies "
+                      + $"'{csharpDefault}' when the argument is omitted");
+                }
             }
         }
 
         string.Join(Environment.NewLine, violations).Should().BeEmpty(
-            "IsRequired must track whether C# lets a caller omit the argument; catalog-driven code "
-          + "generation reads it to decide whether to emit one, so an understated value produces "
-          + "source that does not compile");
+            "IsRequired must track whether C# lets a caller omit the argument and still get what "
+          + "the listing describes; catalog-driven code generation reads it to decide whether to "
+          + "emit one, so an understated value produces source that does not compile and a default "
+          + "the shorter overload ignores produces a silently different indicator");
     }
 
     [TestMethod]

--- a/tests/Library/Common/Catalog/Catalog.Omission.Tests.cs
+++ b/tests/Library/Common/Catalog/Catalog.Omission.Tests.cs
@@ -1,0 +1,278 @@
+using System.Text.Json;
+
+namespace Catalogging;
+
+/// <summary>
+/// Catalog omission tests covering overloads whose meaning is "this argument was not
+/// given" rather than "this argument took its default".
+/// </summary>
+/// <remarks>
+/// <c>ToPrs(sourceEval, sourceBase)</c> computes no <c>PrsPercent</c> at all. No value
+/// in the listing's advertised range reaches that; the only override that does is the
+/// <c>int.MinValue</c> sentinel the overload forwards internally, which catalog
+/// metadata gives a caller no way to discover. <c>WithoutParam</c> drops the argument
+/// so overload resolution lands on the shorter form without the magic constant.
+/// </remarks>
+[TestClass]
+public class CatalogOmissionTests : TestBase
+{
+    [TestMethod]
+    public void OmittedParameterSelectsShorterOverload()
+    {
+        IndicatorListing listing = Catalog.Get("PRS", Style.Series);
+
+        IReadOnlyList<PrsResult> viaCatalog = listing
+            .WithParamValue("sourceBase", OtherBars)
+            .WithoutParam("lookbackPeriods")
+            .FromSource((IEnumerable<IBar>)Bars)
+            .Execute<PrsResult>();
+
+        IReadOnlyList<PrsResult> direct = ((IReadOnlyList<IReusable>)Bars).ToPrs(OtherBars);
+
+        viaCatalog.Should().HaveCount(direct.Count);
+        viaCatalog.Select(static r => r.Prs).Should().Equal(direct.Select(static r => r.Prs));
+        viaCatalog.Select(static r => r.PrsPercent).Should().Equal(direct.Select(static r => r.PrsPercent));
+    }
+
+    [TestMethod]
+    public void OmittedParameterDiffersFromTheDeclaredDefault()
+    {
+        // the point of the feature: the shorter overload is a different indicator,
+        // not the declared default, so it could not be reached by overriding
+        IndicatorListing listing = Catalog.Get("PRS", Style.Series);
+
+        IReadOnlyList<PrsResult> withDefault = listing
+            .WithParamValue("sourceBase", OtherBars)
+            .FromSource((IEnumerable<IBar>)Bars)
+            .Execute<PrsResult>();
+
+        IReadOnlyList<PrsResult> omitted = listing
+            .WithParamValue("sourceBase", OtherBars)
+            .WithoutParam("lookbackPeriods")
+            .FromSource((IEnumerable<IBar>)Bars)
+            .Execute<PrsResult>();
+
+        withDefault.Should().Contain(static r => r.PrsPercent != null,
+            "the declared default of 20 computes a percent change");
+
+        omitted.Should().OnlyContain(static r => r.PrsPercent == null,
+            "the two-argument overload computes no percent change at all");
+
+        // the ratio itself is unaffected either way
+        omitted.Select(static r => r.Prs).Should().Equal(withDefault.Select(static r => r.Prs));
+    }
+
+    [TestMethod]
+    public void OmittedParameterFallsBackToTheMethodDefault()
+    {
+        // ALMA has no shorter overload, so dropping the trailing argument leaves the
+        // method's own default to apply rather than failing to bind
+        IndicatorListing listing = Catalog.Get("ALMA", Style.Series);
+
+        IReadOnlyList<AlmaResult> viaCatalog = listing
+            .WithoutParam("sigma")
+            .FromSource((IEnumerable<IBar>)Bars)
+            .Execute<AlmaResult>();
+
+        IReadOnlyList<AlmaResult> direct = Bars.Use(CandlePart.Close).ToAlma(9, 0.85, 6);
+
+        viaCatalog.Should().HaveCount(direct.Count);
+        viaCatalog[^1].Alma.Should().Be(direct[^1].Alma);
+    }
+
+    [TestMethod]
+    public void OmissionSurvivesLaterBuilderCalls()
+    {
+        // each builder call returns a new instance, so omissions must be carried
+        // forward the way parameter overrides and bars are
+        IndicatorListing listing = Catalog.Get("PRS", Style.Series);
+
+        ListingExecutionBuilder builder = listing
+            .WithoutParam("lookbackPeriods")
+            .WithParamValue("sourceBase", OtherBars)
+            .FromSource((IEnumerable<IBar>)Bars);
+
+        builder.OmittedParameters.Should().Contain("lookbackPeriods");
+
+        builder.Execute<PrsResult>().Should().OnlyContain(static r => r.PrsPercent == null);
+    }
+
+    [TestMethod]
+    public void SupplyingAValueReversesAnEarlierOmission()
+    {
+        IndicatorListing listing = Catalog.Get("PRS", Style.Series);
+
+        ListingExecutionBuilder builder = listing
+            .WithoutParam("lookbackPeriods")
+            .WithParamValue("lookbackPeriods", 20)
+            .WithParamValue("sourceBase", OtherBars)
+            .FromSource((IEnumerable<IBar>)Bars);
+
+        builder.OmittedParameters.Should().BeEmpty();
+
+        builder.Execute<PrsResult>().Should().Contain(static r => r.PrsPercent != null);
+    }
+
+    [TestMethod]
+    public void NonTrailingOmissionIsRejected()
+    {
+        // arguments bind positionally, so dropping lookbackPeriods while offset and
+        // sigma are still supplied would shift both one slot left
+        IndicatorListing listing = Catalog.Get("ALMA", Style.Series);
+
+        Action act = () => listing
+            .WithoutParam("lookbackPeriods")
+            .FromSource((IEnumerable<IBar>)Bars)
+            .Execute<AlmaResult>();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Cannot omit 'lookbackPeriods'*")
+            .WithMessage("*'offset' after it is still supplied*")
+            .WithMessage("*only a trailing run*");
+    }
+
+    [TestMethod]
+    public void OmissionSurvivesAConfigurationRoundTrip()
+    {
+        // a saved configuration that dropped the omission would silently reload as a
+        // different indicator, since leaving a name out of Parameters means "use the
+        // declared default" rather than "pass no argument"
+        IndicatorListing listing = Catalog.Get("PRS", Style.Series);
+
+        ListingExecutionBuilder original = listing
+            .WithParamValue("sourceBase", OtherBars)
+            .WithoutParam("lookbackPeriods");
+
+        IndicatorConfig config = IndicatorConfig.FromBuilder(original);
+        config.OmittedParameters.Should().Contain("lookbackPeriods");
+
+        // through JSON, which is what the type exists for
+        string json = JsonSerializer.Serialize(config);
+        IndicatorConfig restored = JsonSerializer.Deserialize<IndicatorConfig>(json)!;
+        restored.OmittedParameters.Should().Contain("lookbackPeriods");
+
+        IReadOnlyList<PrsResult> reloaded = restored
+            .ToBuilder()
+            .WithParamValue("sourceBase", OtherBars)
+            .FromSource((IEnumerable<IBar>)Bars)
+            .Execute<PrsResult>();
+
+        reloaded.Should().OnlyContain(static r => r.PrsPercent == null,
+            "the reloaded configuration must select the same overload as the original");
+    }
+
+    [TestMethod]
+    public void ConfiguredOmissionOfAnUnknownParameterIsRejected()
+    {
+        // a deserialized configuration never passed through WithoutParam, so the
+        // executor is where these names are first checked
+        IndicatorConfig config = new() {
+            Id = "PRS",
+            Style = Style.Series,
+            OmittedParameters = { "nonsense" }
+        };
+
+        Action act = () => config
+            .ToBuilder()
+            .WithParamValue("sourceBase", OtherBars)
+            .FromSource((IEnumerable<IBar>)Bars)
+            .Execute<PrsResult>();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Cannot omit 'nonsense'*")
+            .WithMessage("*not defined for indicator 'PRS'*");
+    }
+
+    [TestMethod]
+    public void ConfiguredOmissionOfASeriesParameterIsRejected()
+    {
+        IndicatorConfig config = new() {
+            Id = "PRS",
+            Style = Style.Series,
+            OmittedParameters = { "sourceBase" }
+        };
+
+        Action act = () => config
+            .ToBuilder()
+            .FromSource((IEnumerable<IBar>)Bars)
+            .Execute<PrsResult>();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Series parameter 'sourceBase' cannot be omitted*");
+    }
+
+    [TestMethod]
+    public void OmittingAMandatoryParameterReportsTheRequestNotAnArgumentCount()
+    {
+        // EMA's only overload requires lookbackPeriods, so the omission cannot be met;
+        // the caller should learn which request failed, not an internal arity
+        IndicatorListing listing = Catalog.Get("EMA", Style.Series);
+
+        Action act = () => listing
+            .WithoutParam("lookbackPeriods")
+            .FromSource((IEnumerable<IBar>)Bars)
+            .Execute<EmaResult>();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*No form of 'ToEma' omits 'lookbackPeriods'*")
+            .WithMessage("*mandatory, so supply a value instead*");
+    }
+
+    [TestMethod]
+    public void OmittedParametersCannotBeMutatedThroughTheExposedSet()
+    {
+        // the property must not hand out the builder's own collection; mutating it
+        // would reach every builder derived from this one
+        IndicatorListing listing = Catalog.Get("PRS", Style.Series);
+
+        ListingExecutionBuilder builder = listing
+            .WithParamValue("sourceBase", OtherBars)
+            .WithoutParam("lookbackPeriods");
+
+        ((HashSet<string>)builder.OmittedParameters).Clear();
+
+        builder.OmittedParameters.Should().Contain("lookbackPeriods");
+
+        builder
+            .FromSource((IEnumerable<IBar>)Bars)
+            .Execute<PrsResult>()
+            .Should().OnlyContain(static r => r.PrsPercent == null);
+    }
+
+    [TestMethod]
+    public void OmittingASeriesParameterIsRejected()
+    {
+        IndicatorListing listing = Catalog.Get("PRS", Style.Series);
+
+        Action act = () => listing.WithoutParam("sourceBase");
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*Series parameter 'sourceBase' cannot be omitted*")
+            .WithMessage("*supplies the data the indicator reads*");
+    }
+
+    [TestMethod]
+    public void OmittingAnUnknownParameterIsRejected()
+    {
+        IndicatorListing listing = Catalog.Get("PRS", Style.Series);
+
+        Action act = () => listing.WithoutParam("nonsense");
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*'nonsense' not found in indicator 'PRS'*");
+    }
+
+    [TestMethod]
+    public void NullParameterValueIsRejectedAndPointsAtOmission()
+    {
+        // a null cannot bind to these value-typed parameters, and previously failed
+        // deep inside reflection with nothing naming the cause
+        IndicatorListing listing = Catalog.Get("PRS", Style.Series);
+
+        Action act = () => listing.WithParamValue("lookbackPeriods", null!);
+
+        act.Should().Throw<ArgumentNullException>()
+            .WithMessage("*cannot be set to null*")
+            .WithMessage("*WithoutParam(\"lookbackPeriods\")*");
+    }
+}

--- a/tests/Library/Common/Catalog/Catalog.Reflection.cs
+++ b/tests/Library/Common/Catalog/Catalog.Reflection.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System.Globalization;
 using System.Reflection;
 
 namespace Catalogging;
@@ -116,21 +117,112 @@ internal static class CatalogReflection
         => methodNames.AsSpan().IndexOf(catalogNames.AsSpan());
 
     /// <summary>
-    /// Determines whether a caller can leave out the catalog parameter at
-    /// <paramref name="index"/> while still supplying every catalog parameter before it.
+    /// Determines whether an overload carrying the whole catalog run gives the
+    /// parameter at <paramref name="index"/> a C# default value.
     /// </summary>
     /// <remarks>
-    /// A parameter is omittable in two ways, and checking only the first reports
-    /// defects that are not real: the parameter carries a C# default value, or a
-    /// shorter overload exists that does not declare it at all. The second is how
-    /// <c>ToVwap(bars)</c> makes <c>startDate</c> genuinely optional even though the
-    /// only signature naming it requires it.
+    /// This is the only way omitting the argument provably yields a known value, so it
+    /// is what lets a listing advertise a <see cref="IndicatorParam.DefaultValue"/> that
+    /// a caller can rely on by leaving the argument out.
     /// </remarks>
     /// <param name="overloads">All overloads of the listing's method.</param>
     /// <param name="catalogNames">Catalog parameter names, in listing order.</param>
     /// <param name="index">Index of the parameter being tested.</param>
-    /// <returns><c>true</c> when some public form of the method omits it.</returns>
-    internal static bool IsOmittable(
+    /// <returns><c>true</c> when the parameter carries a C# default.</returns>
+    internal static bool HasCSharpDefault(
+        IReadOnlyList<MethodInfo> overloads,
+        string[] catalogNames,
+        int index)
+        => TryGetCSharpDefault(overloads, catalogNames, index, out _);
+
+    /// <summary>
+    /// Gets the C# default value for the catalog parameter at <paramref name="index"/>.
+    /// </summary>
+    /// <param name="overloads">All overloads of the listing's method.</param>
+    /// <param name="catalogNames">Catalog parameter names, in listing order.</param>
+    /// <param name="index">Index of the parameter being tested.</param>
+    /// <param name="value">The compiler-recorded default, when there is one.</param>
+    /// <returns><c>true</c> when the parameter carries a C# default.</returns>
+    internal static bool TryGetCSharpDefault(
+        IReadOnlyList<MethodInfo> overloads,
+        string[] catalogNames,
+        int index,
+        out object? value)
+    {
+        foreach (MethodInfo method in overloads)
+        {
+            int offset = IndexOfRun(catalogNames, GetParameterNames(method));
+
+            if (offset >= 0 && method.GetParameters()[offset + index] is { HasDefaultValue: true } parameter)
+            {
+                value = parameter.DefaultValue;
+                return true;
+            }
+        }
+
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether a listing's declared default is the same value the compiler
+    /// applies when the argument is left out.
+    /// </summary>
+    /// <remarks>
+    /// The two arrive as differently typed boxes for the same number — a
+    /// <c>decimal</c> parameter default against a <c>double</c> in the listing, or an
+    /// enum member against the <c>int</c> the builder stores — so they are compared
+    /// numerically rather than by boxed identity or rendered text.
+    /// </remarks>
+    /// <param name="csharpDefault">Compiler-recorded default.</param>
+    /// <param name="declaredDefault">Value the listing advertises.</param>
+    /// <returns><c>true</c> when the two agree.</returns>
+    internal static bool DefaultsAgree(object? csharpDefault, object? declaredDefault)
+    {
+        if (csharpDefault is null || declaredDefault is null)
+        {
+            return csharpDefault is null && declaredDefault is null;
+        }
+
+        return IsNumeric(csharpDefault) && IsNumeric(declaredDefault)
+            ? Convert.ToDecimal(csharpDefault, CultureInfo.InvariantCulture)
+           == Convert.ToDecimal(declaredDefault, CultureInfo.InvariantCulture)
+            : string.Equals(
+                Convert.ToString(csharpDefault, CultureInfo.InvariantCulture),
+                Convert.ToString(declaredDefault, CultureInfo.InvariantCulture),
+                StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Determines whether a boxed value is a number, counting enums as their backing
+    /// integer because that is how a listing stores an enum default.
+    /// </summary>
+    /// <param name="value">Boxed value.</param>
+    /// <returns><c>true</c> when it converts to a number.</returns>
+    private static bool IsNumeric(object value)
+        => value is byte or sbyte or short or ushort or int or uint
+                 or long or ulong or float or double or decimal
+        || value.GetType().IsEnum;
+
+    /// <summary>
+    /// Determines whether a shorter overload drops the parameter at
+    /// <paramref name="index"/> while still accepting every catalog parameter before it.
+    /// </summary>
+    /// <remarks>
+    /// This makes the argument omittable but says nothing about what the shorter
+    /// overload then does, and the compiler records no default to compare against.
+    /// <c>ToPrs(sourceEval, sourceBase)</c> computes no <c>PrsPercent</c>, reachable
+    /// otherwise only through an <c>int.MinValue</c> sentinel outside the parameter's
+    /// declared range; <c>ToVwap(bars)</c> starts from the first bar's timestamp, a
+    /// value that depends on the data rather than a constant. Neither is a default a
+    /// listing could honestly advertise, so this kind of omittability can back only
+    /// the absence of one.
+    /// </remarks>
+    /// <param name="overloads">All overloads of the listing's method.</param>
+    /// <param name="catalogNames">Catalog parameter names, in listing order.</param>
+    /// <param name="index">Index of the parameter being tested.</param>
+    /// <returns><c>true</c> when a shorter overload omits it.</returns>
+    internal static bool HasShorterOverload(
         IReadOnlyList<MethodInfo> overloads,
         string[] catalogNames,
         int index)
@@ -139,15 +231,6 @@ internal static class CatalogReflection
         {
             string[] methodNames = GetParameterNames(method);
 
-            // (a) an overload carrying the whole run gives this parameter a default
-            int offset = IndexOfRun(catalogNames, methodNames);
-
-            if (offset >= 0 && method.GetParameters()[offset + index].HasDefaultValue)
-            {
-                return true;
-            }
-
-            // (b) an overload drops it yet still accepts every earlier catalog parameter
             if (!methodNames.Contains(catalogNames[index], StringComparer.Ordinal)
              && IndexOfRun(catalogNames[..index], methodNames) >= 0)
             {


### PR DESCRIPTION
Closes #2202.

`ToPrs(sourceEval, sourceBase)` computes no `PrsPercent`. The catalog declared `lookbackPeriods` as `isRequired: false, defaultValue: 20`, which promises that leaving the argument out yields 20. Leaving it out actually selects that overload and computes no `PrsPercent` at any row — so a catalog-driven caller taking the documented permission got a silently different indicator than the listing describes.

## Correcting the premise in the issue

#2202 says the sentinel is "unrepresentable within the declared bounds, so the no-PrsPercent behavior is unreachable from the catalog." The second half is not true, and it changed the shape of the fix. `Prs.Utilities.cs:28` whitelists the sentinel (`is <= 0 and not int.MinValue`) and nothing in the executor enforces the listing's `Minimum`/`Maximum`, so `WithParamValue("lookbackPeriods", int.MinValue)` reaches it. Verified by assertion: results are element-identical to `ToPrs(sourceEval, sourceBase)`.

The behavior is therefore *reachable but undiscoverable* — no catalog consumer can derive `int.MinValue` from metadata that advertises a range of 1–250. That is the real justification for this change, and it is the one written into the code.

## What this adds

**`WithoutParam(name)`** on `ListingExecutionBuilder` (plus the matching `IndicatorListing` extension). It drops the argument rather than supplying one, so a shorter overload is selected where one exists and the method's own default applies where none does.

Arguments bind positionally, so only a **trailing run** may be dropped. Omitting a parameter while a later one is still supplied would shift every later argument one slot left — the same silent misbinding the catalog's contiguity rule prevents — so it is rejected at execute time, which is also the only place it can be judged, since a later call may still drop the parameters that follow. Series parameters supply the indicator's data rather than a setting and cannot be omitted.

**`IndicatorConfig.OmittedParameters`** carries omissions through save and reload. Without it a configuration round-trip silently regained the default and recomputed `PrsPercent` — the exact failure this feature exists to prevent. Round-tripped through real `JsonSerializer` in the test, not just the in-memory hop.

**PRS `lookbackPeriods` is now `isRequired: true`.** Execution is byte-identical: `ListingExecutor` supplies the same `20` on both the required and optional branches, and they diverge only when `DefaultValue` is null. `TwoSeriesIndicatorFillsFirstSourceFromBars` still asserts the catalog path equals `ToPrs(bars, other, 20)` and is untouched.

## Non-recurrence

`EveryParameterIsRequiredMatchesCallability` was a biconditional — `IsRequired == !IsOmittable` — which cannot separate an argument omittable *into its declared default* from one omittable *only into different behavior*. It now checks four things:

1. a parameter no form of the method omits must be required
2. one C# gives a default must not be required
3. one marked optional with a declared default must actually carry that C# default
4. an advertised default must equal the value C# applies when the argument is omitted

Rule 4 is new coverage: the docs already claimed equality while the helper only checked existence. Zero violations catalog-wide, with numeric comparison so ZIGZAG's `5` vs `5.0` is correctly equal rather than a false positive. VWAP `startDate` stays optional under rule 3 because it declares no default to break — it promises nothing, which is the honest shape for an argument omittable only via a shorter overload.

`WithParamValue(name, null)` now throws immediately naming `WithoutParam`, instead of failing inside reflection with nothing naming the cause. No listing had a reachable success path for a null override, so this narrows *which* exception is thrown, not whether one is.

## Verification

Six mutations, each confirming a check fails on the real defect rather than merely passing on the fix:

| Mutation | Caught by |
| --- | --- |
| executor stops skipping omitted parameters | 3 omission tests |
| trailing-run guard removed | `NonTrailingOmissionIsRejected` |
| PRS reverted to `isRequired: false` | rule 3, naming PRS and the shorter overload |
| BETA reverted to optional | rule 1 |
| ALLIGATOR marked required | rule 2 |
| catalog advertises a default C# does not apply | rule 4, naming both values |
| `IndicatorConfig` drops omissions | 3 config tests |

- `dotnet build --no-incremental -c Release` — 0 errors, 0 new warnings (15 `NU1507` are pre-existing package-source config)
- `dotnet test -c Release` — 2546 / 76 / 4 passing, 0 failed

## Reviewed

Four specialist lanes. Compatibility assessed clean — every public change is additive, and the null rejection removes no reachable success path. The review found one defect I had introduced (`IndicatorConfig` dropping omissions) and one false rationale ("unreachable by overriding"), both fixed here; the rationale is corrected in all five places it appeared.

The executor keeps its own name and series-parameter guards, which two lanes read as unreachable duplicates of the builder's. They are the trust boundary: `IndicatorConfig.ToBuilder` feeds omission names straight from deserialized JSON, which never passed through `WithoutParam`. Two tests exercise that path.
