### PR TITLE
fix: Correct inverted ratio returned by obsolete GetPrs

### DIFF
--- a/docs/migration/v3.md
+++ b/docs/migration/v3.md
@@ -58,6 +58,28 @@ The old `Quote`, `IQuote`, `PeriodSize`, `IReusableResult`, and `BasicData` name
 - **`ToTupleCollection()` utility**: Deprecated
 - **`ToCollection()` utility**: Deprecated
 
+### Corrections to obsolete v2 shims
+
+Defects in the `[Obsolete]` compatibility shims, shipped in `3.0.0` and **corrected in
+`3.0.1`**. Each changes **returned values** for code still calling the v2 method names.
+They are worth correcting even though the shims themselves are removed in `3.1`: `3.0.x`
+is the version you are told to land on before upgrading further, so it has to be right.
+
+These version as bug fixes rather than breaking changes because the shipped behavior
+never matched its own documentation — see the correctness principles on [correcting a
+defect versus changing intended behavior](https://github.com/facioquo/stock-indicators-dotnet/blob/main/docs/PRINCIPLES.md).
+
+- **`GetPrs()` returned the inverted ratio.** In `3.0.0` the shim passed its two series
+  in the wrong order, so it returned `base / eval` — the reciprocal of the ratio
+  [documented for PRS](/indicators/prs). As of `3.0.1` it returns `eval / base`, matching
+  `ToPrs()` and pre-`3.0.0` behavior. **If you called `GetPrs()` on `3.0.x`, stored values and any
+  thresholds tuned against them must be revalidated; new values are the reciprocal of
+  old ones.** Callers of `ToPrs()` were never affected.
+- **`GetPrs()` with no `lookbackPeriods` threw.** The unspecified lookback was mapped to
+  `0`, which validation rejects, so the shim's own default raised
+  `ArgumentOutOfRangeException`. As of `3.0.1` it computes with a null `PrsPercent`, as
+  it did before `3.0.0`.
+
 ### Other changes
 
 - **Indicator method parameters**: v2 generic signatures like `GetSma<TQuote>(this IEnumerable<TQuote>)` are now interface-typed, like `ToSma(this IReadOnlyList<IReusable>)` and `ToFractal(this IReadOnlyList<IBar>)`. Concrete lists (e.g. `List<Bar>`) convert automatically; your own generic wrapper methods need a `class` constraint (see [Step 4](#step-4-update-generic-extension-methods))

--- a/src/Obsolete.V3.Indicators.cs
+++ b/src/Obsolete.V3.Indicators.cs
@@ -680,18 +680,22 @@ public static partial class Indicator
     public static IEnumerable<PrsResult> GetPrs(
     this IEnumerable<IBar> quotesEval,
     IEnumerable<IBar> quotesBase, int? lookbackPeriods = null)
-    => quotesBase.ToSortedList()
-        .ToPrs(quotesEval.ToSortedList(), lookbackPeriods ?? 0);
+    // an unspecified lookback means "compute no PrsPercent", which is the
+    // two-argument overload -- not lookbackPeriods 0, which validation rejects
+    => lookbackPeriods is int periods
+        ? quotesEval.ToSortedList().ToPrs(quotesBase.ToSortedList(), periods)
+        : quotesEval.ToSortedList().ToPrs(quotesBase.ToSortedList());
 
     [ExcludeFromCodeCoverage]
     [Obsolete("Use a chained `results.ToSma(smaPeriods)` for moving averages.", true)]
     public static IEnumerable<PrsResult> GetPrs(
         this IEnumerable<IBar> quotesEval,
         IEnumerable<IBar> quotesBase, int? lookbackPeriods, int? smaPeriods = null)
-        => quotesEval
-            .ToSortedList()
-            .Use(CandlePart.Close)
-            .ToPrs(quotesBase.ToSortedList().Use(CandlePart.Close), lookbackPeriods ?? 0);
+        => lookbackPeriods is int periods
+            ? quotesEval.ToSortedList().Use(CandlePart.Close)
+                .ToPrs(quotesBase.ToSortedList().Use(CandlePart.Close), periods)
+            : quotesEval.ToSortedList().Use(CandlePart.Close)
+                .ToPrs(quotesBase.ToSortedList().Use(CandlePart.Close));
 
     [ExcludeFromCodeCoverage]
     [Obsolete("Use 'ToPrs(..)' method. Tuple arguments were removed.", false)]
@@ -700,11 +704,21 @@ public static partial class Indicator
         IEnumerable<(DateTime d, double v)> tupleBase,
         int lookbackPeriods = 0,
         int smaPeriods = 0)
-        => tupleEval
-            .Select(static t => new TimeValue(t.d, t.v)).ToSortedList()
-            .ToPrs(tupleBase
-                .Select(static t => new TimeValue(t.d, t.v)).ToSortedList(),
-            lookbackPeriods);
+        // v2 declared this int? and treated null as "no PrsPercent"; the 3.0.0 shim
+        // narrowed it to int = 0, so 0 is the only marker left for "unspecified".
+        // Restoring the default therefore also accepts an explicit 0, which v2 rejected
+        // -- the alternative, changing the signature back, would break already-compiled
+        // callers rather than fix them.
+        => lookbackPeriods == 0
+            ? tupleEval
+                .Select(static t => new TimeValue(t.d, t.v)).ToSortedList()
+                .ToPrs(tupleBase
+                    .Select(static t => new TimeValue(t.d, t.v)).ToSortedList())
+            : tupleEval
+                .Select(static t => new TimeValue(t.d, t.v)).ToSortedList()
+                .ToPrs(tupleBase
+                    .Select(static t => new TimeValue(t.d, t.v)).ToSortedList(),
+                lookbackPeriods);
 
     [ExcludeFromCodeCoverage]
     [Obsolete("Rename `GetPvo(..)` to `ToPvo(..)`", false)]

--- a/tests/Library/Indicators/k-q/Prs/PrsObsoleteShimTests.cs
+++ b/tests/Library/Indicators/k-q/Prs/PrsObsoleteShimTests.cs
@@ -1,0 +1,195 @@
+using System.Reflection;
+
+namespace StaticSeries;
+
+/// <summary>
+/// Tests for the obsolete v3 <c>GetPrs</c> shims, which must return what the pre-3.0.0
+/// API returned.
+/// </summary>
+/// <remarks>
+/// The shim exists only to keep v2 code working, so "matches <c>ToPrs</c>" is its whole
+/// contract. Two defects shipped in 3.0.0 and survived because nothing here called it:
+/// the evaluated and base series were passed in the wrong order, so every result was the
+/// reciprocal of the ratio; and an unspecified lookback mapped to <c>0</c>, which
+/// validation rejects, so the documented default threw instead of computing.
+/// </remarks>
+[TestClass]
+public class PrsObsoleteShimTests : TestBaseWithPrecision
+{
+    [TestMethod]
+    public void GetPrsMatchesToPrsRatioDirection()
+    {
+        const int lookbackPeriods = 20;
+
+#pragma warning disable CS0618 // exercising the obsolete shim is the point
+        IReadOnlyList<PrsResult> shim
+            = Bars.GetPrs(OtherBars, lookbackPeriods).ToList();
+#pragma warning restore CS0618
+
+        IReadOnlyList<PrsResult> expected
+            = ((IReadOnlyList<IReusable>)Bars).ToPrs(OtherBars, lookbackPeriods);
+
+        shim.Select(static r => r.Prs).Should().Equal(expected.Select(static r => r.Prs),
+            "GetPrs(quotesEval, quotesBase) evaluates the first series against the second, as it did before 3.0.0");
+
+        shim.Select(static r => r.PrsPercent).Should().Equal(expected.Select(static r => r.PrsPercent));
+    }
+
+    [TestMethod]
+    public void GetPrsIsNotTheInvertedRatio()
+    {
+        // guards the specific 3.0.0 regression: the arguments were swapped, so every
+        // value came back as the reciprocal
+        const int lookbackPeriods = 20;
+
+#pragma warning disable CS0618
+        List<PrsResult> shimResults = Bars.GetPrs(OtherBars, lookbackPeriods).ToList();
+        double shim = shimResults[^1].Prs!.Value;
+#pragma warning restore CS0618
+
+        IReadOnlyList<PrsResult> invertedResults
+            = ((IReadOnlyList<IReusable>)OtherBars).ToPrs(Bars, lookbackPeriods);
+        double inverted = invertedResults[^1].Prs!.Value;
+
+        shim.Should().BeApproximately(1 / inverted, Money6);
+    }
+
+    [TestMethod]
+    public void GetPrsWithUnspecifiedLookbackComputesWithoutPercent()
+    {
+        // the shim's own default: v2 treated it as "no PrsPercent", not as an error
+#pragma warning disable CS0618
+        IReadOnlyList<PrsResult> shim = Bars.GetPrs(OtherBars).ToList();
+#pragma warning restore CS0618
+
+        IReadOnlyList<PrsResult> expected
+            = ((IReadOnlyList<IReusable>)Bars).ToPrs(OtherBars);
+
+        shim.Should().HaveCount(expected.Count);
+        shim.Select(static r => r.Prs).Should().Equal(expected.Select(static r => r.Prs));
+        shim.Should().OnlyContain(static r => r.PrsPercent == null);
+    }
+
+    [TestMethod]
+    public void GetPrsFromTuplesMatchesToPrs()
+    {
+        IEnumerable<(DateTime d, double v)> evalTuples
+            = Bars.Select(static b => (b.Timestamp, (double)b.Close));
+
+        IEnumerable<(DateTime d, double v)> baseTuples
+            = OtherBars.Select(static b => (b.Timestamp, (double)b.Close));
+
+#pragma warning disable CS0618
+        IReadOnlyList<PrsResult> shim = evalTuples.GetPrs(baseTuples, 20).ToList();
+#pragma warning restore CS0618
+
+        IReadOnlyList<PrsResult> expected
+            = ((IReadOnlyList<IReusable>)Bars).ToPrs(OtherBars, 20);
+
+        shim.Select(static r => r.Prs).Should().Equal(expected.Select(static r => r.Prs));
+    }
+
+    [TestMethod]
+    public void GetPrsFromTuplesWithUnspecifiedLookbackComputesWithoutPercent()
+    {
+        IEnumerable<(DateTime d, double v)> evalTuples
+            = Bars.Select(static b => (b.Timestamp, (double)b.Close));
+
+        IEnumerable<(DateTime d, double v)> baseTuples
+            = OtherBars.Select(static b => (b.Timestamp, (double)b.Close));
+
+#pragma warning disable CS0618
+        IReadOnlyList<PrsResult> shim = evalTuples.GetPrs(baseTuples).ToList();
+#pragma warning restore CS0618
+
+        IReadOnlyList<PrsResult> expected
+            = ((IReadOnlyList<IReusable>)Bars).ToPrs(OtherBars);
+
+        shim.Should().HaveCount(Bars.Count);
+        shim.Select(static r => r.Prs).Should().Equal(expected.Select(static r => r.Prs));
+        shim.Should().OnlyContain(static r => r.PrsPercent == null);
+    }
+
+    [TestMethod]
+    public void GetPrsMatchesKnownValues()
+    {
+        // every other test here compares the shim against ToPrs, so a co-regression in
+        // ToPrs would move both sides together; these anchor the shim to absolute values
+        const int lookbackPeriods = 30;
+
+#pragma warning disable CS0618
+        List<PrsResult> shim = Bars.GetPrs(OtherBars, lookbackPeriods).ToList();
+#pragma warning restore CS0618
+
+        shim.Should().HaveCount(502);
+        shim[8].Prs.Should().BeApproximately(0.902250, Money6);
+        shim[249].Prs.Should().BeApproximately(0.818081, Money6);
+        shim[249].PrsPercent.Should().BeApproximately(0.023089, Money6);
+        shim[501].Prs.Should().BeApproximately(0.737019, Money6);
+        shim[501].PrsPercent.Should().BeApproximately(-0.037082, Money6);
+    }
+
+    [TestMethod]
+    public void GetPrsRejectsAnExplicitZeroLookback()
+    {
+        // v2 rejected <= 0; null was the "no PrsPercent" marker, not 0. This overload
+        // still distinguishes the two, so an explicit 0 stays an error.
+#pragma warning disable CS0618
+        Action act = () => _ = Bars.GetPrs(OtherBars, 0).ToList();
+#pragma warning restore CS0618
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [TestMethod]
+    public void GetPrsRejectsANegativeLookback()
+    {
+#pragma warning disable CS0618
+        Action act = () => _ = Bars.GetPrs(OtherBars, -5).ToList();
+#pragma warning restore CS0618
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [TestMethod]
+    public void GetPrsFromTuplesTreatsZeroAsUnspecified()
+    {
+        // pins the one place this shim knowingly diverges from v2, which rejected an
+        // explicit 0: the 3.0.0 signature narrowed int? to int = 0, leaving 0 as the
+        // only marker for "unspecified", and restoring the default has to honor it
+        IEnumerable<(DateTime d, double v)> evalTuples
+            = Bars.Select(static b => (b.Timestamp, (double)b.Close));
+
+        IEnumerable<(DateTime d, double v)> baseTuples
+            = OtherBars.Select(static b => (b.Timestamp, (double)b.Close));
+
+#pragma warning disable CS0618
+        List<PrsResult> shim = evalTuples.GetPrs(baseTuples, 0).ToList();
+#pragma warning restore CS0618
+
+        shim.Should().HaveCount(Bars.Count);
+        shim.Should().OnlyContain(static r => r.PrsPercent == null);
+    }
+
+    [TestMethod]
+    public void ErrorLevelGetPrsOverloadAppliesTheSameLookbackMapping()
+    {
+        // the four-argument overload is Obsolete(.., true), so C# cannot call it at all
+        // and CS0619 is not suppressible -- but reflection reaches it, and it carried
+        // the same defective mapping, so it is verified the only way it can be
+        MethodInfo overload = typeof(Prs).Assembly
+            .GetType("FacioQuo.Stock.Indicators.Indicator")
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Single(m => m.Name == "GetPrs"
+                      && m.GetParameters().Length == 4
+                      && m.GetParameters()[0].ParameterType == typeof(IEnumerable<IBar>));
+
+        object raw = overload.Invoke(null, [Bars, OtherBars, null, null]);
+        List<PrsResult> shim = ((IEnumerable<PrsResult>)raw).ToList();
+
+        shim.Should().HaveCount(Bars.Count);
+        shim.Should().OnlyContain(static r => r.PrsPercent == null,
+            "an unspecified lookback must compute no percent rather than throw");
+        shim[^1].Prs.Should().BeApproximately(0.737019, Money6);
+    }
+}


### PR DESCRIPTION
Closes #2208.

> [!IMPORTANT]
> **Returned values change for code still calling `GetPrs`.** In 3.0.0 it returned `base / eval` — the reciprocal of the ratio this library documents. It now returns `eval / base`. If you called `GetPrs` on 3.0.x, stored values and any thresholds tuned against them must be revalidated; new values are the reciprocal of old ones. **Callers of `ToPrs` were never affected.**
>
> Separately, `GetPrs(eval, base)` with no `lookbackPeriods` previously threw `ArgumentOutOfRangeException` and now computes with a null `PrsPercent`, as it did before 3.0.0.

## The defects

**Inverted ratio.** The receiver of `.ToPrs(..)` binds to `sourceEval`, and the shim passed `quotesBase` there ([`Obsolete.V3.Indicators.cs:683-684`](https://github.com/facioquo/stock-indicators-dotnet/blob/main/src/Obsolete.V3.Indicators.cs#L683-L684) on main). Measured on the repo's test data:

```
GetPrs(eval, base, 20)  = 1.3568166993
ToPrs(eval, base, 20)   = 0.7370192308     <- correct
ToPrs(base, eval, 20)   = 1.3568166993     <- what the shim returned
shim == 1 / correct      : True
```

**Unusable default.** `lookbackPeriods` was mapped to `0`, which `Prs.Utilities.cs:28` rejects (`is <= 0 and not int.MinValue`), so the shim's own documented default threw.

## Why this is a bug fix, not a behavior change

This restores what the method returned before 3.0.0. It does not choose new behavior.

Before the 3.0.0 rewrite, all three `GetPrs` overloads called `CalcPrs(tpListEval, tpListBase, …)` — eval first — and `CalcPrs` computed `Prs = (bValue == 0) ? null : (eValue / bValue)`, with `eValue` from `tpListEval`. (`src/m-r/Prs/Prs.Api.cs` and `src/m-r/Prs/Prs.Series.cs` at `896ae089^`.) So V2 returned eval ÷ base, and a caller who upgraded to 3.0.0 without changing a line silently began receiving the reciprocal.

Three further corroborations:

- [`docs/indicators/prs.md`](https://github.com/facioquo/stock-indicators-dotnet/blob/main/docs/indicators/prs.md) defines `Prs` as `Eval / Base`, with a worked example
- the shim's own attribute reads `"Rename GetPrs(..) to ToPrs(..)"`, and a *rename* asserts identical semantics — it cannot carry a deliberate redefinition
- the sibling `GetBeta` and `GetCorrelation` shims order their arguments correctly, so this is an isolated slip rather than a pattern

The likely mechanism is visible in the V2 source: it *declared* `tpListBase` before `tpListEval` but *passed* eval first, and the shim appears to have transcribed declaration order into call order.

### The counter-argument, and why it was dismissed

A consumer on 3.0.0 since June may have unknowingly built on the reciprocal, and their numbers move. That was weighed and rejected:

- the values contradicted the library's own published formula, so no consumer could have validated them against the documentation and concluded they were right
- `[Obsolete]` means the method's entire contract is "behaves as V2 did" — the reciprocal is not a behavior anyone chose
- gating on a major version would mean knowingly shipping wrong numbers for the shim's remaining life, which is the worse trade

This is exactly the case #2215 added to `docs/PRINCIPLES.md`: correcting a defect, where the shipped behavior never matched its own documentation, is a bug fix and versions as one. It lands in **3.0.1**. The disclosure obligation still applies in full — the callout above and the new **Corrections to obsolete v2 shims** section in `docs/migration/v3.md` name the affected method, the observable change in output, and the version it lands in.

Worth noting these shims are themselves removed in `3.1`. Correcting them still matters, because `3.0.x` is the version the migration guide tells users to land on before upgrading further — so it has to be right.

## Implementation note

The unspecified lookback now calls the two-argument `ToPrs` overload, which is the library's own public expression of "compute no `PrsPercent`", rather than replicating that overload's internal `int.MinValue` sentinel in the shim. If the sentinel ever changes, the shim follows automatically.

The tuple overload knowingly diverges from V2 on one point: it also accepts an explicit `0`, which V2 rejected. The 3.0.0 signature narrowed V2's `int?` to `int = 0`, so `0` is the only marker left for "unspecified", and restoring the default has to honor it. Restoring the `int?` signature instead would break already-compiled callers rather than fix them. Pinned by `GetPrsFromTuplesTreatsZeroAsUnspecified`.

## Tests

These are the **first tests to call `GetPrs` at all**. No test anywhere referenced it and every overload carries `[ExcludeFromCodeCoverage]` — that is why two defects survived a major release.

Ten tests, including absolute anchored values so a co-regression in `ToPrs` cannot pass unnoticed (every other assertion compares the shim *against* `ToPrs`, so both sides would move together), explicit-`0` and negative-lookback pins, and a reflection test for the `Obsolete(.., true)` overload — C# cannot call it and `CS0619` is not suppressible, so reflection is the only way it can be verified.

Mutation-verified:

| Mutation | Result |
| --- | --- |
| re-invert the reachable overload | 4 of 10 fail |
| unspecified lookback back to `0` | `GetPrsWithUnspecifiedLookbackComputesWithoutPercent` fails |
| break the reflection-only overload | `ErrorLevelGetPrsOverloadAppliesTheSameLookbackMapping` fails |

- `dotnet build --no-incremental -c Release` — 0 errors, 0 new warnings (15 `NU1507` are pre-existing package-source config)
- `dotnet test -c Release` — 2542 / 76 / 4 passing, 0 failed

## Reviewed

Three specialist lanes. The restoration claim was independently verified against the V2 source by two of them. Review changed the implementation (dropping a private sentinel constant in favor of the two-argument overload), added four tests, and struck a rationale of mine that was factually wrong — I had argued the `Obsolete(.., true)` site was worth patching because `CS0619` is suppressible; it is not. The site is still worth patching because reflection reaches it, which the new test demonstrates.

**A second, worse defect of the same class is out of scope here and not yet filed:** `GetPvo`'s shim declares `fastPeriods = 9, slowPeriods = 12` where both V2 and `ToPvo` declare `12` and `26`. `bars.GetPvo()` returns `1.4387` against a correct `10.4395` — silently, with no exception. Raised for routing rather than folded in, since it needs its own tracked record.


