### PR TITLE
fix: Correct wrong default periods in obsolete GetPvo

### DIFF
--- a/docs/migration/v3.md
+++ b/docs/migration/v3.md
@@ -75,6 +75,12 @@ defect versus changing intended behavior](https://github.com/facioquo/stock-indi
   `ToPrs()` and pre-`3.0.0` behavior. **If you called `GetPrs()` on `3.0.x`, stored values and any
   thresholds tuned against them must be revalidated; new values are the reciprocal of
   old ones.** Callers of `ToPrs()` were never affected.
+- **`GetPvo()` used the wrong default periods.** The shim declared
+  `fastPeriods: 9, slowPeriods: 12` where both v2 and `ToPvo()` declare `12` and `26`,
+  so calling `GetPvo()` with no arguments silently computed a differently-parameterized
+  PVO. Corrected in `3.0.1`. **If you called `GetPvo()` without explicit periods on `3.0.x`, stored values
+  must be revalidated.** Callers who passed explicit periods, and callers of `ToPvo()`,
+  were never affected.
 - **`GetPrs()` with no `lookbackPeriods` threw.** The unspecified lookback was mapped to
   `0`, which validation rejects, so the shim's own default raised
   `ArgumentOutOfRangeException`. As of `3.0.1` it computes with a null `PrsPercent`, as

--- a/src/Obsolete.V3.Indicators.cs
+++ b/src/Obsolete.V3.Indicators.cs
@@ -724,7 +724,7 @@ public static partial class Indicator
     [Obsolete("Rename `GetPvo(..)` to `ToPvo(..)`", false)]
     public static IEnumerable<PvoResult> GetPvo(
         this IEnumerable<IBar> bars,
-        int fastPeriods = 9, int slowPeriods = 12, int signalPeriods = 9)
+        int fastPeriods = 12, int slowPeriods = 26, int signalPeriods = 9)
         => bars.ToSortedList().ToPvo(fastPeriods, slowPeriods, signalPeriods);
 
     [ExcludeFromCodeCoverage]

--- a/tests/Library/Indicators/k-q/Pvo/PvoObsoleteShimTests.cs
+++ b/tests/Library/Indicators/k-q/Pvo/PvoObsoleteShimTests.cs
@@ -1,0 +1,69 @@
+namespace StaticSeries;
+
+/// <summary>
+/// Tests for the obsolete v3 <c>GetPvo</c> shim, which must return what the pre-3.0.0
+/// API returned.
+/// </summary>
+/// <remarks>
+/// The shim declared <c>9, 12, 9</c> where both v2 and <c>ToPvo</c> declare
+/// <c>12, 26, 9</c> — the correct values shifted one position. Calling the documented
+/// default therefore computed a different indicator, silently: the result is a
+/// well-formed PVO, just not the one asked for. Nothing here called the shim, so
+/// nothing caught it.
+/// </remarks>
+[TestClass]
+public class PvoObsoleteShimTests : TestBaseWithPrecision
+{
+    [TestMethod]
+    public void GetPvoDefaultsMatchToPvo()
+    {
+#pragma warning disable CS0618 // exercising the obsolete shim is the point
+        List<PvoResult> shim = Bars.GetPvo().ToList();
+#pragma warning restore CS0618
+
+        IReadOnlyList<PvoResult> expected = Bars.ToPvo();
+
+        shim.Should().HaveCount(expected.Count);
+        shim.Select(static r => r.Pvo).Should().Equal(expected.Select(static r => r.Pvo));
+        shim.Select(static r => r.Signal).Should().Equal(expected.Select(static r => r.Signal));
+        shim.Select(static r => r.Histogram).Should().Equal(expected.Select(static r => r.Histogram));
+    }
+
+    [TestMethod]
+    public void GetPvoDefaultsAreNotTheShiftedPeriods()
+    {
+        // guards the specific 3.0.0 regression: the shim declared 9, 12, 9
+#pragma warning disable CS0618
+        List<PvoResult> shim = Bars.GetPvo().ToList();
+#pragma warning restore CS0618
+
+        IReadOnlyList<PvoResult> shifted = Bars.ToPvo(9, 12, 9);
+
+        shim[^1].Pvo.Should().NotBeApproximately(shifted[^1].Pvo!.Value, Money6);
+    }
+
+    [TestMethod]
+    public void GetPvoMatchesKnownValues()
+    {
+        // anchors the shim to absolute values, so a co-regression in ToPvo cannot
+        // move both sides of the comparison above and pass unnoticed
+#pragma warning disable CS0618
+        List<PvoResult> shim = Bars.GetPvo().ToList();
+#pragma warning restore CS0618
+
+        shim.Should().HaveCount(502);
+        shim[501].Pvo.Should().BeApproximately(10.439509, Money6);
+    }
+
+    [TestMethod]
+    public void GetPvoWithExplicitPeriodsMatchesToPvo()
+    {
+#pragma warning disable CS0618
+        List<PvoResult> shim = Bars.GetPvo(10, 20, 7).ToList();
+#pragma warning restore CS0618
+
+        IReadOnlyList<PvoResult> expected = Bars.ToPvo(10, 20, 7);
+
+        shim.Select(static r => r.Pvo).Should().Equal(expected.Select(static r => r.Pvo));
+    }
+}


### PR DESCRIPTION
Closes #2211.

> [!IMPORTANT]
> **Returned values change for callers who used `GetPvo()` without explicit periods.** The shim used `fastPeriods: 9, slowPeriods: 12` where both v2 and `ToPvo()` use `12` and `26`, so the documented default computed a differently-parameterized PVO. If you called `GetPvo()` with no arguments on 3.0.x, stored values must be revalidated. **Callers who passed explicit periods, and callers of `ToPvo()`, were never affected.**

> [!NOTE]
> Stacked on #2210 — both add entries to the same new *Corrections to obsolete v2 shims* section in `docs/migration/v3.md`, and basing this on `main` would have produced a merge conflict there. Retarget to `main` once #2210 lands. The code changes are independent.

## The defect

[`src/Obsolete.V3.Indicators.cs:715-719`](https://github.com/facioquo/stock-indicators-dotnet/blob/main/src/Obsolete.V3.Indicators.cs#L715-L719) declared `9, 12, 9` — the correct values shifted one position left:

| Source | fastPeriods | slowPeriods | signalPeriods |
| --- | --- | --- | --- |
| v2 `GetPvo` (`src/m-r/Pvo/Pvo.Api.cs:9-13` @ `896ae089^`) | 12 | 26 | 9 |
| v3 `ToPvo` | 12 | 26 | 9 |
| v3 `GetPvo` shim | **9** | **12** | 9 |

Measured on the repo's test data:

```
GetPvo()      [501].Pvo = 1.4387350287
ToPvo()       [501].Pvo = 10.4395089356
ToPvo(9,12,9) [501].Pvo = 1.4387350287
shim == ToPvo(9,12,9) : True
shim == ToPvo()       : False
```

## Why this is a bug fix, not a behavior change

Same reasoning as #2210, and simpler here: v2 and the v3 target agree on `12, 26, 9`, so the shim is returned to the values it was written to preserve. The `[Obsolete]` message reads `"Rename GetPvo(..) to ToPvo(..)"`, and a rename asserts identical semantics — it cannot carry a redefinition of the defaults.

This one is in some ways worse than #2210's reciprocal: that defect at least produced a value with a recognizable relationship to the correct one, and threw outright on its documented default. This returns a plausible, well-formed PVO that is simply the wrong indicator, with nothing in the result to signal it.

## Tests

The first tests to call `GetPvo`. As in #2210 they include an absolute anchored value, because every other assertion compares the shim *against* `ToPvo` — a co-regression there would move both sides together and pass. Also pins that the shifted `9, 12, 9` periods are no longer what the default produces, and that explicit periods still pass through unchanged.

- `dotnet build --no-incremental -c Release` — 0 errors, 0 new warnings (15 `NU1507` are pre-existing package-source config)
- `dotnet test -c Release` — 2546 / 76 / 4 passing, 0 failed

## Context

Third defect found in this shim layer, after #2208 (inverted ratio, fixed in #2210) and alongside #2212 (compile break) and #2213 (silently discarded argument). The common root cause is that all 135 shims carry `[ExcludeFromCodeCoverage]` and, until #2210, none had a single test caller — so no gate could see any of this. A systematic audit of the layer against the v2 signatures is worth scoping separately.
