### PR TITLE
docs: Distinguish correcting a defect from changing intended behavior

### DIFF
--- a/docs/PRINCIPLES.md
+++ b/docs/PRINCIPLES.md
@@ -15,7 +15,10 @@ All indicators MUST be mathematically correct, deterministic, and reproducible a
 - Results MUST match validated reference data (published examples, academic definitions, or vetted calculators).
 - All implementation styles (Series/batch, BufferList/streaming, StreamHub/streaming) MUST produce bit-for-bit identical final values for deterministic calculations; Series serves as the validated baseline and streaming implementations must match it precisely.
 - Any new indicator requires a written spec (math definition + parameter constraints) before implementation.
-- Breaking mathematical behavior changes require a MAJOR library version bump and release note callout.
+- Changing *intended* mathematical behavior — replacing a formula, redefining a parameter, or altering a documented default that was correct as specified — requires a MAJOR library version bump.
+- Correcting a *defect* — where the shipped behavior never matched its own documentation, specification, or reference data — is a bug fix, and versions as one. Restoring the specified behavior is not a breaking change to it.
+- Both require a release note callout naming the affected indicator, the observable change in output, and the version it lands in. The version bump distinguishes the two cases; the disclosure obligation does not.
+- When it is genuinely unclear whether behavior was intended or defective, treat it as intended and bump MAJOR. The ambiguity itself should be resolved in the indicator's documentation so the next occurrence is not ambiguous.
 
 **Formula sourcing hierarchy:**
 


### PR DESCRIPTION
Principle 1 required *"a MAJOR library version bump and release note callout"* for **"breaking mathematical behavior changes"**. Read literally, that makes **every numerical bug fix a major release** — correcting a wrong number changes mathematical output. The repository has never worked that way.

## This reconciles a contradiction rather than loosening a rule

The repo's two canonical version rules currently give **opposite answers for the same commit**:

| Document | Says |
| --- | --- |
| `docs/CONTRIBUTING.md` (Versioning table) | `Patch` — "Bug fixes, documentation" |
| `docs/PRINCIPLES.md:18` (before this PR) | `MAJOR` — "breaking mathematical behavior changes" |

A numerical bug fix is simultaneously a bug fix *and* a change in mathematical behavior, so both rules apply and they disagree. The distinction is also already present elsewhere in this document — principle 4 requires that *"Bug fixes MUST add regression test proving defect and fix"*, which treats defects as their own class. Principle 1 simply didn't carry it.

## The rule

The question is whether the shipped behavior was ever the **intended** behavior.

- **Changing intended behavior** — replacing a formula, redefining a parameter, altering a documented default that was correct as specified — changes a promise the library made. MAJOR.
- **Correcting a defect** — where shipped behavior never matched its own documentation, specification, or reference data — doesn't change that promise, it delivers it. Versions as the bug fix it is.
- **Both owe a release note**, now made more specific: affected indicator, observable change in output, landing version. The version bump distinguishes the two cases; the disclosure obligation does not.
- **Ambiguity resolves toward MAJOR**, with the ambiguity to be settled in the indicator's documentation so the next occurrence isn't ambiguous.

## Evidence: four v3 shim defects

- **#2208** — `GetPrs` returns the **reciprocal** of the correct ratio, and its default lookback throws
- **#2211** — `GetPvo` ships **wrong default periods**, silently computing a different indicator than the one requested
- **#2212** — `GetKeltner` narrows its multiplier to `int`, breaking compilation of the v2 code the shim exists to support
- **#2213** — tuple `GetPrs` and `GetRoc` **silently discard** `smaPeriods`, while the bar overloads reject it

None of these is behavior anyone chose; they are shims failing to honor the signature they publish. Under the previous wording, the in-flight fixes **#2210** and **#2214** would each force a major release — meaning **a compatibility shim could only be repaired by breaking compatibility**.

## Deliberately out of scope

**#2212 and #2213 fall outside this wording and need their own treatment.** Neither is a mathematical defect — #2212 is a compile-time API narrowing, #2213 a silently discarded parameter. This rule governs mathematical behavior only, and the shim surface can break in ways that aren't mathematical. That gap is real, but stretching this amendment to cover it would make the rule about two different things at once; it deserves a separate decision.

## Discarded alternative

Define the split by **output magnitude** — a tolerance below which a correction is a patch. Rejected: it makes the version bump depend on the size of the error rather than on whether a promise changed, and a small wrong number is exactly as wrong as a large one. The reciprocal in #2208 would land on either side of such a threshold depending on the input.

## Verification

`markdownlint-cli2` — 0 issues across 183 files. The rule appears in exactly one file org-wide (verified by code search), so no mirrored copy needs a paired edit.