### PR TITLE
docs: Remove arbitrary line breaks in markdown prose

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -82,12 +82,9 @@ When reviewing PRs with baseline changes, verify the reason is documented, revie
 
 ### Performance benchmarking
 
-Performance (timing) benchmarks run through one script: `tools/performance/perf.sh`.
-Copy/paste these exact commands — run them from the repository root. Do not add
-options; the defaults keep runs comparable to the committed baselines.
+Performance (timing) benchmarks run through one script: `tools/performance/perf.sh`. Copy/paste these exact commands — run them from the repository root. Do not add options; the defaults keep runs comparable to the committed baselines.
 
-Requirements: .NET SDK and [`jq`](https://jqlang.github.io/jq/) (for `evaluate`
-and `spot`).
+Requirements: .NET SDK and [`jq`](https://jqlang.github.io/jq/) (for `evaluate` and `spot`).
 
 ```bash
 # Check one indicator against the baselines (fast — use this in your dev loop)
@@ -100,15 +97,11 @@ bash tools/performance/perf.sh evaluate
 bash tools/performance/perf.sh reset
 ```
 
-That is everything most contributors need. For the baseline set, single-style spot
-checks, CI workflows, and raw BenchmarkDotNet usage, see the
-[benchmarking guide](https://github.com/facioquo/stock-indicators-dotnet/blob/main/tools/performance/benchmarking.md).
+That is everything most contributors need. For the baseline set, single-style spot checks, CI workflows, and raw BenchmarkDotNet usage, see the [benchmarking guide](https://github.com/facioquo/stock-indicators-dotnet/blob/main/tools/performance/benchmarking.md).
 
 ## Documentation
 
-This site uses [VitePress](https://vitepress.dev) with Vue components and Markdown.
-Our documentation site code is in the `docs` folder.
-Build the site locally to test that it works properly.
+This site uses [VitePress](https://vitepress.dev) with Vue components and Markdown. Our documentation site code is in the `docs` folder. Build the site locally to test that it works properly.
 
 ```bash
 # one-time: grant your gh CLI token read:packages access
@@ -282,5 +275,4 @@ This repository uses a standard Apache 2.0 open-source license.  It enables open
 
 [Start a new discussion](https://github.com/facioquo/stock-indicators-dotnet/discussions) or [submit an issue](https://github.com/facioquo/stock-indicators-dotnet/issues) if it is publicly relevant.  You can also direct message [@daveskender](https://twitter.com/messages/compose?recipient_id=27475431).
 
-Thanks,
-Dave Skender
+Thanks, Dave Skender

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -17,9 +17,7 @@ For more information on how to use this library overall, see the [Guide](/guide/
 
 ## Getting started with our sample projects
 
-We use an external API quote source for our **streaming** and **quote API** examples.  If you intend to run those locally, you'll need to
-[get a free Alpaca API key and secret](https://docs.alpaca.markets/),
-then set your local environment variables.
+We use an external API quote source for our **streaming** and **quote API** examples.  If you intend to run those locally, you'll need to [get a free Alpaca API key and secret](https://docs.alpaca.markets/), then set your local environment variables.
 
 Run the following command line items to set, after replacing the `MY-ALPACA-KEY` and `MY-ALPACA-SECRET` values; then restart your IDE.
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -104,8 +104,7 @@ You must provide historical price bars to the library in the standard OHLCV `IRe
 ### Where can I get historical bar data?
 
 ::: info BYOD: bring your own data
-You must get price bar data from your own provider.
-_The `GetBarsFromFeed()` method shown in our examples represents your own acquisition of price data and **is not part of this library**._
+You must get price bar data from your own provider. _The `GetBarsFromFeed()` method shown in our examples represents your own acquisition of price data and **is not part of this library**._
 :::
 
 There are many places to get financial market data.  Check with your brokerage or other commercial sites.  If you're looking for a free developer API, see our ongoing [discussion on market data](https://github.com/facioquo/stock-indicators-dotnet/discussions/579) for ideas.
@@ -164,8 +163,7 @@ When implementing your custom bar type, it must be either `record` class or impl
 
 ## Chaining indicators
 
-If you want to compute an indicator of indicators, such as an SMA of an ADX or an [RSI of an OBV](https://medium.com/@robswc/this-is-what-happens-when-you-combine-the-obv-and-rsi-indicators-6616d991773d), use _**chaining**_ to calculate an indicator from prior results.
-Example:
+If you want to compute an indicator of indicators, such as an SMA of an ADX or an [RSI of an OBV](https://medium.com/@robswc/this-is-what-happens-when-you-combine-the-obv-and-rsi-indicators-6616d991773d), use _**chaining**_ to calculate an indicator from prior results. Example:
 
 ```csharp
 // fetch historical price bars from your feed (your method)

--- a/docs/indicators/beta.md
+++ b/docs/indicators/beta.md
@@ -5,8 +5,7 @@ description: Beta coefficient with Beta+/Beta- shows how strongly one asset's pr
 
 # Beta coefficient (β)
 
-[Beta](https://en.wikipedia.org/wiki/Beta_(finance)) shows how strongly one asset's price responds to systemic volatility of the entire market. Beta measures an asset's non-diversifiable systematic risk — its market exposure — not its idiosyncratic, asset-specific risk. [Upside Beta](https://en.wikipedia.org/wiki/Upside_beta) (Beta+) and [Downside Beta](https://en.wikipedia.org/wiki/Downside_beta) (Beta-), [popularized by Harry M. Markowitz](https://www.jstor.org/stable/j.ctt1bh4c8h), are also included.  Beta+ and Beta- capture asymmetric sensitivity during rising and falling markets.
-[[Discuss] &#128172;](https://github.com/facioquo/stock-indicators-dotnet/discussions/268 "Community discussion about this indicator")
+[Beta](https://en.wikipedia.org/wiki/Beta_(finance)) shows how strongly one asset's price responds to systemic volatility of the entire market. Beta measures an asset's non-diversifiable systematic risk — its market exposure — not its idiosyncratic, asset-specific risk. [Upside Beta](https://en.wikipedia.org/wiki/Upside_beta) (Beta+) and [Downside Beta](https://en.wikipedia.org/wiki/Downside_beta) (Beta-), [popularized by Harry M. Markowitz](https://www.jstor.org/stable/j.ctt1bh4c8h), are also included.  Beta+ and Beta- capture asymmetric sensitivity during rising and falling markets. [[Discuss] &#128172;](https://github.com/facioquo/stock-indicators-dotnet/discussions/268 "Community discussion about this indicator")
 
 <ClientOnly>
   <StockIndicatorChart indicator="Beta" withOverlay />
@@ -109,6 +108,4 @@ See [Chaining indicators](/guide/chaining) for more.
 
 ## Streaming
 
-Streaming is not supported for this indicator.
-This indicator requires a second synchronized bar series, which cannot be expressed in the single-series streaming model.
-Use the Series (batch) implementation with periodic recalculation instead.
+Streaming is not supported for this indicator. This indicator requires a second synchronized bar series, which cannot be expressed in the single-series streaming model. Use the Series (batch) implementation with periodic recalculation instead.

--- a/docs/indicators/correlation.md
+++ b/docs/indicators/correlation.md
@@ -5,8 +5,7 @@ description: Created by Karl Pearson, the correlation coefficient depicts the li
 
 # Correlation coefficient
 
-Created by Karl Pearson, the [Correlation coefficient](https://en.wikipedia.org/wiki/Correlation_coefficient) depicts the linear statistical correlation between two price bar histories; includes R-squared (R²) / coefficient of determination, variance, and covariance.
-[[Discuss] &#128172;](https://github.com/facioquo/stock-indicators-dotnet/discussions/259 "Community discussion about this indicator")
+Created by Karl Pearson, the [Correlation coefficient](https://en.wikipedia.org/wiki/Correlation_coefficient) depicts the linear statistical correlation between two price bar histories; includes R-squared (R²) / coefficient of determination, variance, and covariance. [[Discuss] &#128172;](https://github.com/facioquo/stock-indicators-dotnet/discussions/259 "Community discussion about this indicator")
 
 ```csharp
 // C# usage syntax
@@ -87,6 +86,4 @@ See [Chaining indicators](/guide/chaining) for more.
 
 ## Streaming
 
-Streaming is not supported for this indicator.
-This indicator requires a second synchronized bar series, which cannot be expressed in the single-series streaming model.
-Use the Series (batch) implementation with periodic recalculation instead.
+Streaming is not supported for this indicator. This indicator requires a second synchronized bar series, which cannot be expressed in the single-series streaming model. Use the Series (batch) implementation with periodic recalculation instead.

--- a/docs/indicators/gator.md
+++ b/docs/indicators/gator.md
@@ -5,8 +5,7 @@ description: Created by Bill Williams, the Gator Oscillator is an expanded oscil
 
 # Gator Oscillator
 
-Created by Bill Williams, the Gator Oscillator is an expanded oscillator view of [Williams Alligator](/indicators/alligator)'s three moving averages.
-[[Discuss] &#128172;](https://github.com/facioquo/stock-indicators-dotnet/discussions/385 "Community discussion about this indicator")
+Created by Bill Williams, the Gator Oscillator is an expanded oscillator view of [Williams Alligator](/indicators/alligator)'s three moving averages. [[Discuss] &#128172;](https://github.com/facioquo/stock-indicators-dotnet/discussions/385 "Community discussion about this indicator")
 
 <ClientOnly>
   <StockIndicatorChart indicator="Gator" withOverlay />
@@ -109,9 +108,7 @@ IReadOnlyList<GatorResult> results = observer.Results;
 ```
 
 ::: info Compound hub
-The Gator hub is based on the Alligator indicator.
-When the Gator hub is chained from an existing `AlligatorHub` instance it will reuse the existing Alligator hub values rather than creating its own internal Alligator calculations.
-**This is not a normal chaining model.**
+The Gator hub is based on the Alligator indicator. When the Gator hub is chained from an existing `AlligatorHub` instance it will reuse the existing Alligator hub values rather than creating its own internal Alligator calculations. **This is not a normal chaining model.**
 
 ```csharp
 // creates an internal Alligator hub

--- a/docs/indicators/prs.md
+++ b/docs/indicators/prs.md
@@ -5,8 +5,7 @@ description: Price Relative Strength, also called Comparative Relative Strength,
 
 # Price Relative Strength (PRS)
 
-[Price Relative Strength (PRS)](https://en.wikipedia.org/wiki/Relative_strength), also called Comparative Relative Strength, shows the ratio of two bar histories, based on price.  It is often used to compare against a market index or sector ETF.  When using the optional `lookbackPeriods`, this also returns relative percent change over the specified periods.  This is not the same as the more prevalent [Relative Strength Index (RSI)](/indicators/rsi).
-[[Discuss] &#128172;](https://github.com/facioquo/stock-indicators-dotnet/discussions/243 "Community discussion about this indicator")
+[Price Relative Strength (PRS)](https://en.wikipedia.org/wiki/Relative_strength), also called Comparative Relative Strength, shows the ratio of two bar histories, based on price.  It is often used to compare against a market index or sector ETF.  When using the optional `lookbackPeriods`, this also returns relative percent change over the specified periods.  This is not the same as the more prevalent [Relative Strength Index (RSI)](/indicators/rsi). [[Discuss] &#128172;](https://github.com/facioquo/stock-indicators-dotnet/discussions/243 "Community discussion about this indicator")
 
 ```csharp
 // C# usage syntax
@@ -87,6 +86,4 @@ See [Chaining indicators](/guide/chaining) for more.
 
 ## Streaming
 
-Streaming is not supported for this indicator.
-This indicator requires a second synchronized bar series, which cannot be expressed in the single-series streaming model.
-Use the Series (batch) implementation with periodic recalculation instead.
+Streaming is not supported for this indicator. This indicator requires a second synchronized bar series, which cannot be expressed in the single-series streaming model. Use the Series (batch) implementation with periodic recalculation instead.

--- a/docs/indicators/renko.md
+++ b/docs/indicators/renko.md
@@ -5,8 +5,7 @@ description: The Renko Chart is a Japanese price transformed candlestick pattern
 
 # Renko Chart
 
-The [Renko Chart](https://en.m.wikipedia.org/wiki/Renko_chart) is a Japanese price transformed candlestick pattern that uses "bricks" to show a defined increment of change over a non-linear time series.  Transitions can use either `Close` or `High/Low` price values.  An ATR variant is also provided where brick size is determined by current Average True Range values.
-[[Discuss] &#128172;](https://github.com/facioquo/stock-indicators-dotnet/discussions/478 "Community discussion about this indicator")
+The [Renko Chart](https://en.m.wikipedia.org/wiki/Renko_chart) is a Japanese price transformed candlestick pattern that uses "bricks" to show a defined increment of change over a non-linear time series.  Transitions can use either `Close` or `High/Low` price values.  An ATR variant is also provided where brick size is determined by current Average True Range values. [[Discuss] &#128172;](https://github.com/facioquo/stock-indicators-dotnet/discussions/478 "Community discussion about this indicator")
 
 ```csharp
 // C# usage syntax (fixed brick size)
@@ -135,9 +134,7 @@ IReadOnlyList<RenkoResult> results = observer.Results;
 ```
 
 ::: warning 🚩
-`ToRenkoAtr()` does not support streaming.
-The ATR brick size is derived from the full dataset and changes as new bars are added, making incremental output undefined.
-Use the Series implementation with periodic recalculation instead.
+`ToRenkoAtr()` does not support streaming. The ATR brick size is derived from the full dataset and changes as new bars are added, making incremental output undefined. Use the Series implementation with periodic recalculation instead.
 :::
 
 See [Buffer lists](/guide/styles/buffer) and [Stream hubs](/guide/styles/stream) for full usage guides.

--- a/docs/indicators/stoch-rsi.md
+++ b/docs/indicators/stoch-rsi.md
@@ -5,8 +5,7 @@ description: Created by Tushar Chande and Stanley Kroll, Stochastic RSI is a Sto
 
 # Stochastic RSI
 
-Created by Tushar Chande and Stanley Kroll, [Stochastic RSI](https://chartschool.stockcharts.com/table-of-contents/technical-indicators-and-overlays/technical-indicators/stochrsi) is a Stochastic interpretation of the Relative Strength Index.  It is different from, and often confused with the more traditional [Stochastic Oscillator](/indicators/stoch).
-[[Discuss] &#128172;](https://github.com/facioquo/stock-indicators-dotnet/discussions/236 "Community discussion about this indicator")
+Created by Tushar Chande and Stanley Kroll, [Stochastic RSI](https://chartschool.stockcharts.com/table-of-contents/technical-indicators-and-overlays/technical-indicators/stochrsi) is a Stochastic interpretation of the Relative Strength Index.  It is different from, and often confused with the more traditional [Stochastic Oscillator](/indicators/stoch). [[Discuss] &#128172;](https://github.com/facioquo/stock-indicators-dotnet/discussions/236 "Community discussion about this indicator")
 
 <ClientOnly>
   <StockIndicatorChart indicator="StochRsi" withOverlay />
@@ -120,9 +119,7 @@ IReadOnlyList<StochRsiResult> results = observer.Results;
 ```
 
 ::: info Compound hub
-The StochRSI hub is based on the RSI indicator.
-When the StochRSI hub is chained from an existing `RsiHub` instance it will reuse the existing RSI hub values rather than creating its own internal RSI calculations.
-**This is not a normal chaining model.**
+The StochRSI hub is based on the RSI indicator. When the StochRSI hub is chained from an existing `RsiHub` instance it will reuse the existing RSI hub values rather than creating its own internal RSI calculations. **This is not a normal chaining model.**
 
 ```csharp
 // creates a new internal RSI hub

--- a/docs/indicators/vwma.md
+++ b/docs/indicators/vwma.md
@@ -5,8 +5,7 @@ description: Volume Weighted Moving Average is the volume adjusted average price
 
 # Volume Weighted Moving Average (VWMA)
 
-Volume Weighted Moving Average is the volume adjusted average price over a lookback window.
-[[Discuss] &#128172;](https://github.com/facioquo/stock-indicators-dotnet/discussions/657 "Community discussion about this indicator")
+Volume Weighted Moving Average is the volume adjusted average price over a lookback window. [[Discuss] &#128172;](https://github.com/facioquo/stock-indicators-dotnet/discussions/657 "Community discussion about this indicator")
 
 <ClientOnly>
   <StockIndicatorChart indicator="Vwma" />

--- a/docs/indicators/zig-zag.md
+++ b/docs/indicators/zig-zag.md
@@ -5,8 +5,7 @@ description: Zig Zag is a financial market price chart overlay that simplifies t
 
 # Zig Zag
 
-[Zig Zag](https://www.google.com/search?q=Zig+Zag+(ZIGZAG)+indicator) is a price chart overlay that simplifies the up and down movements and transitions based on a percent change smoothing threshold.
-[[Discuss] &#128172;](https://github.com/facioquo/stock-indicators-dotnet/discussions/226 "Community discussion about this indicator")
+[Zig Zag](https://www.google.com/search?q=Zig+Zag+(ZIGZAG)+indicator) is a price chart overlay that simplifies the up and down movements and transitions based on a percent change smoothing threshold. [[Discuss] &#128172;](https://github.com/facioquo/stock-indicators-dotnet/discussions/226 "Community discussion about this indicator")
 
 <ClientOnly>
   <StockIndicatorChart indicator="ZigZag" />
@@ -93,6 +92,4 @@ See [Chaining indicators](/guide/chaining) for more.
 
 ## Streaming
 
-Streaming is not supported for this indicator.
-This indicator requires lookahead to confirm reversal points; output repaints as new data arrives, making incremental results undefined.
-Use the Series (batch) implementation with periodic recalculation instead.
+Streaming is not supported for this indicator. This indicator requires lookahead to confirm reversal points; output repaints as new data arrives, making incremental results undefined. Use the Series (batch) implementation with periodic recalculation instead.

--- a/docs/migration/v3.md
+++ b/docs/migration/v3.md
@@ -60,31 +60,13 @@ The old `Quote`, `IQuote`, `PeriodSize`, `IReusableResult`, and `BasicData` name
 
 ### Corrections to obsolete v2 shims
 
-Defects in the `[Obsolete]` compatibility shims, shipped in `3.0.0` and **corrected in
-`3.0.1`**. Each changes **returned values** for code still calling the v2 method names.
-They are worth correcting even though the shims themselves are removed in `3.1`: `3.0.x`
-is the version you are told to land on before upgrading further, so it has to be right.
+Defects in the `[Obsolete]` compatibility shims, shipped in `3.0.0` and **corrected in `3.0.1`**. Each changes **returned values** for code still calling the v2 method names. They are worth correcting even though the shims themselves are removed in `3.1`: `3.0.x` is the version you are told to land on before upgrading further, so it has to be right.
 
-These version as bug fixes rather than breaking changes because the shipped behavior
-never matched its own documentation — see the correctness principles on [correcting a
-defect versus changing intended behavior](https://github.com/facioquo/stock-indicators-dotnet/blob/main/docs/PRINCIPLES.md).
+These version as bug fixes rather than breaking changes because the shipped behavior never matched its own documentation — see the correctness principles on [correcting a defect versus changing intended behavior](https://github.com/facioquo/stock-indicators-dotnet/blob/main/docs/PRINCIPLES.md).
 
-- **`GetPrs()` returned the inverted ratio.** In `3.0.0` the shim passed its two series
-  in the wrong order, so it returned `base / eval` — the reciprocal of the ratio
-  [documented for PRS](/indicators/prs). As of `3.0.1` it returns `eval / base`, matching
-  `ToPrs()` and pre-`3.0.0` behavior. **If you called `GetPrs()` on `3.0.x`, stored values and any
-  thresholds tuned against them must be revalidated; new values are the reciprocal of
-  old ones.** Callers of `ToPrs()` were never affected.
-- **`GetPvo()` used the wrong default periods.** The shim declared
-  `fastPeriods: 9, slowPeriods: 12` where both v2 and `ToPvo()` declare `12` and `26`,
-  so calling `GetPvo()` with no arguments silently computed a differently-parameterized
-  PVO. Corrected in `3.0.1`. **If you called `GetPvo()` without explicit periods on `3.0.x`, stored values
-  must be revalidated.** Callers who passed explicit periods, and callers of `ToPvo()`,
-  were never affected.
-- **`GetPrs()` with no `lookbackPeriods` threw.** The unspecified lookback was mapped to
-  `0`, which validation rejects, so the shim's own default raised
-  `ArgumentOutOfRangeException`. As of `3.0.1` it computes with a null `PrsPercent`, as
-  it did before `3.0.0`.
+- **`GetPrs()` returned the inverted ratio.** In `3.0.0` the shim passed its two series in the wrong order, so it returned `base / eval` — the reciprocal of the ratio [documented for PRS](/indicators/prs). As of `3.0.1` it returns `eval / base`, matching `ToPrs()` and pre-`3.0.0` behavior. **If you called `GetPrs()` on `3.0.x`, stored values and any thresholds tuned against them must be revalidated; new values are the reciprocal of old ones.** Callers of `ToPrs()` were never affected.
+- **`GetPvo()` used the wrong default periods.** The shim declared `fastPeriods: 9, slowPeriods: 12` where both v2 and `ToPvo()` declare `12` and `26`, so calling `GetPvo()` with no arguments silently computed a differently-parameterized PVO. Corrected in `3.0.1`. **If you called `GetPvo()` without explicit periods on `3.0.x`, stored values must be revalidated.** Callers who passed explicit periods, and callers of `ToPvo()`, were never affected.
+- **`GetPrs()` with no `lookbackPeriods` threw.** The unspecified lookback was mapped to `0`, which validation rejects, so the shim's own default raised `ArgumentOutOfRangeException`. As of `3.0.1` it computes with a null `PrsPercent`, as it did before `3.0.0`.
 
 ### Other changes
 

--- a/tools/performance/benchmarking.md
+++ b/tools/performance/benchmarking.md
@@ -1,8 +1,6 @@
 # Performance benchmarking guide
 
-Canonical guide for running indicator performance benchmarks, refreshing
-baselines, and checking for regressions. Uses
-[BenchmarkDotNet](https://benchmarkdotnet.org/) under `tools/performance`.
+Canonical guide for running indicator performance benchmarks, refreshing baselines, and checking for regressions. Uses [BenchmarkDotNet](https://benchmarkdotnet.org/) under `tools/performance`.
 
 > **Not the same as correctness (regression) baselines** in `tools/baselining/`,
 > which capture expected indicator *output values*
@@ -11,8 +9,7 @@ baselines, and checking for regressions. Uses
 
 ## TL;DR — one script, three workflows
 
-Run everything through `perf.sh` from the repository root. Requires `jq` for
-`evaluate`/`spot`.
+Run everything through `perf.sh` from the repository root. Requires `jq` for `evaluate`/`spot`.
 
 ```bash
 # 1. Spot check: one indicator vs baseline (fast; recommended dev-loop check)
@@ -28,16 +25,11 @@ bash tools/performance/perf.sh reset
 
 `reset` and `evaluate` run the full suite (~1 hour). `spot` is quick.
 
-**Keep runs comparable.** The commands above intentionally take no tuning options
-(no `--job`, `--warmupCount`, threshold, etc.). Each suite pins its own
-BenchmarkDotNet job in code, so plain runs compare apples-to-apples with the
-committed baselines. Only add flags for raw exploration (see below), never for
-baseline comparison.
+**Keep runs comparable.** The commands above intentionally take no tuning options (no `--job`, `--warmupCount`, threshold, etc.). Each suite pins its own BenchmarkDotNet job in code, so plain runs compare apples-to-apples with the committed baselines. Only add flags for raw exploration (see below), never for baseline comparison.
 
 ## The baseline set
 
-The **baseline set** is exactly what `dotnet run -c Release` (no arguments)
-produces, and what `perf.sh reset`/`evaluate` cover:
+The **baseline set** is exactly what `dotnet run -c Release` (no arguments) produces, and what `perf.sh reset`/`evaluate` cover:
 
 | Suite | File (`Perf.*.cs`) | Coverage |
 | ----- | ------------------ | -------- |
@@ -48,24 +40,19 @@ produces, and what `perf.sh reset`/`evaluate` cover:
 | `UtilityNullMath` | `Perf.Utility.NullMath.cs` | null-math helpers |
 | `UtilityStdDev` | `Perf.Utility.StdDev.cs` | standard-deviation helper |
 
-The list lives in two places that must stay in sync: the no-arg run in
-`Program.cs` and `BASELINE_CLASSES` in `perf.sh`.
+The list lives in two places that must stay in sync: the no-arg run in `Program.cs` and `BASELINE_CLASSES` in `perf.sh`.
 
 ### Not baselined (diagnostics)
 
-Useful but intentionally **not** committed as baselines. Run ad-hoc with
-`--filter`:
+Useful but intentionally **not** committed as baselines. Run ad-hoc with `--filter`:
 
-- `StyleComparison` (`Perf.StyleComparison.cs`) — cross-style ratio view; overlaps
-  the core three suites, so it adds no new regression signal.
+- `StyleComparison` (`Perf.StyleComparison.cs`) — cross-style ratio view; overlaps the core three suites, so it adds no new regression signal.
 - `StreamExternal` (`Perf.StreamExternal.cs`) — EMA series-vs-stream microcheck.
 - `ManualTestDirect` (`Perf.ManualTestDirect.cs`) — large-N spot harness (below).
 
 ## Manual / large-N spot harness
 
-`ManualTestDirect` validates a single indicator at large bar counts without the
-full catalog overhead. It is separate from `perf.sh spot` (which compares the real
-suites to baselines); `ManualTestDirect` has no baseline.
+`ManualTestDirect` validates a single indicator at large bar counts without the full catalog overhead. It is separate from `perf.sh spot` (which compares the real suites to baselines); `ManualTestDirect` has no baseline.
 
 ```bash
 cd tools/performance
@@ -79,8 +66,7 @@ PERF_TEST_KEYWORD=adl PERF_TEST_PERIODS=500000 PERF_TEST_CAP=100000 dotnet run -
 
 ## Raw BenchmarkDotNet runs
 
-For exploration only (not baseline comparison). Always `-c Release`; pass BDN args
-after `--`:
+For exploration only (not baseline comparison). Always `-c Release`; pass BDN args after `--`:
 
 ```bash
 cd tools/performance
@@ -97,10 +83,7 @@ Artifacts land in `BenchmarkDotNet.Artifacts/results/`:
 
 ## Regression detection details
 
-`perf.sh evaluate` and `perf.sh spot` call `detect-regressions.sh`, which pairs
-each `*-report-full.json` in `BenchmarkDotNet.Artifacts/results/` with the
-same-named file in `baselines/` and compares per method. Only suites present in
-the results are compared, so a spot run compares just what it ran.
+`perf.sh evaluate` and `perf.sh spot` call `detect-regressions.sh`, which pairs each `*-report-full.json` in `BenchmarkDotNet.Artifacts/results/` with the same-named file in `baselines/` and compares per method. Only suites present in the results are compared, so a spot run compares just what it ran.
 
 Run it directly if you already have results (requires `jq`):
 
@@ -127,9 +110,7 @@ Exit codes: `0` no regressions, `1` regressions found, `2` usage/IO error.
 
 ## CI workflows
 
-All are `workflow_dispatch` (manual) and informational only. **Do not gate merges
-on absolute CI timings** — baselines are captured on a developer machine and CI
-runners differ, so cross-machine comparisons are noisy.
+All are `workflow_dispatch` (manual) and informational only. **Do not gate merges on absolute CI timings** — baselines are captured on a developer machine and CI runners differ, so cross-machine comparisons are noisy.
 
 - `test-performance.yml` — full baseline suite
 - `test-performance-comparison.yml` — `StyleComparison` diagnostic


### PR DESCRIPTION
Prose paragraphs and list items were hard-wrapped at roughly 80–90 characters in thirteen files, against the convention everywhere else in the repo, where a paragraph or list item is one line. `MD013` is disabled in `.markdownlint-cli2.jsonc`, so line length is deliberately unenforced.

Hard wrapping makes diffs noisier than the edit: changing a word reflows the rest of the paragraph, so a one-word change shows as several changed lines and review has to re-read all of them. Some of this was mine — the shim correction notes added in #2210 and #2214 were wrapped.

## Scope

13 files, 54 joined lines. Three account for most of it:

| File | Joined lines |
| --- | --- |
| `tools/performance/benchmarking.md` | 19 |
| `docs/migration/v3.md` | 17 |
| `docs/CONTRIBUTING.md` | 8 |
| 10 others | 1 each |

Finding them took two attempts. A naive scan reported 117 files and 984 lines, but almost all were VitePress YAML frontmatter and Vue `<ClientOnly>` blocks rather than prose. Excluding frontmatter, fences, tables, blockquotes, HTML/Vue blocks, containers, and link reference definitions brings it to the real set above.

## Safety

Content is **byte-identical under whitespace normalization**, asserted per file before writing — a file whose normalized text changed would have been skipped, and none were.

Left untouched: YAML frontmatter, code fences, tables, blockquotes, HTML and Vue blocks, `:::` containers, link reference definitions, and explicit two-space hard breaks (which are a real `<br>` and must not be joined). No fence or table line appears anywhere in the diff — verified by grepping the diff itself.

`markdownlint-cli2` reports **0 issues across all 183 files**, and the detector now finds zero remaining wrapped prose.

## Merge order

No constraint. Verified clean against both open PRs (#2218, #2219) in every direction — those two carry their own added prose already unwrapped, so nothing here overlaps them.
